### PR TITLE
Add link to retrieve manually the current market price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a button to fetch the current market price in the create or edit transaction dialog
+
 ### Changed
 
 - Improved the transaction filtering with multi filter support

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.component.ts
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.component.ts
@@ -30,9 +30,9 @@ import { CreateOrUpdateTransactionDialogParams } from './interfaces/interfaces';
 })
 export class CreateOrUpdateTransactionDialog {
   public currencies: Currency[] = [];
+  public currentMarketPrice = null;
   public filteredLookupItems: Observable<LookupItem[]>;
   public isLoading = false;
-  public currentMarketPrice = null;
   public platforms: { id: string; name: string }[];
   public searchSymbolCtrl = new FormControl(
     this.data.transaction.symbol,
@@ -80,7 +80,6 @@ export class CreateOrUpdateTransactionDialog {
 
   public applyCurrentMarketPrice() {
     this.data.transaction.unitPrice = this.currentMarketPrice;
-    this.cd.markForCheck();
   }
 
   public onCancel(): void {

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.component.ts
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.component.ts
@@ -32,6 +32,7 @@ export class CreateOrUpdateTransactionDialog {
   public currencies: Currency[] = [];
   public filteredLookupItems: Observable<LookupItem[]>;
   public isLoading = false;
+  public currentMarketPrice = null;
   public platforms: { id: string; name: string }[];
   public searchSymbolCtrl = new FormControl(
     this.data.transaction.symbol,
@@ -65,6 +66,21 @@ export class CreateOrUpdateTransactionDialog {
         return [];
       })
     );
+
+    if (this.data.transaction.symbol) {
+      this.dataService
+        .fetchSymbolItem(this.data.transaction.symbol)
+        .pipe(takeUntil(this.unsubscribeSubject))
+        .subscribe(({ marketPrice }) => {
+          this.currentMarketPrice = marketPrice;
+          this.cd.markForCheck();
+        });
+    }
+  }
+
+  public applyCurrentMarketPrice() {
+    this.data.transaction.unitPrice = this.currentMarketPrice;
+    this.cd.markForCheck();
   }
 
   public onCancel(): void {
@@ -81,7 +97,7 @@ export class CreateOrUpdateTransactionDialog {
       .subscribe(({ currency, dataSource, marketPrice }) => {
         this.data.transaction.currency = currency;
         this.data.transaction.dataSource = dataSource;
-        this.data.transaction.unitPrice = marketPrice;
+        this.currentMarketPrice = marketPrice;
 
         this.isLoading = false;
 

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.html
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.html
@@ -110,7 +110,7 @@
       </mat-form-field>
     </div>
     <div>
-      <mat-form-field appearance="outline" class="w-100">
+      <mat-form-field appearance="outline" class="w-100 mb-4">
         <mat-label i18n>Unit Price</mat-label>
         <input
           matInput
@@ -119,6 +119,14 @@
           type="number"
           [(ngModel)]="data.transaction.unitPrice"
         />
+        <mat-hint
+          *ngIf="currentMarketPrice"
+          align="start"
+          class="hint-action"
+          (click)="applyCurrentMarketPrice()"
+          >Use current market price from {{ data.transaction.dataSource
+          }}</mat-hint
+        >
       </mat-form-field>
     </div>
     <div>

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.html
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.html
@@ -81,7 +81,13 @@
           [matDatepicker]="date"
           [(ngModel)]="data.transaction.date"
         />
-        <mat-datepicker-toggle matSuffix [for]="date"></mat-datepicker-toggle>
+        <mat-datepicker-toggle matSuffix [for]="date">
+          <ion-icon
+            class="text-muted"
+            matDatepickerToggleIcon
+            name="calendar-clear-outline"
+          ></ion-icon>
+        </mat-datepicker-toggle>
         <mat-datepicker #date disabled="false"></mat-datepicker>
       </mat-form-field>
     </div>
@@ -110,7 +116,7 @@
       </mat-form-field>
     </div>
     <div>
-      <mat-form-field appearance="outline" class="w-100 mb-4">
+      <mat-form-field appearance="outline" class="unit-price w-100">
         <mat-label i18n>Unit Price</mat-label>
         <input
           matInput
@@ -119,14 +125,15 @@
           type="number"
           [(ngModel)]="data.transaction.unitPrice"
         />
-        <mat-hint
+        <button
           *ngIf="currentMarketPrice"
-          align="start"
-          class="hint-action"
+          mat-icon-button
+          matSuffix
+          title="Apply current market price"
           (click)="applyCurrentMarketPrice()"
-          >Use current market price from {{ data.transaction.dataSource
-          }}</mat-hint
         >
+          <ion-icon class="text-muted" name="refresh-outline"></ion-icon>
+        </button>
       </mat-form-field>
     </div>
     <div>

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.module.ts
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
@@ -30,6 +30,7 @@ import { CreateOrUpdateTransactionDialog } from './create-or-update-transaction-
     MatSelectModule,
     ReactiveFormsModule
   ],
-  providers: []
+  providers: [],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class CreateOrUpdateTransactionDialogModule {}

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.scss
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.scss
@@ -29,6 +29,14 @@
         color: var(--dark-primary-text);
       }
     }
+
+    .hint-action {
+      color: var(--dark-primary-text);
+      text-decoration: underline;
+      &:hover {
+        cursor: pointer;
+      }
+    }
   }
 }
 

--- a/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.scss
+++ b/apps/client/src/app/pages/transactions/create-or-update-transaction-dialog/create-or-update-transaction-dialog.scss
@@ -14,6 +14,18 @@
       }
     }
 
+    .mat-form-field-appearance-outline {
+      ::ng-deep {
+        .mat-form-field-suffix {
+          top: -0.3rem;
+        }
+      }
+
+      ion-icon {
+        font-size: 130%;
+      }
+    }
+
     .mat-select {
       &.no-arrow {
         ::ng-deep {
@@ -27,14 +39,6 @@
     .mat-datepicker-input {
       &.mat-input-element:disabled {
         color: var(--dark-primary-text);
-      }
-    }
-
-    .hint-action {
-      color: var(--dark-primary-text);
-      text-decoration: underline;
-      &:hover {
-        cursor: pointer;
       }
     }
   }


### PR DESCRIPTION
Affected component: `create-or-update-transaction-dialog.component`

I added a link (suggestion) under the unit price input to retrieve and use the current market price retrieved from the data source.

In this way the user has more control and everything is more transparent.
The link is displayed only when a valid symbol is present and a current market price could be retrieved.

In addition I added the `fetchSymbolItem` on init, so if the user come from "Clone" action can immediately see and click the link to use the current price.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/8224739/117451206-80e31480-af42-11eb-8316-1a558ad4a8f1.png">
