### PR TITLE
Add the platformId property on Prisma Order type

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Order {
   Account       Account?   @relation(fields: [accountId, accountUserId], references: [id, userId])
   accountId     String?
   accountUserId String?
+  platformId    String?
   createdAt     DateTime   @default(now())
   currency      Currency
   dataSource    DataSource @default(YAHOO)


### PR DESCRIPTION
When you populate the database using `yarn setup:database` you receive a typescript error, because the property platformId is not present on Order schema.

```
         ^
TSError: ⨯ Unable to compile TypeScript:
prisma/seed.ts:147:9 - error TS2322: Type '{ accountId: string; accountUserId: string; currency: "USD"; date: Date; fee: number; id: string; platformId: string; quantity: number; symbol: string; type: "BUY"; unitPrice: number; userId: string; }' is not assignable to type 'OrderCreateManyInput'.
  Object literal may only specify known properties, and 'platformId' does not exist in type 'OrderCreateManyInput'.

147         platformId: platformDegiro.id,
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I added the `platformId` property to Order type in schema.prisma file.