### PR TITLE
Feature/introduce max items in portfolio proportion chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a counter column to the transactions table
 - Added a label to indicate the default account in the accounts table
+- Added an option to limit the items in pie charts
 
 ### Changed
 
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a connect or create symbol profile model logic on creating a new transaction
-- Added an option to limit the items in pie charts
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a connect or create symbol profile model logic on creating a new transaction
+- Added an option to limit the items in pie charts
 
 ### Changed
 

--- a/apps/client/src/app/pages/tools/analysis/analysis-page.html
+++ b/apps/client/src/app/pages/tools/analysis/analysis-page.html
@@ -75,6 +75,7 @@
             [baseCurrency]="user?.settings?.baseCurrency"
             [isInPercent]="true"
             [locale]="user?.settings?.locale"
+            [maxItems]="10"
             [positions]="positions"
           ></gf-portfolio-proportion-chart>
         </mat-card-content>
@@ -97,6 +98,7 @@
             [baseCurrency]="user?.settings?.baseCurrency"
             [isInPercent]="true"
             [locale]="user?.settings?.locale"
+            [maxItems]="10"
             [positions]="positions"
           ></gf-portfolio-proportion-chart>
         </mat-card-content>
@@ -185,6 +187,7 @@
             [baseCurrency]="user?.settings?.baseCurrency"
             [isInPercent]="false"
             [locale]="user?.settings?.locale"
+            [maxItems]="10"
             [positions]="countries"
           ></gf-portfolio-proportion-chart>
         </mat-card-content>


### PR DESCRIPTION
### Before
<img width="470" alt="portfolio-proportion-chart-before" src="https://user-images.githubusercontent.com/4159106/121788415-6f3dfe00-cbcd-11eb-8630-2ff7f0e565b6.png">

### After
<img width="470" alt="portfolio-proportion-chart-after" src="https://user-images.githubusercontent.com/4159106/121788421-749b4880-cbcd-11eb-8157-7f6449700a9e.png">