### PR TITLE
Add account filter with chips on transactions

### DIFF
--- a/apps/client/src/app/components/transactions-table/transactions-table.component.html
+++ b/apps/client/src/app/components/transactions-table/transactions-table.component.html
@@ -1,3 +1,24 @@
+<div *ngIf="chipsAccount.length > 1">
+  <mat-chip-list aria-label="Account selection" class="d-block mb-4">
+    <mat-chip
+      [selected]="true"
+      #c="matChip"
+      (click)="!c.selected && c.toggleSelected()"
+      (selectionChange)="applyAccountFilter($event)"
+    >
+      All
+    </mat-chip>
+    <mat-chip
+      #c="matChip"
+      *ngFor="let account of chipsAccount"
+      (click)="!c.selected && c.toggleSelected()"
+      (selectionChange)="applyAccountFilter($event)"
+    >
+      {{ account }}
+    </mat-chip>
+  </mat-chip-list>
+</div>
+
 <mat-form-field appearance="outline" class="w-100">
   <input
     #input

--- a/apps/client/src/app/components/transactions-table/transactions-table.component.ts
+++ b/apps/client/src/app/components/transactions-table/transactions-table.component.ts
@@ -11,6 +11,11 @@ import {
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
+import {
+  MatChipList,
+  MatChip,
+  MatChipSelectionChange
+} from '@angular/material/chips';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DEFAULT_DATE_FORMAT } from '@ghostfolio/helper';
@@ -39,12 +44,15 @@ export class TransactionsTableComponent
   @Output() transactionToUpdate = new EventEmitter<OrderModel>();
 
   @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatChipList) chipsList: MatChipList;
 
   public dataSource: MatTableDataSource<OrderModel> = new MatTableDataSource();
   public defaultDateFormat = DEFAULT_DATE_FORMAT;
   public displayedColumns = [];
   public isLoading = true;
   public routeQueryParams: Subscription;
+
+  chipsAccount: string[] = [];
 
   private unsubscribeSubject = new Subject<void>();
 
@@ -89,7 +97,25 @@ export class TransactionsTableComponent
       this.dataSource = new MatTableDataSource(this.transactions);
       this.dataSource.sort = this.sort;
 
+      this.chipsAccount = [
+        ...new Set(this.transactions.map((t) => t.Account?.name))
+      ];
+
       this.isLoading = false;
+    }
+  }
+
+  public applyAccountFilter(event: MatChipSelectionChange) {
+    if (event.selected) {
+      const selectedAccount = event.source.value.trim();
+      if (selectedAccount === 'All') {
+        this.dataSource.data = this.transactions;
+      } else {
+        const filtered = this.transactions.filter(
+          (f) => f.Account.name === selectedAccount
+        );
+        this.dataSource.data = filtered;
+      }
     }
   }
 

--- a/apps/client/src/app/components/transactions-table/transactions-table.module.ts
+++ b/apps/client/src/app/components/transactions-table/transactions-table.module.ts
@@ -5,6 +5,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
+import { MatChipsModule } from '@angular/material/chips';
 import { RouterModule } from '@angular/router';
 import { GfSymbolModule } from '@ghostfolio/client/pipes/symbol/symbol.module';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -29,6 +30,7 @@ import { TransactionsTableComponent } from './transactions-table.component';
     MatSortModule,
     MatTableModule,
     NgxSkeletonLoaderModule,
+    MatChipsModule,
     RouterModule
   ],
   providers: [],


### PR DESCRIPTION
I added the possibility to filter the transactions by account using chips component.

This is a first basic solution but in the future it can be improved by combining it with other fields such as type to build advanced search queries.

The chips component is displayed only when there are more than 2 different accounts in the transactions.

The search with text input is applied to the list filtered by account.

Preview:
<img width="1427" alt="Screenshot 2021-05-05 at 17 59 54" src="https://user-images.githubusercontent.com/8224739/117172621-43f51180-adcc-11eb-8297-2580d2076b34.png">

