### PR TITLE
Add duplicate action on transactions table

### DIFF
--- a/apps/client/src/app/components/transactions-table/transactions-table.component.html
+++ b/apps/client/src/app/components/transactions-table/transactions-table.component.html
@@ -177,6 +177,9 @@
         <button i18n mat-menu-item (click)="onUpdateTransaction(element)">
           Edit
         </button>
+        <button i18n mat-menu-item (click)="onDuplicateTransaction(element)">
+          Duplicate
+        </button>
         <button i18n mat-menu-item (click)="onDeleteTransaction(element.id)">
           Delete
         </button>

--- a/apps/client/src/app/components/transactions-table/transactions-table.component.html
+++ b/apps/client/src/app/components/transactions-table/transactions-table.component.html
@@ -177,8 +177,8 @@
         <button i18n mat-menu-item (click)="onUpdateTransaction(element)">
           Edit
         </button>
-        <button i18n mat-menu-item (click)="onDuplicateTransaction(element)">
-          Duplicate
+        <button i18n mat-menu-item (click)="onCloneTransaction(element)">
+          Clone
         </button>
         <button i18n mat-menu-item (click)="onDeleteTransaction(element.id)">
           Delete

--- a/apps/client/src/app/components/transactions-table/transactions-table.component.ts
+++ b/apps/client/src/app/components/transactions-table/transactions-table.component.ts
@@ -35,8 +35,8 @@ export class TransactionsTableComponent
   @Input() transactions: OrderModel[];
 
   @Output() transactionDeleted = new EventEmitter<string>();
+  @Output() transactionToClone = new EventEmitter<OrderModel>();
   @Output() transactionToUpdate = new EventEmitter<OrderModel>();
-  @Output() transactionToDuplicate = new EventEmitter<OrderModel>();
 
   @ViewChild(MatSort) sort: MatSort;
 
@@ -124,8 +124,8 @@ export class TransactionsTableComponent
     this.transactionToUpdate.emit(aTransaction);
   }
 
-  public onDuplicateTransaction(aTransaction: OrderModel) {
-    this.transactionToDuplicate.emit(aTransaction);
+  public onCloneTransaction(aTransaction: OrderModel) {
+    this.transactionToClone.emit(aTransaction);
   }
 
   public openPositionDialog({

--- a/apps/client/src/app/components/transactions-table/transactions-table.component.ts
+++ b/apps/client/src/app/components/transactions-table/transactions-table.component.ts
@@ -36,6 +36,7 @@ export class TransactionsTableComponent
 
   @Output() transactionDeleted = new EventEmitter<string>();
   @Output() transactionToUpdate = new EventEmitter<OrderModel>();
+  @Output() transactionToDuplicate = new EventEmitter<OrderModel>();
 
   @ViewChild(MatSort) sort: MatSort;
 
@@ -121,6 +122,10 @@ export class TransactionsTableComponent
 
   public onUpdateTransaction(aTransaction: OrderModel) {
     this.transactionToUpdate.emit(aTransaction);
+  }
+
+  public onDuplicateTransaction(aTransaction: OrderModel) {
+    this.transactionToDuplicate.emit(aTransaction);
   }
 
   public openPositionDialog({

--- a/apps/client/src/app/pages/transactions/transactions-page.component.ts
+++ b/apps/client/src/app/pages/transactions/transactions-page.component.ts
@@ -123,6 +123,10 @@ export class TransactionsPageComponent implements OnInit {
     });
   }
 
+  public onDuplicateTransaction(aTransaction: OrderModel) {
+    this.openCreateTransactionDialog(aTransaction);
+  }
+
   public openUpdateTransactionDialog({
     accountId,
     currency,
@@ -175,7 +179,7 @@ export class TransactionsPageComponent implements OnInit {
     this.unsubscribeSubject.complete();
   }
 
-  private openCreateTransactionDialog(): void {
+  private openCreateTransactionDialog(aTransaction?: OrderModel): void {
     const dialogRef = this.dialog.open(CreateOrUpdateTransactionDialog, {
       data: {
         accounts: this.user?.accounts,
@@ -183,11 +187,11 @@ export class TransactionsPageComponent implements OnInit {
           accountId: this.user?.accounts.find((account) => {
             return account.isDefault;
           })?.id,
-          currency: null,
+          currency: aTransaction?.currency || null,
           date: new Date(),
           fee: 0,
           quantity: null,
-          symbol: null,
+          symbol: aTransaction?.symbol || null,
           type: 'BUY',
           unitPrice: null
         }

--- a/apps/client/src/app/pages/transactions/transactions-page.component.ts
+++ b/apps/client/src/app/pages/transactions/transactions-page.component.ts
@@ -188,11 +188,12 @@ export class TransactionsPageComponent implements OnInit {
             return account.isDefault;
           })?.id,
           currency: aTransaction?.currency ?? null,
+          dataSource: aTransaction?.dataSource ?? null,
           date: new Date(),
           fee: 0,
           quantity: null,
           symbol: aTransaction?.symbol ?? null,
-          type: 'BUY',
+          type: aTransaction?.type ?? 'BUY',
           unitPrice: null
         }
       },

--- a/apps/client/src/app/pages/transactions/transactions-page.component.ts
+++ b/apps/client/src/app/pages/transactions/transactions-page.component.ts
@@ -109,6 +109,10 @@ export class TransactionsPageComponent implements OnInit {
     });
   }
 
+  public onCloneTransaction(aTransaction: OrderModel) {
+    this.openCreateTransactionDialog(aTransaction);
+  }
+
   public onDeleteTransaction(aId: string) {
     this.dataService.deleteOrder(aId).subscribe({
       next: () => {
@@ -121,10 +125,6 @@ export class TransactionsPageComponent implements OnInit {
     this.router.navigate([], {
       queryParams: { editDialog: true, transactionId: aTransaction.id }
     });
-  }
-
-  public onDuplicateTransaction(aTransaction: OrderModel) {
-    this.openCreateTransactionDialog(aTransaction);
   }
 
   public openUpdateTransactionDialog({
@@ -184,14 +184,14 @@ export class TransactionsPageComponent implements OnInit {
       data: {
         accounts: this.user?.accounts,
         transaction: {
-          accountId: this.user?.accounts.find((account) => {
+          accountId: aTransaction?.accountId ?? this.user?.accounts.find((account) => {
             return account.isDefault;
           })?.id,
-          currency: aTransaction?.currency || null,
+          currency: aTransaction?.currency ?? null,
           date: new Date(),
           fee: 0,
           quantity: null,
-          symbol: aTransaction?.symbol || null,
+          symbol: aTransaction?.symbol ?? null,
           type: 'BUY',
           unitPrice: null
         }

--- a/apps/client/src/app/pages/transactions/transactions-page.html
+++ b/apps/client/src/app/pages/transactions/transactions-page.html
@@ -9,8 +9,8 @@
         [showActions]="!hasImpersonationId && hasPermissionToDeleteOrder"
         [transactions]="transactions"
         (transactionDeleted)="onDeleteTransaction($event)"
+        (transactionToClone)="onCloneTransaction($event)"
         (transactionToUpdate)="onUpdateTransaction($event)"
-        (transactionToDuplicate)="onDuplicateTransaction($event)"
       ></gf-transactions-table>
     </div>
   </div>

--- a/apps/client/src/app/pages/transactions/transactions-page.html
+++ b/apps/client/src/app/pages/transactions/transactions-page.html
@@ -10,6 +10,7 @@
         [transactions]="transactions"
         (transactionDeleted)="onDeleteTransaction($event)"
         (transactionToUpdate)="onUpdateTransaction($event)"
+        (transactionToDuplicate)="onDuplicateTransaction($event)"
       ></gf-transactions-table>
     </div>
   </div>


### PR DESCRIPTION
I added the "Duplicate" (let me know if you have a better proposal for the label) action on transactions table item.

In this way the user can add a new transaction using an existing one.
I retrieved from the OrderModel the currency and the symbol. I think the quantity is not useful.


<img width="1308" alt="Screenshot 2021-05-04 at 20 48 04" src="https://user-images.githubusercontent.com/8224739/117054120-12237280-ad1a-11eb-9013-c0c3a397e8a3.png">
