### PR TITLE
net performance for current positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Switched from gross to net performance
+- Restructured the portfolio summary tab on the home page (fees and net performance)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `Nx` from version `12.5.4` to `12.8.0`
 - Upgraded `prisma` from version `2.24.1` to `2.30.2`
 
+### Changed
+
+- Switched from gross to net performance
+
 ### Fixed
 
 - Fixed the value formatting for integers (transactions count)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added a story for the trend indicator component
   - Added a story for the value component
 
+### Changed
+
+- Switched from gross to net performance
+- Restructured the portfolio summary tab on the home page (fees and net performance)
+
 ## 1.45.0 - 04.09.2021
 
 ### Added
@@ -30,11 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `@angular/cdk` and `@angular/material` from version `12.0.6` to `12.2.4`
 - Upgraded `Nx` from version `12.5.4` to `12.8.0`
 - Upgraded `prisma` from version `2.24.1` to `2.30.2`
-
-### Changed
-
-- Switched from gross to net performance
-- Restructured the portfolio summary tab on the home page (fees and net performance)
 
 ### Fixed
 

--- a/apps/api/src/app/portfolio/interfaces/current-positions.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/current-positions.interface.ts
@@ -6,6 +6,8 @@ export interface CurrentPositions {
   positions: TimelinePosition[];
   grossPerformance: Big;
   grossPerformancePercentage: Big;
+  netPerformance: Big;
+  netPerformancePercentage: Big;
   currentValue: Big;
   totalInvestment: Big;
 }

--- a/apps/api/src/app/portfolio/interfaces/portfolio-order.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/portfolio-order.interface.ts
@@ -5,10 +5,10 @@ import Big from 'big.js';
 export interface PortfolioOrder {
   currency: Currency;
   date: string;
+  fee: Big;
   name: string;
   quantity: Big;
   symbol: string;
   type: OrderType;
   unitPrice: Big;
-  fee: Big;
 }

--- a/apps/api/src/app/portfolio/interfaces/portfolio-order.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/portfolio-order.interface.ts
@@ -10,4 +10,5 @@ export interface PortfolioOrder {
   symbol: string;
   type: OrderType;
   unitPrice: Big;
+  fee: Big;
 }

--- a/apps/api/src/app/portfolio/interfaces/portfolio-position-detail.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/portfolio-position-detail.interface.ts
@@ -11,6 +11,8 @@ export interface PortfolioPositionDetail {
   marketPrice: number;
   maxPrice: number;
   minPrice: number;
+  netPerformance: number;
+  netPerformancePercent: number;
   quantity: number;
   symbol: string;
   transactionCount: number;

--- a/apps/api/src/app/portfolio/interfaces/timeline-period.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/timeline-period.interface.ts
@@ -4,5 +4,6 @@ export interface TimelinePeriod {
   date: string;
   grossPerformance: Big;
   investment: Big;
+  netPerformance: Big;
   value: Big;
 }

--- a/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
@@ -8,4 +8,5 @@ export interface TransactionPointSymbol {
   quantity: Big;
   symbol: string;
   transactionCount: number;
+  fee: Big;
 }

--- a/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
@@ -4,7 +4,6 @@ import Big from 'big.js';
 export interface TransactionPointSymbol {
   currency: Currency;
   fee: Big;
-  feeAccumulated: Big;
   firstBuyDate: string;
   investment: Big;
   quantity: Big;

--- a/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
@@ -3,10 +3,10 @@ import Big from 'big.js';
 
 export interface TransactionPointSymbol {
   currency: Currency;
+  fee: Big;
   firstBuyDate: string;
   investment: Big;
   quantity: Big;
   symbol: string;
   transactionCount: number;
-  fee: Big;
 }

--- a/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/transaction-point-symbol.interface.ts
@@ -4,6 +4,7 @@ import Big from 'big.js';
 export interface TransactionPointSymbol {
   currency: Currency;
   fee: Big;
+  feeAccumulated: Big;
   firstBuyDate: string;
   investment: Big;
   quantity: Big;

--- a/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
@@ -194,8 +194,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 1,
-              fee: new Big('5'),
-              feeAccumulated: new Big('5')
+              fee: new Big('5')
             }
           ]
         },
@@ -209,8 +208,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 2,
-              fee: new Big('10'),
-              feeAccumulated: new Big('15')
+              fee: new Big('15')
             }
           ]
         },
@@ -224,8 +222,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 3,
-              fee: new Big('5'),
-              feeAccumulated: new Big('20')
+              fee: new Big('20')
             }
           ]
         }
@@ -284,8 +281,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 1,
-              fee: new Big('5'),
-              feeAccumulated: new Big('5')
+              fee: new Big('5')
             }
           ]
         },
@@ -299,8 +295,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 1,
-              fee: new Big('0'),
-              feeAccumulated: new Big('5')
+              fee: new Big('5')
             },
             {
               quantity: new Big('10'),
@@ -309,8 +304,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-08-03',
               transactionCount: 1,
-              fee: new Big('10'),
-              feeAccumulated: new Big('10')
+              fee: new Big('10')
             }
           ]
         },
@@ -324,8 +318,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 2,
-              fee: new Big('5'),
-              feeAccumulated: new Big('10')
+              fee: new Big('10')
             },
             {
               quantity: new Big('10'),
@@ -334,8 +327,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-08-03',
               transactionCount: 1,
-              fee: new Big('0'),
-              feeAccumulated: new Big('10')
+              fee: new Big('10')
             }
           ]
         }
@@ -375,7 +367,6 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('10'),
               symbol: 'VTI',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -390,7 +381,6 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('20'),
               symbol: 'VTI',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -405,7 +395,6 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('5'),
               symbol: 'VTI',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 3
             }
           ]
@@ -420,7 +409,6 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('35'),
               symbol: 'VTI',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 5
             }
           ]
@@ -435,7 +423,6 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('45'),
               symbol: 'VTI',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 6
             }
           ]
@@ -476,7 +463,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -491,7 +477,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -506,7 +491,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -516,7 +500,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -531,7 +514,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -541,7 +523,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 3
             }
           ]
@@ -556,7 +537,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -566,7 +546,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 4
             }
           ]
@@ -581,7 +560,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -591,7 +569,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 5
             }
           ]
@@ -656,7 +633,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -671,7 +647,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-07-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -681,7 +656,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -696,7 +670,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2018-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -706,7 +679,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-07-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -716,7 +688,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -959,7 +930,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -974,7 +944,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -989,7 +958,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 3
             }
           ]
@@ -1048,7 +1016,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1064,7 +1031,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -1133,7 +1099,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
-              feeAccumulated: new Big(50),
               transactionCount: 1
             }
           ]
@@ -1148,8 +1113,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
-              fee: new Big(50),
-              feeAccumulated: new Big(100),
+              fee: new Big(100),
               transactionCount: 2
             }
           ]
@@ -1226,7 +1190,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
-              feeAccumulated: new Big(50),
               transactionCount: 1
             }
           ]
@@ -1241,8 +1204,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
-              fee: new Big(50),
-              feeAccumulated: new Big(100),
+              fee: new Big(100),
               transactionCount: 2
             }
           ]
@@ -1315,7 +1277,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2010-12-31',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1330,7 +1291,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2010-12-31',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -1392,7 +1352,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -1402,7 +1361,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1417,7 +1375,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -1427,7 +1384,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1541,7 +1497,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
-              feeAccumulated: new Big(50),
               transactionCount: 1
             }
           ]
@@ -1555,8 +1510,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
-              fee: new Big(50),
-              feeAccumulated: new Big(100),
+              fee: new Big(100),
               transactionCount: 2
             }
           ]
@@ -1570,8 +1524,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('652.55'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
-              fee: new Big(50),
-              feeAccumulated: new Big(150),
+              fee: new Big(150),
               transactionCount: 3
             }
           ]
@@ -1585,8 +1538,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2684.05'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
-              fee: new Big(50),
-              feeAccumulated: new Big(200),
+              fee: new Big(200),
               transactionCount: 4
             }
           ]
@@ -1600,8 +1552,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('4460.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
-              fee: new Big(50),
-              feeAccumulated: new Big(250),
+              fee: new Big(250),
               transactionCount: 5
             }
           ]
@@ -2266,7 +2217,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -2276,7 +2226,6 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
-              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -2411,7 +2360,6 @@ const orderTslaTransactionPoint: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2021-01-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 1
       }
     ]
@@ -2429,7 +2377,6 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 1
       }
     ]
@@ -2444,7 +2391,6 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 2
       }
     ]
@@ -2459,7 +2405,6 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 3
       }
     ]
@@ -2474,7 +2419,6 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 4
       }
     ]
@@ -2489,7 +2433,6 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 5
       }
     ]
@@ -2507,7 +2450,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 1
       }
     ]
@@ -2522,7 +2464,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 2
       }
     ]
@@ -2537,7 +2478,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 1
       },
       {
@@ -2547,7 +2487,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 2
       }
     ]
@@ -2562,7 +2501,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 1
       },
       {
@@ -2572,7 +2510,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 3
       }
     ]
@@ -2587,7 +2524,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 2
       },
       {
@@ -2597,7 +2533,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 3
       }
     ]
@@ -2612,7 +2547,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 2
       },
       {
@@ -2622,7 +2556,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 4
       }
     ]
@@ -2637,7 +2570,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 2
       },
       {
@@ -2647,7 +2579,6 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
-        feeAccumulated: new Big(0),
         transactionCount: 5
       }
     ]

--- a/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
@@ -142,6 +142,198 @@ describe('PortfolioCalculator', () => {
       );
     });
 
+    it('with orders of only one symbol and a fee', () => {
+      const portfolioCalculator = new PortfolioCalculator(
+        currentRateService,
+        Currency.USD
+      );
+      const orders = [
+        {
+          date: '2019-02-01',
+          name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+          quantity: new Big('10'),
+          symbol: 'VTI',
+          type: OrderType.Buy,
+          unitPrice: new Big('144.38'),
+          currency: Currency.USD,
+          fee: new Big('5')
+        },
+        {
+          date: '2019-08-03',
+          name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+          quantity: new Big('10'),
+          symbol: 'VTI',
+          type: OrderType.Buy,
+          unitPrice: new Big('147.99'),
+          currency: Currency.USD,
+          fee: new Big('10')
+        },
+        {
+          date: '2020-02-02',
+          name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+          quantity: new Big('15'),
+          symbol: 'VTI',
+          type: OrderType.Sell,
+          unitPrice: new Big('151.41'),
+          currency: Currency.USD,
+          fee: new Big('5')
+        }
+      ];
+      portfolioCalculator.computeTransactionPoints(orders);
+      const portfolioItemsAtTransactionPoints =
+        portfolioCalculator.getTransactionPoints();
+
+      expect(portfolioItemsAtTransactionPoints).toEqual([
+        {
+          date: '2019-02-01',
+          items: [
+            {
+              quantity: new Big('10'),
+              symbol: 'VTI',
+              investment: new Big('1443.8'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              transactionCount: 1,
+              fee: new Big('5')
+            }
+          ]
+        },
+        {
+          date: '2019-08-03',
+          items: [
+            {
+              quantity: new Big('20'),
+              symbol: 'VTI',
+              investment: new Big('2923.7'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              transactionCount: 2,
+              fee: new Big('10')
+            }
+          ]
+        },
+        {
+          date: '2020-02-02',
+          items: [
+            {
+              quantity: new Big('5'),
+              symbol: 'VTI',
+              investment: new Big('652.55'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              transactionCount: 3,
+              fee: new Big('5')
+            }
+          ]
+        }
+      ]);
+    });
+
+    it('with orders of two different symbols and a fee', () => {
+      const portfolioCalculator = new PortfolioCalculator(
+        currentRateService,
+        Currency.USD
+      );
+      const orders = [
+        {
+          date: '2019-02-01',
+          name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+          quantity: new Big('10'),
+          symbol: 'VTI',
+          type: OrderType.Buy,
+          unitPrice: new Big('144.38'),
+          currency: Currency.USD,
+          fee: new Big('5')
+        },
+        {
+          date: '2019-08-03',
+          name: 'Something else',
+          quantity: new Big('10'),
+          symbol: 'VTX',
+          type: OrderType.Buy,
+          unitPrice: new Big('147.99'),
+          currency: Currency.USD,
+          fee: new Big('10')
+        },
+        {
+          date: '2020-02-02',
+          name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+          quantity: new Big('5'),
+          symbol: 'VTI',
+          type: OrderType.Sell,
+          unitPrice: new Big('151.41'),
+          currency: Currency.USD,
+          fee: new Big('5')
+        }
+      ];
+      portfolioCalculator.computeTransactionPoints(orders);
+      const portfolioItemsAtTransactionPoints =
+        portfolioCalculator.getTransactionPoints();
+
+      expect(portfolioItemsAtTransactionPoints).toEqual([
+        {
+          date: '2019-02-01',
+          items: [
+            {
+              quantity: new Big('10'),
+              symbol: 'VTI',
+              investment: new Big('1443.8'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              transactionCount: 1,
+              fee: new Big('5')
+            }
+          ]
+        },
+        {
+          date: '2019-08-03',
+          items: [
+            {
+              quantity: new Big('10'),
+              symbol: 'VTI',
+              investment: new Big('1443.8'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              transactionCount: 1,
+              fee: new Big('0')
+            },
+            {
+              quantity: new Big('10'),
+              symbol: 'VTX',
+              investment: new Big('1479.9'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-08-03',
+              transactionCount: 1,
+              fee: new Big('10')
+            }
+          ]
+        },
+        {
+          date: '2020-02-02',
+          items: [
+            {
+              quantity: new Big('5'),
+              symbol: 'VTI',
+              investment: new Big('686.75'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              transactionCount: 2,
+              fee: new Big('5')
+            },
+            {
+              quantity: new Big('10'),
+              symbol: 'VTX',
+              investment: new Big('1479.9'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-08-03',
+              transactionCount: 1,
+              fee: new Big('0')
+            }
+          ]
+        }
+      ]);
+    });
+
     it('with two orders at the same day of the same type', () => {
       const orders = [
         ...ordersVTI,
@@ -152,7 +344,8 @@ describe('PortfolioCalculator', () => {
           quantity: new Big('20'),
           symbol: 'VTI',
           type: OrderType.Buy,
-          unitPrice: new Big('197.15')
+          unitPrice: new Big('197.15'),
+          fee: new Big(0)
         }
       ];
       const portfolioCalculator = new PortfolioCalculator(
@@ -173,6 +366,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1443.8'),
               quantity: new Big('10'),
               symbol: 'VTI',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -186,6 +380,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               quantity: new Big('20'),
               symbol: 'VTI',
+              fee: new Big(0),
               transactionCount: 2
             }
           ]
@@ -199,6 +394,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('652.55'),
               quantity: new Big('5'),
               symbol: 'VTI',
+              fee: new Big(0),
               transactionCount: 3
             }
           ]
@@ -212,6 +408,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('6627.05'),
               quantity: new Big('35'),
               symbol: 'VTI',
+              fee: new Big(0),
               transactionCount: 5
             }
           ]
@@ -225,6 +422,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('8403.95'),
               quantity: new Big('45'),
               symbol: 'VTI',
+              fee: new Big(0),
               transactionCount: 6
             }
           ]
@@ -242,7 +440,8 @@ describe('PortfolioCalculator', () => {
           quantity: new Big('5'),
           symbol: 'AMZN',
           type: OrderType.Buy,
-          unitPrice: new Big('2021.99')
+          unitPrice: new Big('2021.99'),
+          fee: new Big(0)
         }
       ];
       const portfolioCalculator = new PortfolioCalculator(
@@ -263,6 +462,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1443.8'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -276,6 +476,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 2
             }
           ]
@@ -289,6 +490,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('10109.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -297,6 +499,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 2
             }
           ]
@@ -310,6 +513,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('10109.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -318,6 +522,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('652.55'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 3
             }
           ]
@@ -331,6 +536,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('10109.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -339,6 +545,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2684.05'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 4
             }
           ]
@@ -352,6 +559,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('10109.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -360,6 +568,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('4460.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 5
             }
           ]
@@ -377,7 +586,8 @@ describe('PortfolioCalculator', () => {
           symbol: 'AMZN',
           type: OrderType.Buy,
           unitPrice: new Big('2021.99'),
-          currency: Currency.USD
+          currency: Currency.USD,
+          fee: new Big(0)
         },
         {
           date: '2020-08-02',
@@ -386,7 +596,8 @@ describe('PortfolioCalculator', () => {
           symbol: 'AMZN',
           type: OrderType.Sell,
           unitPrice: new Big('2412.23'),
-          currency: Currency.USD
+          currency: Currency.USD,
+          fee: new Big(0)
         }
       ];
       const portfolioCalculator = new PortfolioCalculator(
@@ -421,6 +632,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2148.5'),
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -434,6 +646,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1999.9999999999998659756'),
               currency: Currency.USD,
               firstBuyDate: '2017-07-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -442,6 +655,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2148.5'),
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -455,6 +669,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('10109.95'),
               currency: Currency.USD,
               firstBuyDate: '2018-09-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -463,6 +678,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1999.9999999999998659756'),
               currency: Currency.USD,
               firstBuyDate: '2017-07-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -471,6 +687,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2148.5'),
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -702,6 +919,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('805.9'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -715,6 +933,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('0'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 2
             }
           ]
@@ -728,6 +947,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1013.9'),
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
+              fee: new Big(0),
               transactionCount: 3
             }
           ]
@@ -783,6 +1003,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1443.8'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -797,6 +1018,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('2923.7'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 2
             }
           ]
@@ -864,6 +1086,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1000000'), // 1 million
               currency: Currency.USD,
               firstBuyDate: '2010-12-31',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -877,6 +1100,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1100000'), // 1,000,000 + 100,000
               currency: Currency.USD,
               firstBuyDate: '2010-12-31',
+              fee: new Big(0),
               transactionCount: 2
             }
           ]
@@ -933,6 +1157,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('200'),
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -941,6 +1166,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('300'),
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -954,6 +1180,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('200'),
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -962,6 +1189,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('300'),
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1599,6 +1827,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('10109.95'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 1
             },
             {
@@ -1607,6 +1836,7 @@ describe('PortfolioCalculator', () => {
               investment: new Big('1443.8'),
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
+              fee: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1650,7 +1880,8 @@ const ordersMixedSymbols: PortfolioOrder[] = [
     symbol: 'TSLA',
     type: OrderType.Buy,
     unitPrice: new Big('42.97'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   },
   {
     date: '2017-07-01',
@@ -1659,7 +1890,8 @@ const ordersMixedSymbols: PortfolioOrder[] = [
     symbol: 'BTCUSD',
     type: OrderType.Buy,
     unitPrice: new Big('3562.089535970158'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   },
   {
     date: '2018-09-01',
@@ -1668,7 +1900,8 @@ const ordersMixedSymbols: PortfolioOrder[] = [
     symbol: 'AMZN',
     type: OrderType.Buy,
     unitPrice: new Big('2021.99'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   }
 ];
 
@@ -1680,7 +1913,8 @@ const ordersVTI: PortfolioOrder[] = [
     symbol: 'VTI',
     type: OrderType.Buy,
     unitPrice: new Big('144.38'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   },
   {
     date: '2019-08-03',
@@ -1689,7 +1923,8 @@ const ordersVTI: PortfolioOrder[] = [
     symbol: 'VTI',
     type: OrderType.Buy,
     unitPrice: new Big('147.99'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   },
   {
     date: '2020-02-02',
@@ -1698,7 +1933,8 @@ const ordersVTI: PortfolioOrder[] = [
     symbol: 'VTI',
     type: OrderType.Sell,
     unitPrice: new Big('151.41'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   },
   {
     date: '2021-08-01',
@@ -1707,7 +1943,8 @@ const ordersVTI: PortfolioOrder[] = [
     symbol: 'VTI',
     type: OrderType.Buy,
     unitPrice: new Big('177.69'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   },
   {
     date: '2021-02-01',
@@ -1716,7 +1953,8 @@ const ordersVTI: PortfolioOrder[] = [
     symbol: 'VTI',
     type: OrderType.Buy,
     unitPrice: new Big('203.15'),
-    currency: Currency.USD
+    currency: Currency.USD,
+    fee: new Big(0)
   }
 ];
 
@@ -1730,6 +1968,7 @@ const orderTslaTransactionPoint: TransactionPoint[] = [
         investment: new Big('719.46'),
         currency: Currency.USD,
         firstBuyDate: '2021-01-01',
+        fee: new Big(0),
         transactionCount: 1
       }
     ]
@@ -1746,6 +1985,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         investment: new Big('1443.8'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 1
       }
     ]
@@ -1759,6 +1999,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         investment: new Big('2923.7'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 2
       }
     ]
@@ -1772,6 +2013,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         investment: new Big('652.55'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 3
       }
     ]
@@ -1785,6 +2027,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         investment: new Big('2684.05'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 4
       }
     ]
@@ -1798,6 +2041,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         investment: new Big('4460.95'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 5
       }
     ]
@@ -1814,6 +2058,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('1443.8'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 1
       }
     ]
@@ -1827,6 +2072,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('2923.7'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 2
       }
     ]
@@ -1840,6 +2086,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('10109.95'),
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
+        fee: new Big(0),
         transactionCount: 1
       },
       {
@@ -1848,6 +2095,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('2923.7'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 2
       }
     ]
@@ -1861,6 +2109,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('10109.95'),
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
+        fee: new Big(0),
         transactionCount: 1
       },
       {
@@ -1869,6 +2118,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('652.55'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 3
       }
     ]
@@ -1882,6 +2132,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('0'),
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
+        fee: new Big(0),
         transactionCount: 2
       },
       {
@@ -1890,6 +2141,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('652.55'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 3
       }
     ]
@@ -1903,6 +2155,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('0'),
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
+        fee: new Big(0),
         transactionCount: 2
       },
       {
@@ -1911,6 +2164,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('2684.05'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 4
       }
     ]
@@ -1924,6 +2178,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('0'),
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
+        fee: new Big(0),
         transactionCount: 2
       },
       {
@@ -1932,6 +2187,7 @@ const transactionPointsBuyAndSell = [
         investment: new Big('4460.95'),
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
+        fee: new Big(0),
         transactionCount: 5
       }
     ]

--- a/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
@@ -194,7 +194,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 1,
-              fee: new Big('5')
+              fee: new Big('5'),
+              feeAccumulated: new Big('5')
             }
           ]
         },
@@ -208,7 +209,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 2,
-              fee: new Big('10')
+              fee: new Big('10'),
+              feeAccumulated: new Big('15')
             }
           ]
         },
@@ -222,7 +224,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 3,
-              fee: new Big('5')
+              fee: new Big('5'),
+              feeAccumulated: new Big('20')
             }
           ]
         }
@@ -281,7 +284,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 1,
-              fee: new Big('5')
+              fee: new Big('5'),
+              feeAccumulated: new Big('5')
             }
           ]
         },
@@ -295,7 +299,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 1,
-              fee: new Big('0')
+              fee: new Big('0'),
+              feeAccumulated: new Big('5')
             },
             {
               quantity: new Big('10'),
@@ -304,7 +309,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-08-03',
               transactionCount: 1,
-              fee: new Big('10')
+              fee: new Big('10'),
+              feeAccumulated: new Big('10')
             }
           ]
         },
@@ -318,7 +324,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               transactionCount: 2,
-              fee: new Big('5')
+              fee: new Big('5'),
+              feeAccumulated: new Big('10')
             },
             {
               quantity: new Big('10'),
@@ -327,7 +334,8 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-08-03',
               transactionCount: 1,
-              fee: new Big('0')
+              fee: new Big('0'),
+              feeAccumulated: new Big('10')
             }
           ]
         }
@@ -367,6 +375,7 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('10'),
               symbol: 'VTI',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -381,6 +390,7 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('20'),
               symbol: 'VTI',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -395,6 +405,7 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('5'),
               symbol: 'VTI',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 3
             }
           ]
@@ -409,6 +420,7 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('35'),
               symbol: 'VTI',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 5
             }
           ]
@@ -423,6 +435,7 @@ describe('PortfolioCalculator', () => {
               quantity: new Big('45'),
               symbol: 'VTI',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 6
             }
           ]
@@ -463,6 +476,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -477,6 +491,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -491,6 +506,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -500,6 +516,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -514,6 +531,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -523,6 +541,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 3
             }
           ]
@@ -537,6 +556,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -546,6 +566,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 4
             }
           ]
@@ -560,6 +581,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -569,6 +591,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 5
             }
           ]
@@ -633,6 +656,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -647,6 +671,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-07-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -656,6 +681,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -670,6 +696,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2018-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -679,6 +706,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-07-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -688,6 +716,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2017-01-03',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -930,6 +959,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -944,6 +974,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -958,6 +989,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-09-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 3
             }
           ]
@@ -1016,6 +1048,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1031,6 +1064,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -1099,6 +1133,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
+              feeAccumulated: new Big(50),
               transactionCount: 1
             }
           ]
@@ -1114,6 +1149,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
+              feeAccumulated: new Big(100),
               transactionCount: 2
             }
           ]
@@ -1190,6 +1226,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
+              feeAccumulated: new Big(50),
               transactionCount: 1
             }
           ]
@@ -1205,6 +1242,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(50),
+              feeAccumulated: new Big(100),
               transactionCount: 2
             }
           ]
@@ -1277,6 +1315,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2010-12-31',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1291,6 +1330,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2010-12-31',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 2
             }
           ]
@@ -1352,6 +1392,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -1361,6 +1402,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1375,6 +1417,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -1384,6 +1427,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.CHF,
               firstBuyDate: '2012-12-31',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -1460,18 +1504,141 @@ describe('PortfolioCalculator', () => {
         {
           date: '2019-01-01',
           grossPerformance: new Big('0'),
+          netPerformance: new Big('0'),
           investment: new Big('0'),
           value: new Big('0')
         },
         {
           date: '2020-01-01',
           grossPerformance: new Big('498.3'),
+          netPerformance: new Big('498.3'),
           investment: new Big('2923.7'),
           value: new Big('3422') // 20 * (144.38 + days=335 * 0.08)
         },
         {
           date: '2021-01-01',
           grossPerformance: new Big('349.35'),
+          netPerformance: new Big('349.35'),
+          investment: new Big('652.55'),
+          value: new Big('1001.9') // 5 * (144.38 + days=700 * 0.08)
+        }
+      ]);
+    });
+
+    it('with yearly and fees', async () => {
+      const portfolioCalculator = new PortfolioCalculator(
+        currentRateService,
+        Currency.USD
+      );
+      const transactionPoints = [
+        {
+          date: '2019-02-01',
+          items: [
+            {
+              quantity: new Big('10'),
+              symbol: 'VTI',
+              investment: new Big('1443.8'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              feeAccumulated: new Big(50),
+              transactionCount: 1
+            }
+          ]
+        },
+        {
+          date: '2019-08-03',
+          items: [
+            {
+              quantity: new Big('20'),
+              symbol: 'VTI',
+              investment: new Big('2923.7'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              feeAccumulated: new Big(100),
+              transactionCount: 2
+            }
+          ]
+        },
+        {
+          date: '2020-02-02',
+          items: [
+            {
+              quantity: new Big('5'),
+              symbol: 'VTI',
+              investment: new Big('652.55'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              feeAccumulated: new Big(150),
+              transactionCount: 3
+            }
+          ]
+        },
+        {
+          date: '2021-02-01',
+          items: [
+            {
+              quantity: new Big('15'),
+              symbol: 'VTI',
+              investment: new Big('2684.05'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              feeAccumulated: new Big(200),
+              transactionCount: 4
+            }
+          ]
+        },
+        {
+          date: '2021-08-01',
+          items: [
+            {
+              quantity: new Big('25'),
+              symbol: 'VTI',
+              investment: new Big('4460.95'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              feeAccumulated: new Big(250),
+              transactionCount: 5
+            }
+          ]
+        }
+      ];
+      portfolioCalculator.setTransactionPoints(transactionPoints);
+      const timelineSpecification: TimelineSpecification[] = [
+        {
+          start: '2019-01-01',
+          accuracy: 'year'
+        }
+      ];
+      const timeline: TimelinePeriod[] =
+        await portfolioCalculator.calculateTimeline(
+          timelineSpecification,
+          '2021-06-30'
+        );
+
+      expect(timeline).toEqual([
+        {
+          date: '2019-01-01',
+          grossPerformance: new Big('0'),
+          netPerformance: new Big('0'),
+          investment: new Big('0'),
+          value: new Big('0')
+        },
+        {
+          date: '2020-01-01',
+          grossPerformance: new Big('498.3'),
+          netPerformance: new Big('398.3'), // 100 fees
+          investment: new Big('2923.7'),
+          value: new Big('3422') // 20 * (144.38 + days=335 * 0.08)
+        },
+        {
+          date: '2021-01-01',
+          grossPerformance: new Big('349.35'),
+          netPerformance: new Big('199.35'), // 150 fees
           investment: new Big('652.55'),
           value: new Big('1001.9') // 5 * (144.38 + days=700 * 0.08)
         }
@@ -1500,180 +1667,210 @@ describe('PortfolioCalculator', () => {
         {
           date: '2019-01-01',
           grossPerformance: new Big('0'),
+          netPerformance: new Big('0'),
           investment: new Big('0'),
           value: new Big('0')
         },
         {
           date: '2019-02-01',
           grossPerformance: new Big('0'),
+          netPerformance: new Big('0'),
           investment: new Big('1443.8'),
           value: new Big('1443.8') // 10 * (144.38 + days=0 * 0.08)
         },
         {
           date: '2019-03-01',
           grossPerformance: new Big('22.4'),
+          netPerformance: new Big('22.4'),
           investment: new Big('1443.8'),
           value: new Big('1466.2') // 10 * (144.38 + days=28 * 0.08)
         },
         {
           date: '2019-04-01',
           grossPerformance: new Big('47.2'),
+          netPerformance: new Big('47.2'),
           investment: new Big('1443.8'),
           value: new Big('1491') // 10 * (144.38 + days=59 * 0.08)
         },
         {
           date: '2019-05-01',
           grossPerformance: new Big('71.2'),
+          netPerformance: new Big('71.2'),
           investment: new Big('1443.8'),
           value: new Big('1515') // 10 * (144.38 + days=89 * 0.08)
         },
         {
           date: '2019-06-01',
           grossPerformance: new Big('96'),
+          netPerformance: new Big('96'),
           investment: new Big('1443.8'),
           value: new Big('1539.8') // 10 * (144.38 + days=120 * 0.08)
         },
         {
           date: '2019-07-01',
           grossPerformance: new Big('120'),
+          netPerformance: new Big('120'),
           investment: new Big('1443.8'),
           value: new Big('1563.8') // 10 * (144.38 + days=150 * 0.08)
         },
         {
           date: '2019-08-01',
           grossPerformance: new Big('144.8'),
+          netPerformance: new Big('144.8'),
           investment: new Big('1443.8'),
           value: new Big('1588.6') // 10 * (144.38 + days=181 * 0.08)
         },
         {
           date: '2019-09-01',
           grossPerformance: new Big('303.1'),
+          netPerformance: new Big('303.1'),
           investment: new Big('2923.7'),
           value: new Big('3226.8') // 20 * (144.38 + days=212 * 0.08)
         },
         {
           date: '2019-10-01',
           grossPerformance: new Big('351.1'),
+          netPerformance: new Big('351.1'),
           investment: new Big('2923.7'),
           value: new Big('3274.8') // 20 * (144.38 + days=242 * 0.08)
         },
         {
           date: '2019-11-01',
           grossPerformance: new Big('400.7'),
+          netPerformance: new Big('400.7'),
           investment: new Big('2923.7'),
           value: new Big('3324.4') // 20 * (144.38 + days=273 * 0.08)
         },
         {
           date: '2019-12-01',
           grossPerformance: new Big('448.7'),
+          netPerformance: new Big('448.7'),
           investment: new Big('2923.7'),
           value: new Big('3372.4') // 20 * (144.38 + days=303 * 0.08)
         },
         {
           date: '2020-01-01',
           grossPerformance: new Big('498.3'),
+          netPerformance: new Big('498.3'),
           investment: new Big('2923.7'),
           value: new Big('3422') // 20 * (144.38 + days=335 * 0.08)
         },
         {
           date: '2020-02-01',
           grossPerformance: new Big('547.9'),
+          netPerformance: new Big('547.9'),
           investment: new Big('2923.7'),
           value: new Big('3471.6') // 20 * (144.38 + days=365 * 0.08)
         },
         {
           date: '2020-03-01',
           grossPerformance: new Big('226.95'),
+          netPerformance: new Big('226.95'),
           investment: new Big('652.55'),
           value: new Big('879.5') // 5 * (144.38 + days=394 * 0.08)
         },
         {
           date: '2020-04-01',
           grossPerformance: new Big('239.35'),
+          netPerformance: new Big('239.35'),
           investment: new Big('652.55'),
           value: new Big('891.9') // 5 * (144.38 + days=425 * 0.08)
         },
         {
           date: '2020-05-01',
           grossPerformance: new Big('251.35'),
+          netPerformance: new Big('251.35'),
           investment: new Big('652.55'),
           value: new Big('903.9') // 5 * (144.38 + days=455 * 0.08)
         },
         {
           date: '2020-06-01',
           grossPerformance: new Big('263.75'),
+          netPerformance: new Big('263.75'),
           investment: new Big('652.55'),
           value: new Big('916.3') // 5 * (144.38 + days=486 * 0.08)
         },
         {
           date: '2020-07-01',
           grossPerformance: new Big('275.75'),
+          netPerformance: new Big('275.75'),
           investment: new Big('652.55'),
           value: new Big('928.3') // 5 * (144.38 + days=516 * 0.08)
         },
         {
           date: '2020-08-01',
           grossPerformance: new Big('288.15'),
+          netPerformance: new Big('288.15'),
           investment: new Big('652.55'),
           value: new Big('940.7') // 5 * (144.38 + days=547 * 0.08)
         },
         {
           date: '2020-09-01',
           grossPerformance: new Big('300.55'),
+          netPerformance: new Big('300.55'),
           investment: new Big('652.55'),
           value: new Big('953.1') // 5 * (144.38 + days=578 * 0.08)
         },
         {
           date: '2020-10-01',
           grossPerformance: new Big('312.55'),
+          netPerformance: new Big('312.55'),
           investment: new Big('652.55'),
           value: new Big('965.1') // 5 * (144.38 + days=608 * 0.08)
         },
         {
           date: '2020-11-01',
           grossPerformance: new Big('324.95'),
+          netPerformance: new Big('324.95'),
           investment: new Big('652.55'),
           value: new Big('977.5') // 5 * (144.38 + days=639 * 0.08)
         },
         {
           date: '2020-12-01',
           grossPerformance: new Big('336.95'),
+          netPerformance: new Big('336.95'),
           investment: new Big('652.55'),
           value: new Big('989.5') // 5 * (144.38 + days=669 * 0.08)
         },
         {
           date: '2021-01-01',
           grossPerformance: new Big('349.35'),
+          netPerformance: new Big('349.35'),
           investment: new Big('652.55'),
           value: new Big('1001.9') // 5 * (144.38 + days=700 * 0.08)
         },
         {
           date: '2021-02-01',
           grossPerformance: new Big('358.85'),
+          netPerformance: new Big('358.85'),
           investment: new Big('2684.05'),
           value: new Big('3042.9') // 15 * (144.38 + days=731 * 0.08)
         },
         {
           date: '2021-03-01',
           grossPerformance: new Big('392.45'),
+          netPerformance: new Big('392.45'),
           investment: new Big('2684.05'),
           value: new Big('3076.5') // 15 * (144.38 + days=759 * 0.08)
         },
         {
           date: '2021-04-01',
           grossPerformance: new Big('429.65'),
+          netPerformance: new Big('429.65'),
           investment: new Big('2684.05'),
           value: new Big('3113.7') // 15 * (144.38 + days=790 * 0.08)
         },
         {
           date: '2021-05-01',
           grossPerformance: new Big('465.65'),
+          netPerformance: new Big('465.65'),
           investment: new Big('2684.05'),
           value: new Big('3149.7') // 15 * (144.38 + days=820 * 0.08)
         },
         {
           date: '2021-06-01',
           grossPerformance: new Big('502.85'),
+          netPerformance: new Big('502.85'),
           investment: new Big('2684.05'),
           value: new Big('3186.9') // 15 * (144.38 + days=851 * 0.08)
         }
@@ -1706,48 +1903,56 @@ describe('PortfolioCalculator', () => {
         {
           date: '2019-01-01',
           grossPerformance: new Big('0'),
+          netPerformance: new Big('0'),
           investment: new Big('0'),
           value: new Big('0')
         },
         {
           date: '2020-01-01',
           grossPerformance: new Big('498.3'),
+          netPerformance: new Big('498.3'),
           investment: new Big('2923.7'),
           value: new Big('3422') // 20 * (144.38 + days=335 * 0.08)
         },
         {
           date: '2021-01-01',
           grossPerformance: new Big('349.35'),
+          netPerformance: new Big('349.35'),
           investment: new Big('652.55'),
           value: new Big('1001.9') // 5 * (144.38 + days=700 * 0.08)
         },
         {
           date: '2021-02-01',
           grossPerformance: new Big('358.85'),
+          netPerformance: new Big('358.85'),
           investment: new Big('2684.05'),
           value: new Big('3042.9') // 15 * (144.38 + days=731 * 0.08)
         },
         {
           date: '2021-03-01',
           grossPerformance: new Big('392.45'),
+          netPerformance: new Big('392.45'),
           investment: new Big('2684.05'),
           value: new Big('3076.5') // 15 * (144.38 + days=759 * 0.08)
         },
         {
           date: '2021-04-01',
           grossPerformance: new Big('429.65'),
+          netPerformance: new Big('429.65'),
           investment: new Big('2684.05'),
           value: new Big('3113.7') // 15 * (144.38 + days=790 * 0.08)
         },
         {
           date: '2021-05-01',
           grossPerformance: new Big('465.65'),
+          netPerformance: new Big('465.65'),
           investment: new Big('2684.05'),
           value: new Big('3149.7') // 15 * (144.38 + days=820 * 0.08)
         },
         {
           date: '2021-06-01',
           grossPerformance: new Big('502.85'),
+          netPerformance: new Big('502.85'),
           investment: new Big('2684.05'),
           value: new Big('3186.9') // 15 * (144.38 + days=851 * 0.08)
         }
@@ -1785,222 +1990,259 @@ describe('PortfolioCalculator', () => {
           {
             date: '2019-01-01',
             grossPerformance: new Big('0'),
+            netPerformance: new Big('0'),
             investment: new Big('0'),
             value: new Big('0')
           },
           {
             date: '2020-01-01',
             grossPerformance: new Big('498.3'),
+            netPerformance: new Big('498.3'),
             investment: new Big('2923.7'),
             value: new Big('3422') // 20 * (144.38 + days=335 * 0.08)
           },
           {
             date: '2021-01-01',
             grossPerformance: new Big('349.35'),
+            netPerformance: new Big('349.35'),
             investment: new Big('652.55'),
             value: new Big('1001.9') // 5 * (144.38 + days=700 * 0.08)
           },
           {
             date: '2021-02-01',
             grossPerformance: new Big('358.85'),
+            netPerformance: new Big('358.85'),
             investment: new Big('2684.05'),
             value: new Big('3042.9') // 15 * (144.38 + days=731 * 0.08)
           },
           {
             date: '2021-03-01',
             grossPerformance: new Big('392.45'),
+            netPerformance: new Big('392.45'),
             investment: new Big('2684.05'),
             value: new Big('3076.5') // 15 * (144.38 + days=759 * 0.08)
           },
           {
             date: '2021-04-01',
             grossPerformance: new Big('429.65'),
+            netPerformance: new Big('429.65'),
             investment: new Big('2684.05'),
             value: new Big('3113.7') // 15 * (144.38 + days=790 * 0.08)
           },
           {
             date: '2021-05-01',
             grossPerformance: new Big('465.65'),
+            netPerformance: new Big('465.65'),
             investment: new Big('2684.05'),
             value: new Big('3149.7') // 15 * (144.38 + days=820 * 0.08)
           },
           {
             date: '2021-06-01',
             grossPerformance: new Big('502.85'),
+            netPerformance: new Big('502.85'),
             investment: new Big('2684.05'),
             value: new Big('3186.9') // 15 * (144.38 + days=851 * 0.08)
           },
           {
             date: '2021-06-02',
             grossPerformance: new Big('504.05'),
+            netPerformance: new Big('504.05'),
             investment: new Big('2684.05'),
             value: new Big('3188.1') // 15 * (144.38 + days=852 * 0.08) / +1.2
           },
           {
             date: '2021-06-03',
             grossPerformance: new Big('505.25'),
+            netPerformance: new Big('505.25'),
             investment: new Big('2684.05'),
             value: new Big('3189.3') // +1.2
           },
           {
             date: '2021-06-04',
             grossPerformance: new Big('506.45'),
+            netPerformance: new Big('506.45'),
             investment: new Big('2684.05'),
             value: new Big('3190.5') // +1.2
           },
           {
             date: '2021-06-05',
             grossPerformance: new Big('507.65'),
+            netPerformance: new Big('507.65'),
             investment: new Big('2684.05'),
             value: new Big('3191.7') // +1.2
           },
           {
             date: '2021-06-06',
             grossPerformance: new Big('508.85'),
+            netPerformance: new Big('508.85'),
             investment: new Big('2684.05'),
             value: new Big('3192.9') // +1.2
           },
           {
             date: '2021-06-07',
             grossPerformance: new Big('510.05'),
+            netPerformance: new Big('510.05'),
             investment: new Big('2684.05'),
             value: new Big('3194.1') // +1.2
           },
           {
             date: '2021-06-08',
             grossPerformance: new Big('511.25'),
+            netPerformance: new Big('511.25'),
             investment: new Big('2684.05'),
             value: new Big('3195.3') // +1.2
           },
           {
             date: '2021-06-09',
             grossPerformance: new Big('512.45'),
+            netPerformance: new Big('512.45'),
             investment: new Big('2684.05'),
             value: new Big('3196.5') // +1.2
           },
           {
             date: '2021-06-10',
             grossPerformance: new Big('513.65'),
+            netPerformance: new Big('513.65'),
             investment: new Big('2684.05'),
             value: new Big('3197.7') // +1.2
           },
           {
             date: '2021-06-11',
             grossPerformance: new Big('514.85'),
+            netPerformance: new Big('514.85'),
             investment: new Big('2684.05'),
             value: new Big('3198.9') // +1.2
           },
           {
             date: '2021-06-12',
             grossPerformance: new Big('516.05'),
+            netPerformance: new Big('516.05'),
             investment: new Big('2684.05'),
             value: new Big('3200.1') // +1.2
           },
           {
             date: '2021-06-13',
             grossPerformance: new Big('517.25'),
+            netPerformance: new Big('517.25'),
             investment: new Big('2684.05'),
             value: new Big('3201.3') // +1.2
           },
           {
             date: '2021-06-14',
             grossPerformance: new Big('518.45'),
+            netPerformance: new Big('518.45'),
             investment: new Big('2684.05'),
             value: new Big('3202.5') // +1.2
           },
           {
             date: '2021-06-15',
             grossPerformance: new Big('519.65'),
+            netPerformance: new Big('519.65'),
             investment: new Big('2684.05'),
             value: new Big('3203.7') // +1.2
           },
           {
             date: '2021-06-16',
             grossPerformance: new Big('520.85'),
+            netPerformance: new Big('520.85'),
             investment: new Big('2684.05'),
             value: new Big('3204.9') // +1.2
           },
           {
             date: '2021-06-17',
             grossPerformance: new Big('522.05'),
+            netPerformance: new Big('522.05'),
             investment: new Big('2684.05'),
             value: new Big('3206.1') // +1.2
           },
           {
             date: '2021-06-18',
             grossPerformance: new Big('523.25'),
+            netPerformance: new Big('523.25'),
             investment: new Big('2684.05'),
             value: new Big('3207.3') // +1.2
           },
           {
             date: '2021-06-19',
             grossPerformance: new Big('524.45'),
+            netPerformance: new Big('524.45'),
             investment: new Big('2684.05'),
             value: new Big('3208.5') // +1.2
           },
           {
             date: '2021-06-20',
             grossPerformance: new Big('525.65'),
+            netPerformance: new Big('525.65'),
             investment: new Big('2684.05'),
             value: new Big('3209.7') // +1.2
           },
           {
             date: '2021-06-21',
             grossPerformance: new Big('526.85'),
+            netPerformance: new Big('526.85'),
             investment: new Big('2684.05'),
             value: new Big('3210.9') // +1.2
           },
           {
             date: '2021-06-22',
             grossPerformance: new Big('528.05'),
+            netPerformance: new Big('528.05'),
             investment: new Big('2684.05'),
             value: new Big('3212.1') // +1.2
           },
           {
             date: '2021-06-23',
             grossPerformance: new Big('529.25'),
+            netPerformance: new Big('529.25'),
             investment: new Big('2684.05'),
             value: new Big('3213.3') // +1.2
           },
           {
             date: '2021-06-24',
             grossPerformance: new Big('530.45'),
+            netPerformance: new Big('530.45'),
             investment: new Big('2684.05'),
             value: new Big('3214.5') // +1.2
           },
           {
             date: '2021-06-25',
             grossPerformance: new Big('531.65'),
+            netPerformance: new Big('531.65'),
             investment: new Big('2684.05'),
             value: new Big('3215.7') // +1.2
           },
           {
             date: '2021-06-26',
             grossPerformance: new Big('532.85'),
+            netPerformance: new Big('532.85'),
             investment: new Big('2684.05'),
             value: new Big('3216.9') // +1.2
           },
           {
             date: '2021-06-27',
             grossPerformance: new Big('534.05'),
+            netPerformance: new Big('534.05'),
             investment: new Big('2684.05'),
             value: new Big('3218.1') // +1.2
           },
           {
             date: '2021-06-28',
             grossPerformance: new Big('535.25'),
+            netPerformance: new Big('535.25'),
             investment: new Big('2684.05'),
             value: new Big('3219.3') // +1.2
           },
           {
             date: '2021-06-29',
             grossPerformance: new Big('536.45'),
+            netPerformance: new Big('536.45'),
             investment: new Big('2684.05'),
             value: new Big('3220.5') // +1.2
           },
           {
             date: '2021-06-30',
             grossPerformance: new Big('537.65'),
+            netPerformance: new Big('537.65'),
             investment: new Big('2684.05'),
             value: new Big('3221.7') // +1.2
           }
@@ -2024,6 +2266,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             },
             {
@@ -2033,6 +2276,7 @@ describe('PortfolioCalculator', () => {
               currency: Currency.USD,
               firstBuyDate: '2019-02-01',
               fee: new Big(0),
+              feeAccumulated: new Big(0),
               transactionCount: 1
             }
           ]
@@ -2054,12 +2298,14 @@ describe('PortfolioCalculator', () => {
         {
           date: '2019-01-01',
           grossPerformance: new Big('0'),
+          netPerformance: new Big('0'),
           investment: new Big('0'),
           value: new Big('0')
         },
         {
           date: '2020-01-01',
           grossPerformance: new Big('267.2'),
+          netPerformance: new Big('267.2'),
           investment: new Big('11553.75'),
           value: new Big('11820.95') // 10 * (144.38 + days=334 * 0.08) + 5 * 2021.99
         }
@@ -2165,6 +2411,7 @@ const orderTslaTransactionPoint: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2021-01-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 1
       }
     ]
@@ -2182,6 +2429,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 1
       }
     ]
@@ -2196,6 +2444,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 2
       }
     ]
@@ -2210,6 +2459,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 3
       }
     ]
@@ -2224,6 +2474,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 4
       }
     ]
@@ -2238,6 +2489,7 @@ const ordersVTITransactionPoints: TransactionPoint[] = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 5
       }
     ]
@@ -2255,6 +2507,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 1
       }
     ]
@@ -2269,6 +2522,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 2
       }
     ]
@@ -2283,6 +2537,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 1
       },
       {
@@ -2292,6 +2547,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 2
       }
     ]
@@ -2306,6 +2562,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 1
       },
       {
@@ -2315,6 +2572,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 3
       }
     ]
@@ -2329,6 +2587,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 2
       },
       {
@@ -2338,6 +2597,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 3
       }
     ]
@@ -2352,6 +2612,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 2
       },
       {
@@ -2361,6 +2622,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 4
       }
     ]
@@ -2375,6 +2637,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-09-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 2
       },
       {
@@ -2384,6 +2647,7 @@ const transactionPointsBuyAndSell = [
         currency: Currency.USD,
         firstBuyDate: '2019-02-01',
         fee: new Big(0),
+        feeAccumulated: new Big(0),
         transactionCount: 5
       }
     ]

--- a/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.spec.ts
@@ -712,27 +712,29 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('657.62'),
-        grossPerformance: new Big('-61.84'),
-        grossPerformancePercentage: new Big('-0.08595335390431712673'),
-        totalInvestment: new Big('719.46'),
-        positions: [
-          {
-            averagePrice: new Big('719.46'),
-            currency: 'USD',
-            firstBuyDate: '2021-01-01',
-            grossPerformance: new Big('-61.84'), // 657.62-719.46=-61.84
-            grossPerformancePercentage: new Big('-0.08595335390431712673'), // (657.62-719.46)/719.46=-0.08595335390431712673
-            investment: new Big('719.46'),
-            marketPrice: 657.62,
-            quantity: new Big('1'),
-            symbol: 'TSLA',
-            transactionCount: 1
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('657.62'),
+          grossPerformance: new Big('-61.84'),
+          grossPerformancePercentage: new Big('-0.08595335390431712673'),
+          totalInvestment: new Big('719.46'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('719.46'),
+              currency: 'USD',
+              firstBuyDate: '2021-01-01',
+              grossPerformance: new Big('-61.84'), // 657.62-719.46=-61.84
+              grossPerformancePercentage: new Big('-0.08595335390431712673'), // (657.62-719.46)/719.46=-0.08595335390431712673
+              investment: new Big('719.46'),
+              marketPrice: 657.62,
+              quantity: new Big('1'),
+              symbol: 'TSLA',
+              transactionCount: 1
+            })
+          ]
+        })
+      );
     });
 
     it('with single TSLA and buy day start', async () => {
@@ -750,27 +752,29 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('657.62'),
-        grossPerformance: new Big('-61.84'),
-        grossPerformancePercentage: new Big('-0.08595335390431712673'),
-        totalInvestment: new Big('719.46'),
-        positions: [
-          {
-            averagePrice: new Big('719.46'),
-            currency: 'USD',
-            firstBuyDate: '2021-01-01',
-            grossPerformance: new Big('-61.84'), // 657.62-719.46=-61.84
-            grossPerformancePercentage: new Big('-0.08595335390431712673'), // (657.62-719.46)/719.46=-0.08595335390431712673
-            investment: new Big('719.46'),
-            marketPrice: 657.62,
-            quantity: new Big('1'),
-            symbol: 'TSLA',
-            transactionCount: 1
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('657.62'),
+          grossPerformance: new Big('-61.84'),
+          grossPerformancePercentage: new Big('-0.08595335390431712673'),
+          totalInvestment: new Big('719.46'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('719.46'),
+              currency: 'USD',
+              firstBuyDate: '2021-01-01',
+              grossPerformance: new Big('-61.84'), // 657.62-719.46=-61.84
+              grossPerformancePercentage: new Big('-0.08595335390431712673'), // (657.62-719.46)/719.46=-0.08595335390431712673
+              investment: new Big('719.46'),
+              marketPrice: 657.62,
+              quantity: new Big('1'),
+              symbol: 'TSLA',
+              transactionCount: 1
+            })
+          ]
+        })
+      );
     });
 
     it('with single TSLA and late start', async () => {
@@ -788,27 +792,29 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('657.62'),
-        grossPerformance: new Big('-9.04'),
-        grossPerformancePercentage: new Big('-0.01356013560135601356'),
-        totalInvestment: new Big('719.46'),
-        positions: [
-          {
-            averagePrice: new Big('719.46'),
-            currency: 'USD',
-            firstBuyDate: '2021-01-01',
-            grossPerformance: new Big('-9.04'), // 657.62-666.66=-9.04
-            grossPerformancePercentage: new Big('-0.01356013560135601356'), // 657.62/666.66-1=-0.013560136
-            investment: new Big('719.46'),
-            marketPrice: 657.62,
-            quantity: new Big('1'),
-            symbol: 'TSLA',
-            transactionCount: 1
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('657.62'),
+          grossPerformance: new Big('-9.04'),
+          grossPerformancePercentage: new Big('-0.01356013560135601356'),
+          totalInvestment: new Big('719.46'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('719.46'),
+              currency: 'USD',
+              firstBuyDate: '2021-01-01',
+              grossPerformance: new Big('-9.04'), // 657.62-666.66=-9.04
+              grossPerformancePercentage: new Big('-0.01356013560135601356'), // 657.62/666.66-1=-0.013560136
+              investment: new Big('719.46'),
+              marketPrice: 657.62,
+              quantity: new Big('1'),
+              symbol: 'TSLA',
+              transactionCount: 1
+            })
+          ]
+        })
+      );
     });
 
     it('with VTI only', async () => {
@@ -826,30 +832,32 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('4871.5'),
-        grossPerformance: new Big('240.4'),
-        grossPerformancePercentage: new Big('0.08839407904876477102'),
-        totalInvestment: new Big('4460.95'),
-        positions: [
-          {
-            averagePrice: new Big('178.438'),
-            currency: 'USD',
-            firstBuyDate: '2019-02-01',
-            // see next test for details about how to calculate this
-            grossPerformance: new Big('240.4'),
-            grossPerformancePercentage: new Big(
-              '0.0883940790487647710162214425767848424215253864940558186258745429269647266073266478435285352186572448'
-            ),
-            investment: new Big('4460.95'),
-            marketPrice: 194.86,
-            quantity: new Big('25'),
-            symbol: 'VTI',
-            transactionCount: 5
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('4871.5'),
+          grossPerformance: new Big('240.4'),
+          grossPerformancePercentage: new Big('0.08839407904876477102'),
+          totalInvestment: new Big('4460.95'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('178.438'),
+              currency: 'USD',
+              firstBuyDate: '2019-02-01',
+              // see next test for details about how to calculate this
+              grossPerformance: new Big('240.4'),
+              grossPerformancePercentage: new Big(
+                '0.0883940790487647710162214425767848424215253864940558186258745429269647266073266478435285352186572448'
+              ),
+              investment: new Big('4460.95'),
+              marketPrice: 194.86,
+              quantity: new Big('25'),
+              symbol: 'VTI',
+              transactionCount: 5
+            })
+          ]
+        })
+      );
     });
 
     it('with buy and sell', async () => {
@@ -867,41 +875,43 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('4871.5'),
-        grossPerformance: new Big('240.4'),
-        grossPerformancePercentage: new Big('0.01104605615757711361'),
-        totalInvestment: new Big('4460.95'),
-        positions: [
-          {
-            averagePrice: new Big('0'),
-            currency: 'USD',
-            firstBuyDate: '2019-09-01',
-            grossPerformance: new Big('0'),
-            grossPerformancePercentage: new Big('0'),
-            investment: new Big('0'),
-            marketPrice: 2021.99,
-            quantity: new Big('0'),
-            symbol: 'AMZN',
-            transactionCount: 2
-          },
-          {
-            averagePrice: new Big('178.438'),
-            currency: 'USD',
-            firstBuyDate: '2019-02-01',
-            grossPerformance: new Big('240.4'),
-            grossPerformancePercentage: new Big(
-              '0.08839407904876477101219019935616297754969945667391763908415656216989674494965785538864363782688167989866968512455219637257546280462751601552'
-            ),
-            investment: new Big('4460.95'),
-            marketPrice: 194.86,
-            quantity: new Big('25'),
-            symbol: 'VTI',
-            transactionCount: 5
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('4871.5'),
+          grossPerformance: new Big('240.4'),
+          grossPerformancePercentage: new Big('0.01104605615757711361'),
+          totalInvestment: new Big('4460.95'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('0'),
+              currency: 'USD',
+              firstBuyDate: '2019-09-01',
+              grossPerformance: new Big('0'),
+              grossPerformancePercentage: new Big('0'),
+              investment: new Big('0'),
+              marketPrice: 2021.99,
+              quantity: new Big('0'),
+              symbol: 'AMZN',
+              transactionCount: 2
+            }),
+            expect.objectContaining({
+              averagePrice: new Big('178.438'),
+              currency: 'USD',
+              firstBuyDate: '2019-02-01',
+              grossPerformance: new Big('240.4'),
+              grossPerformancePercentage: new Big(
+                '0.08839407904876477101219019935616297754969945667391763908415656216989674494965785538864363782688167989866968512455219637257546280462751601552'
+              ),
+              investment: new Big('4460.95'),
+              marketPrice: 194.86,
+              quantity: new Big('25'),
+              symbol: 'VTI',
+              transactionCount: 5
+            })
+          ]
+        })
+      );
     });
 
     it('with buy, sell, buy', async () => {
@@ -962,29 +972,31 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('1086.7'),
-        grossPerformance: new Big('207.6'),
-        grossPerformancePercentage: new Big('0.2516103956224511062'),
-        totalInvestment: new Big('1013.9'),
-        positions: [
-          {
-            averagePrice: new Big('202.78'),
-            currency: 'USD',
-            firstBuyDate: '2019-09-01',
-            grossPerformance: new Big('207.6'),
-            grossPerformancePercentage: new Big(
-              '0.2516103956224511061954915466429950404846'
-            ),
-            investment: new Big('1013.9'),
-            marketPrice: 217.34,
-            quantity: new Big('5'),
-            symbol: 'VTI',
-            transactionCount: 3
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('1086.7'),
+          grossPerformance: new Big('207.6'),
+          grossPerformancePercentage: new Big('0.2516103956224511062'),
+          totalInvestment: new Big('1013.9'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('202.78'),
+              currency: 'USD',
+              firstBuyDate: '2019-09-01',
+              grossPerformance: new Big('207.6'),
+              grossPerformancePercentage: new Big(
+                '0.2516103956224511061954915466429950404846'
+              ),
+              investment: new Big('1013.9'),
+              marketPrice: 217.34,
+              quantity: new Big('5'),
+              symbol: 'VTI',
+              transactionCount: 3
+            })
+          ]
+        })
+      );
     });
 
     it('with performance since Jan 1st, 2020', async () => {
@@ -1043,11 +1055,100 @@ describe('PortfolioCalculator', () => {
       );
 
       spy.mockRestore();
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('3897.2'),
+          grossPerformance: new Big('303.2'),
+          grossPerformancePercentage: new Big('0.27537838148272398344'),
+          totalInvestment: new Big('2923.7'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('146.185'),
+              firstBuyDate: '2019-02-01',
+              quantity: new Big('20'),
+              symbol: 'VTI',
+              investment: new Big('2923.7'),
+              marketPrice: 194.86,
+              transactionCount: 2,
+              grossPerformance: new Big('303.2'),
+              grossPerformancePercentage: new Big(
+                '0.2753783814827239834392742298083677500037'
+              ),
+              currency: 'USD'
+            })
+          ]
+        })
+      );
+    });
+
+    it('with net performance since Jan 1st, 2020 - include fees', async () => {
+      const portfolioCalculator = new PortfolioCalculator(
+        currentRateService,
+        Currency.USD
+      );
+      const transactionPoints = [
+        {
+          date: '2019-02-01',
+          items: [
+            {
+              quantity: new Big('10'),
+              name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+              symbol: 'VTI',
+              investment: new Big('1443.8'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              transactionCount: 1
+            }
+          ]
+        },
+        {
+          date: '2020-08-03',
+          items: [
+            {
+              quantity: new Big('20'),
+              name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+              symbol: 'VTI',
+              investment: new Big('2923.7'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              transactionCount: 2
+            }
+          ]
+        }
+      ];
+
+      portfolioCalculator.setTransactionPoints(transactionPoints);
+      const spy = jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => new Date(Date.UTC(2020, 9, 24)).getTime()); // 2020-10-24
+
+      // 2020-01-01         -> days 334 => value: VTI: 144.38+334*0.08=171.1  => 10*171.10=1711
+      // 2020-08-03         -> days 549 => value: VTI: 144.38+549*0.08=188.3  => 10*188.30=1883 => 1883/1711 = 1.100526008
+      // 2020-08-03         -> days 549 => value: VTI: 144.38+549*0.08=188.3  => 20*188.30=3766
+      // cash flow: 2923.7-1443.8=1479.9
+      // 2020-10-24 [today] -> days 631 => value: VTI: 144.38+631*0.08=194.86 => 20*194.86=3897.2 => 3897.2/(1883+1479.9) = 1.158880728
+      //                                                                                    and net: 3897.2/(1883+1479.9+50) = 1.14190278
+      // gross performance: 1883-1711 + 3897.2-3766 = 303.2
+      // gross performance percentage: 1.100526008 * 1.158880728 = 1.275378381 => 27.5378381 %
+      // net performance percentage:   1.100526008 * 1.14190278  = 1.25669371  => 25.669371 %
+
+      // more details: https://github.com/ghostfolio/ghostfolio/issues/324#issuecomment-910530823
+
+      const currentPositions = await portfolioCalculator.getCurrentPositions(
+        parseDate('2020-01-01')
+      );
+
+      spy.mockRestore();
       expect(currentPositions).toEqual({
         hasErrors: false,
         currentValue: new Big('3897.2'),
         grossPerformance: new Big('303.2'),
         grossPerformancePercentage: new Big('0.27537838148272398344'),
+        netPerformance: new Big('253.2'),
+        netPerformancePercentage: new Big('0.2566937088951485493'),
         totalInvestment: new Big('2923.7'),
         positions: [
           {
@@ -1062,10 +1163,99 @@ describe('PortfolioCalculator', () => {
             grossPerformancePercentage: new Big(
               '0.2753783814827239834392742298083677500037'
             ),
+            netPerformance: new Big('253.2'), // gross - 50 fees
+            netPerformancePercentage: new Big(
+              '0.2566937088951485493029975263687800261527'
+            ), // see details above
             currency: 'USD'
           }
         ]
       });
+    });
+
+    it('with net performance since Feb 1st, 2019 - include fees', async () => {
+      const portfolioCalculator = new PortfolioCalculator(
+        currentRateService,
+        Currency.USD
+      );
+      const transactionPoints = [
+        {
+          date: '2019-02-01',
+          items: [
+            {
+              quantity: new Big('10'),
+              name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+              symbol: 'VTI',
+              investment: new Big('1443.8'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              transactionCount: 1
+            }
+          ]
+        },
+        {
+          date: '2020-08-03',
+          items: [
+            {
+              quantity: new Big('20'),
+              name: 'Vanguard Total Stock Market Index Fund ETF Shares',
+              symbol: 'VTI',
+              investment: new Big('2923.7'),
+              currency: Currency.USD,
+              firstBuyDate: '2019-02-01',
+              fee: new Big(50),
+              transactionCount: 2
+            }
+          ]
+        }
+      ];
+
+      portfolioCalculator.setTransactionPoints(transactionPoints);
+      const spy = jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => new Date(Date.UTC(2020, 9, 24)).getTime()); // 2020-10-24
+
+      // 2019-02-01         -> value: VTI: 1443.8
+      // 2020-08-03         -> days 549 => value: VTI: 144.38+549*0.08=188.3  => 10*188.30=1883 => net: 1883/(1443.8+50) = 1.26054358
+      // 2020-08-03         -> days 549 => value: VTI: 144.38+549*0.08=188.3  => 20*188.30=3766
+      // cash flow: 2923.7-1443.8=1479.9
+      // 2020-10-24 [today] -> days 631 => value: VTI: 144.38+631*0.08=194.86 => 20*194.86=3897.2 => net: 3897.2/(1883+1479.9+50) = 1.14190278
+      // gross performance: 1883-1443.8 + 3897.2-3766 = 570.4 => net performance: 470.4
+      // net performance percentage:   1.26054358 * 1.14190278  = 1.43941822  => 43.941822 %
+
+      // more details: https://github.com/ghostfolio/ghostfolio/issues/324#issuecomment-910530823
+
+      const currentPositions = await portfolioCalculator.getCurrentPositions(
+        parseDate('2019-02-01')
+      );
+
+      spy.mockRestore();
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('3897.2'),
+          netPerformance: new Big('470.4'),
+          netPerformancePercentage: new Big('0.4394182192526437059'),
+          totalInvestment: new Big('2923.7'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('146.185'),
+              firstBuyDate: '2019-02-01',
+              quantity: new Big('20'),
+              symbol: 'VTI',
+              investment: new Big('2923.7'),
+              marketPrice: 194.86,
+              transactionCount: 2,
+              netPerformance: new Big('470.4'),
+              netPerformancePercentage: new Big(
+                '0.4394182192526437058970248283134805555953'
+              ), // see details above
+              currency: 'USD'
+            })
+          ]
+        })
+      );
     });
 
     /**
@@ -1116,27 +1306,31 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        hasErrors: false,
-        currentValue: new Big('1192327.999656600298238721'),
-        grossPerformance: new Big('92327.999656600898394721'),
-        grossPerformancePercentage: new Big('0.09788498099999947809'),
-        totalInvestment: new Big('1100000'),
-        positions: [
-          {
-            averagePrice: new Big('1.01287018290924923237'), // 1'100'000 / 1'086'022.689344542
-            firstBuyDate: '2010-12-31',
-            quantity: new Big('1086022.689344541'),
-            symbol: 'MFA',
-            investment: new Big('1100000'),
-            marketPrice: 1.097884981,
-            transactionCount: 2,
-            grossPerformance: new Big('92327.999656600898394721'), // 1'192'328 - 1'100'000 = 92'328
-            grossPerformancePercentage: new Big('0.09788498099999947808927632'), // 9.79 %
-            currency: 'USD'
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          hasErrors: false,
+          currentValue: new Big('1192327.999656600298238721'),
+          grossPerformance: new Big('92327.999656600898394721'),
+          grossPerformancePercentage: new Big('0.09788498099999947809'),
+          totalInvestment: new Big('1100000'),
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('1.01287018290924923237'), // 1'100'000 / 1'086'022.689344542
+              firstBuyDate: '2010-12-31',
+              quantity: new Big('1086022.689344541'),
+              symbol: 'MFA',
+              investment: new Big('1100000'),
+              marketPrice: 1.097884981,
+              transactionCount: 2,
+              grossPerformance: new Big('92327.999656600898394721'), // 1'192'328 - 1'100'000 = 92'328
+              grossPerformancePercentage: new Big(
+                '0.09788498099999947808927632'
+              ), // 9.79 %
+              currency: 'USD'
+            })
+          ]
+        })
+      );
     });
 
     /**
@@ -1205,39 +1399,41 @@ describe('PortfolioCalculator', () => {
       );
       spy.mockRestore();
 
-      expect(currentPositions).toEqual({
-        currentValue: new Big('517'),
-        grossPerformance: new Big('17'), // 517 - 500
-        grossPerformancePercentage: new Big('0.034'), // ((200 * 0.025) + (300 * 0.04)) / (200 + 300) = 3.4%
-        totalInvestment: new Big('500'),
-        hasErrors: false,
-        positions: [
-          {
-            averagePrice: new Big('1'),
-            firstBuyDate: '2012-12-31',
-            quantity: new Big('200'),
-            symbol: 'SPA',
-            investment: new Big('200'),
-            marketPrice: 1.025, // 205 / 200
-            transactionCount: 1,
-            grossPerformance: new Big('5'), // 205 - 200
-            grossPerformancePercentage: new Big('0.025'),
-            currency: 'CHF'
-          },
-          {
-            averagePrice: new Big('1'),
-            firstBuyDate: '2012-12-31',
-            quantity: new Big('300'),
-            symbol: 'SPB',
-            investment: new Big('300'),
-            marketPrice: 1.04, // 312 / 300
-            transactionCount: 1,
-            grossPerformance: new Big('12'), // 312 - 300
-            grossPerformancePercentage: new Big('0.04'),
-            currency: 'CHF'
-          }
-        ]
-      });
+      expect(currentPositions).toEqual(
+        expect.objectContaining({
+          currentValue: new Big('517'),
+          grossPerformance: new Big('17'), // 517 - 500
+          grossPerformancePercentage: new Big('0.034'), // ((200 * 0.025) + (300 * 0.04)) / (200 + 300) = 3.4%
+          totalInvestment: new Big('500'),
+          hasErrors: false,
+          positions: [
+            expect.objectContaining({
+              averagePrice: new Big('1'),
+              firstBuyDate: '2012-12-31',
+              quantity: new Big('200'),
+              symbol: 'SPA',
+              investment: new Big('200'),
+              marketPrice: 1.025, // 205 / 200
+              transactionCount: 1,
+              grossPerformance: new Big('5'), // 205 - 200
+              grossPerformancePercentage: new Big('0.025'),
+              currency: 'CHF'
+            }),
+            expect.objectContaining({
+              averagePrice: new Big('1'),
+              firstBuyDate: '2012-12-31',
+              quantity: new Big('300'),
+              symbol: 'SPB',
+              investment: new Big('300'),
+              marketPrice: 1.04, // 312 / 300
+              transactionCount: 1,
+              grossPerformance: new Big('12'), // 312 - 300
+              grossPerformancePercentage: new Big('0.04'),
+              currency: 'CHF'
+            })
+          ]
+        })
+      );
     });
   });
 

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -67,6 +67,7 @@ export class PortfolioCalculator {
                 .add(oldAccumulatedSymbol.investment),
           quantity: newQuantity,
           symbol: order.symbol,
+          fee: order.fee,
           transactionCount: oldAccumulatedSymbol.transactionCount + 1
         };
       } else {
@@ -76,6 +77,7 @@ export class PortfolioCalculator {
           investment: unitPrice.mul(order.quantity).mul(factor),
           quantity: order.quantity.mul(factor),
           symbol: order.symbol,
+          fee: order.fee,
           transactionCount: 1
         };
       }
@@ -83,9 +85,14 @@ export class PortfolioCalculator {
       symbols[order.symbol] = currentTransactionPointItem;
 
       const items = lastTransactionPoint?.items ?? [];
-      const newItems = items.filter(
-        (transactionPointItem) => transactionPointItem.symbol !== order.symbol
-      );
+      const newItems = items
+        .filter(
+          (transactionPointItem) => transactionPointItem.symbol !== order.symbol
+        )
+        .map((transactionPoint) => ({
+          ...transactionPoint,
+          fee: new Big(0)
+        }));
       newItems.push(currentTransactionPointItem);
       newItems.sort((a, b) => a.symbol.localeCompare(b.symbol));
       if (lastDate !== currentDate || lastTransactionPoint === null) {

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -522,7 +522,7 @@ export class PortfolioCalculator {
       }
     }
 
-    const results = [];
+    const results: TimelinePeriod[] = [];
     for (
       let currentDate = startDate;
       isBefore(currentDate, endDate);
@@ -546,10 +546,11 @@ export class PortfolioCalculator {
       }
       if (!invalid) {
         const result = {
+          investment,
+          value,
           date: currentDateAsString,
           grossPerformance: value.minus(investment),
-          investment,
-          value
+          netPerformance: new Big(0) // TODO
         };
         results.push(result);
       }

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -58,6 +58,7 @@ export class PortfolioCalculator {
           .plus(oldAccumulatedSymbol.quantity);
         currentTransactionPointItem = {
           currency: order.currency,
+          fee: order.fee,
           firstBuyDate: oldAccumulatedSymbol.firstBuyDate,
           investment: newQuantity.eq(0)
             ? new Big(0)
@@ -67,17 +68,16 @@ export class PortfolioCalculator {
                 .add(oldAccumulatedSymbol.investment),
           quantity: newQuantity,
           symbol: order.symbol,
-          fee: order.fee,
           transactionCount: oldAccumulatedSymbol.transactionCount + 1
         };
       } else {
         currentTransactionPointItem = {
           currency: order.currency,
+          fee: order.fee,
           firstBuyDate: order.date,
           investment: unitPrice.mul(order.quantity).mul(factor),
           quantity: order.quantity.mul(factor),
           symbol: order.symbol,
-          fee: order.fee,
           transactionCount: 1
         };
       }
@@ -119,13 +119,13 @@ export class PortfolioCalculator {
   public async getCurrentPositions(start: Date): Promise<CurrentPositions> {
     if (!this.transactionPoints?.length) {
       return {
+        currentValue: new Big(0),
         hasErrors: false,
-        positions: [],
         grossPerformance: new Big(0),
         grossPerformancePercentage: new Big(0),
         netPerformance: new Big(0),
         netPerformancePercentage: new Big(0),
-        currentValue: new Big(0),
+        positions: [],
         totalInvestment: new Big(0)
       };
     }
@@ -300,13 +300,13 @@ export class PortfolioCalculator {
           isValid && holdingPeriodReturns[item.symbol]
             ? holdingPeriodReturns[item.symbol].minus(1)
             : null,
+        investment: item.investment,
+        marketPrice: marketValue?.toNumber() ?? null,
         netPerformance: isValid ? netPerformance[item.symbol] ?? null : null,
         netPerformancePercentage:
           isValid && netHoldingPeriodReturns[item.symbol]
             ? netHoldingPeriodReturns[item.symbol].minus(1)
             : null,
-        investment: item.investment,
-        marketPrice: marketValue?.toNumber() ?? null,
         quantity: item.quantity,
         symbol: item.symbol,
         transactionCount: item.transactionCount
@@ -461,9 +461,9 @@ export class PortfolioCalculator {
       currentValue,
       grossPerformance,
       grossPerformancePercentage,
+      hasErrors,
       netPerformance,
       netPerformancePercentage,
-      hasErrors,
       totalInvestment
     };
   }

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -233,6 +233,8 @@ export class PortfolioService {
         marketPrice: item.marketPrice,
         marketState: dataProviderResponse.marketState,
         name: symbolProfile.name,
+        netPerformance: item.netPerformance?.toNumber() ?? 0,
+        netPerformancePercent: item.netPerformancePercentage?.toNumber() ?? 0,
         quantity: item.quantity.toNumber(),
         sectors: symbolProfile.sectors,
         symbol: item.symbol,
@@ -280,6 +282,8 @@ export class PortfolioService {
         marketPrice: undefined,
         maxPrice: undefined,
         minPrice: undefined,
+        netPerformance: undefined,
+        netPerformancePercent: undefined,
         quantity: undefined,
         symbol: aSymbol,
         transactionCount: undefined
@@ -325,7 +329,7 @@ export class PortfolioService {
         transactionCount
       } = position;
 
-      // Convert investment and gross performance to currency of user
+      // Convert investment, gross and net performance to currency of user
       const userCurrency = this.request.user.Settings.currency;
       const investment = this.exchangeRateDataService.toCurrency(
         position.investment.toNumber(),
@@ -334,6 +338,11 @@ export class PortfolioService {
       );
       const grossPerformance = this.exchangeRateDataService.toCurrency(
         position.grossPerformance.toNumber(),
+        currency,
+        userCurrency
+      );
+      const netPerformance = this.exchangeRateDataService.toCurrency(
+        position.netPerformance.toNumber(),
         currency,
         userCurrency
       );
@@ -398,10 +407,12 @@ export class PortfolioService {
         marketPrice,
         maxPrice,
         minPrice,
+        netPerformance,
         transactionCount,
         averagePrice: averagePrice.toNumber(),
         grossPerformancePercent: position.grossPerformancePercentage.toNumber(),
         historicalData: historicalDataArray,
+        netPerformancePercent: position.netPerformancePercentage.toNumber(),
         quantity: quantity.toNumber(),
         symbol: aSymbol
       };
@@ -451,6 +462,8 @@ export class PortfolioService {
         grossPerformancePercent: undefined,
         historicalData: historicalDataArray,
         investment: 0,
+        netPerformance: undefined,
+        netPerformancePercent: undefined,
         quantity: 0,
         symbol: aSymbol,
         transactionCount: undefined
@@ -514,6 +527,9 @@ export class PortfolioService {
           investment: new Big(position.investment).toNumber(),
           marketState: dataProviderResponses[position.symbol].marketState,
           name: symbolProfileMap[position.symbol].name,
+          netPerformance: position.netPerformance?.toNumber() ?? null,
+          netPerformancePercentage:
+            position.netPerformancePercentage?.toNumber() ?? null,
           quantity: new Big(position.quantity).toNumber()
         };
       })
@@ -539,6 +555,8 @@ export class PortfolioService {
         performance: {
           currentGrossPerformance: 0,
           currentGrossPerformancePercent: 0,
+          currentNetPerformance: 0,
+          currentNetPerformancePercent: 0,
           currentValue: 0
         }
       };
@@ -558,11 +576,17 @@ export class PortfolioService {
       currentPositions.grossPerformance.toNumber();
     const currentGrossPerformancePercent =
       currentPositions.grossPerformancePercentage.toNumber();
+    const currentNetPerformance = currentPositions.netPerformance.toNumber();
+    const currentNetPerformancePercent =
+      currentPositions.netPerformancePercentage.toNumber();
+
     return {
       hasErrors: currentPositions.hasErrors || hasErrors,
       performance: {
         currentGrossPerformance,
         currentGrossPerformancePercent,
+        currentNetPerformance,
+        currentNetPerformancePercent,
         currentValue: currentValue
       }
     };
@@ -733,6 +757,8 @@ export class PortfolioService {
       marketPrice: 0,
       marketState: MarketState.open,
       name: 'Cash',
+      netPerformance: 0,
+      netPerformancePercent: 0,
       quantity: 0,
       sectors: [],
       symbol: ghostfolioCashSymbol,

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -295,7 +295,8 @@ export class PortfolioService {
       quantity: new Big(order.quantity),
       symbol: order.symbol,
       type: <OrderType>order.type,
-      unitPrice: new Big(order.unitPrice)
+      unitPrice: new Big(order.unitPrice),
+      fee: new Big(order.fee)
     }));
 
     const portfolioCalculator = new PortfolioCalculator(
@@ -785,6 +786,13 @@ export class PortfolioService {
       unitPrice: new Big(
         this.exchangeRateDataService.toCurrency(
           order.unitPrice,
+          order.currency,
+          userCurrency
+        )
+      ),
+      fee: new Big(
+        this.exchangeRateDataService.toCurrency(
+          order.fee,
           order.currency,
           userCurrency
         )

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -291,12 +291,12 @@ export class PortfolioService {
     const portfolioOrders: PortfolioOrder[] = orders.map((order) => ({
       currency: order.currency,
       date: format(order.date, DATE_FORMAT),
+      fee: new Big(order.fee),
       name: order.SymbolProfile?.name,
       quantity: new Big(order.quantity),
       symbol: order.symbol,
       type: <OrderType>order.type,
-      unitPrice: new Big(order.unitPrice),
-      fee: new Big(order.fee)
+      unitPrice: new Big(order.unitPrice)
     }));
 
     const portfolioCalculator = new PortfolioCalculator(
@@ -779,6 +779,13 @@ export class PortfolioService {
     const portfolioOrders: PortfolioOrder[] = orders.map((order) => ({
       currency: order.currency,
       date: format(order.date, DATE_FORMAT),
+      fee: new Big(
+        this.exchangeRateDataService.toCurrency(
+          order.fee,
+          order.currency,
+          userCurrency
+        )
+      ),
       name: order.SymbolProfile?.name,
       quantity: new Big(order.quantity),
       symbol: order.symbol,
@@ -786,13 +793,6 @@ export class PortfolioService {
       unitPrice: new Big(
         this.exchangeRateDataService.toCurrency(
           order.unitPrice,
-          order.currency,
-          userCurrency
-        )
-      ),
-      fee: new Big(
-        this.exchangeRateDataService.toCurrency(
-          order.fee,
           order.currency,
           userCurrency
         )

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -147,7 +147,7 @@ export class PortfolioService {
       .map((timelineItem) => ({
         date: timelineItem.date,
         marketPrice: timelineItem.value,
-        value: timelineItem.grossPerformance.toNumber()
+        value: timelineItem.netPerformance.toNumber()
       }));
   }
 

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -37,7 +37,7 @@
         [colorizeSign]="true"
         [isCurrency]="true"
         [locale]="locale"
-        [value]="isLoading ? undefined : performance?.currentGrossPerformance"
+        [value]="isLoading ? undefined : performance?.currentNetPerformance"
       ></gf-value>
     </div>
     <div class="col">
@@ -46,7 +46,7 @@
         [isPercent]="true"
         [locale]="locale"
         [value]="
-          isLoading ? undefined : performance?.currentGrossPerformancePercent
+          isLoading ? undefined : performance?.currentNetPerformancePercent
         "
       ></gf-value>
     </div>

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -52,7 +52,7 @@ export class PortfolioPerformanceComponent implements OnChanges, OnInit {
 
         new CountUp(
           'value',
-          this.performance?.currentGrossPerformancePercent * 100,
+          this.performance?.currentNetPerformancePercent * 100,
           {
             decimalPlaces: 2,
             duration: 0.75,

--- a/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html
+++ b/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html
@@ -9,23 +9,6 @@
   <div class="row">
     <div class="col"><hr /></div>
   </div>
-  <div class="row px-3">
-    <div class="d-flex flex-grow-1" i18n>
-      Fees for {{ summary?.ordersCount }} {summary?.ordersCount, plural, =1
-      {order} other {orders}}
-    </div>
-    <div class="d-flex justify-content-end">
-      <gf-value
-        class="justify-content-end"
-        [currency]="baseCurrency"
-        [locale]="locale"
-        [value]="isLoading ? undefined : summary?.fees"
-      ></gf-value>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col"><hr /></div>
-  </div>
   <div class="row px-3 py-1">
     <div class="d-flex flex-grow-1" i18n>Buy</div>
     <div class="d-flex justify-content-end">
@@ -66,7 +49,7 @@
     </div>
   </div>
   <div class="row px-3 py-1">
-    <div class="d-flex flex-grow-1" i18n>Absolute Performance</div>
+    <div class="d-flex flex-grow-1" i18n>Absolute Gross Performance</div>
     <div class="d-flex justify-content-end">
       <gf-value
         class="justify-content-end"
@@ -77,7 +60,7 @@
     </div>
   </div>
   <div class="row px-3 py-1">
-    <div class="d-flex flex-grow-1 ml-3" i18n>Performance (TWR)</div>
+    <div class="d-flex flex-grow-1 ml-3" i18n>Gross Performance (TWR)</div>
     <div class="d-flex flex-column flex-wrap justify-content-end">
       <gf-value
         class="justify-content-end"
@@ -88,6 +71,48 @@
         [value]="
           isLoading ? undefined : summary?.currentGrossPerformancePercent
         "
+      ></gf-value>
+    </div>
+  </div>
+  <div class="row px-3 py-1">
+    <div class="d-flex flex-grow-1" i18n>
+      Fees for {{ summary?.ordersCount }} {summary?.ordersCount, plural, =1
+      {order} other {orders}}
+    </div>
+    <div class="d-flex justify-content-end">
+      <span *ngIf="summary?.fees || summary?.fees === 0" class="mr-1">-</span>
+      <gf-value
+        class="justify-content-end"
+        [currency]="baseCurrency"
+        [locale]="locale"
+        [value]="isLoading ? undefined : summary?.fees"
+      ></gf-value>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col"><hr /></div>
+  </div>
+  <div class="row px-3 py-1">
+    <div class="d-flex flex-grow-1" i18n>Absolute Net Performance</div>
+    <div class="d-flex justify-content-end">
+      <gf-value
+        class="justify-content-end"
+        [currency]="baseCurrency"
+        [locale]="locale"
+        [value]="isLoading ? undefined : summary?.currentNetPerformance"
+      ></gf-value>
+    </div>
+  </div>
+  <div class="row px-3 py-1">
+    <div class="d-flex flex-grow-1 ml-3" i18n>Net Performance (TWR)</div>
+    <div class="d-flex flex-column flex-wrap justify-content-end">
+      <gf-value
+        class="justify-content-end"
+        position="end"
+        [colorizeSign]="true"
+        [isPercent]="true"
+        [locale]="locale"
+        [value]="isLoading ? undefined : summary?.currentNetPerformancePercent"
       ></gf-value>
     </div>
   </div>

--- a/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.component.ts
+++ b/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.component.ts
@@ -34,6 +34,8 @@ export class PositionDetailDialog implements OnDestroy {
   public marketPrice: number;
   public maxPrice: number;
   public minPrice: number;
+  public netPerformance: number;
+  public netPerformancePercent: number;
   public quantity: number;
   public transactionCount: number;
 
@@ -60,6 +62,8 @@ export class PositionDetailDialog implements OnDestroy {
           marketPrice,
           maxPrice,
           minPrice,
+          netPerformance,
+          netPerformancePercent,
           quantity,
           transactionCount
         }) => {
@@ -86,6 +90,8 @@ export class PositionDetailDialog implements OnDestroy {
           this.marketPrice = marketPrice;
           this.maxPrice = maxPrice;
           this.minPrice = minPrice;
+          this.netPerformance = netPerformance;
+          this.netPerformancePercent = netPerformancePercent;
           this.quantity = quantity;
           this.transactionCount = transactionCount;
 

--- a/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.html
+++ b/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.html
@@ -25,7 +25,7 @@
           [colorizeSign]="true"
           [currency]="data.baseCurrency"
           [locale]="data.locale"
-          [value]="grossPerformance"
+          [value]="netPerformance"
         ></gf-value>
       </div>
       <div class="col-6 mb-3">
@@ -35,7 +35,7 @@
           [colorizeSign]="true"
           [isPercent]="true"
           [locale]="data.locale"
-          [value]="grossPerformancePercent"
+          [value]="netPerformancePercent"
         ></gf-value>
       </div>
       <div class="col-6 mb-3">

--- a/apps/client/src/app/components/position/position.component.html
+++ b/apps/client/src/app/components/position/position.component.html
@@ -11,7 +11,7 @@
           [isLoading]="isLoading"
           [marketState]="position?.marketState"
           [range]="range"
-          [value]="position?.grossPerformancePercentage"
+          [value]="position?.netPerformancePercentage"
         ></gf-trend-indicator>
       </div>
       <div *ngIf="isLoading" class="flex-grow-1">
@@ -47,13 +47,13 @@
             [colorizeSign]="true"
             [currency]="baseCurrency"
             [locale]="locale"
-            [value]="position?.grossPerformance"
+            [value]="position?.netPerformance"
           ></gf-value>
           <gf-value
             [colorizeSign]="true"
             [isPercent]="true"
             [locale]="locale"
-            [value]="position?.grossPerformancePercentage"
+            [value]="position?.netPerformancePercentage"
           ></gf-value>
         </div>
       </div>

--- a/apps/client/src/app/components/positions-table/positions-table.component.html
+++ b/apps/client/src/app/components/positions-table/positions-table.component.html
@@ -30,7 +30,7 @@
           [colorizeSign]="true"
           [isPercent]="true"
           [locale]="locale"
-          [value]="isLoading ? undefined : element.grossPerformancePercent"
+          [value]="isLoading ? undefined : element.netPerformancePercent"
         ></gf-value>
       </div>
     </td>

--- a/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
@@ -1,5 +1,7 @@
 export interface PortfolioPerformance {
   currentGrossPerformance: number;
   currentGrossPerformancePercent: number;
+  currentNetPerformance: number;
+  currentNetPerformancePercent: number;
   currentValue: number;
 }

--- a/libs/common/src/lib/interfaces/portfolio-position.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-position.interface.ts
@@ -20,6 +20,8 @@ export interface PortfolioPosition {
   marketPrice: number;
   marketState: MarketState;
   name: string;
+  netPerformance: number;
+  netPerformancePercent: number;
   quantity: number;
   sectors: Sector[];
   transactionCount: number;

--- a/libs/common/src/lib/interfaces/position.interface.ts
+++ b/libs/common/src/lib/interfaces/position.interface.ts
@@ -13,6 +13,8 @@ export interface Position {
   marketPrice?: number;
   marketState?: MarketState;
   name?: string;
+  netPerformance?: number;
+  netPerformancePercentage?: number;
   quantity: number;
   symbol: string;
   transactionCount: number;

--- a/libs/common/src/lib/interfaces/timeline-position.interface.ts
+++ b/libs/common/src/lib/interfaces/timeline-position.interface.ts
@@ -7,6 +7,8 @@ export interface TimelinePosition {
   firstBuyDate: string;
   grossPerformance: Big;
   grossPerformancePercentage: Big;
+  netPerformance: Big;
+  netPerformancePercentage: Big;
   investment: Big;
   marketPrice: number;
   quantity: Big;

--- a/libs/common/src/lib/interfaces/timeline-position.interface.ts
+++ b/libs/common/src/lib/interfaces/timeline-position.interface.ts
@@ -7,10 +7,10 @@ export interface TimelinePosition {
   firstBuyDate: string;
   grossPerformance: Big;
   grossPerformancePercentage: Big;
-  netPerformance: Big;
-  netPerformancePercentage: Big;
   investment: Big;
   marketPrice: number;
+  netPerformance: Big;
+  netPerformancePercentage: Big;
   quantity: Big;
   symbol: string;
   transactionCount: number;


### PR DESCRIPTION
This adds the net performance to the list of current position and implements parts of #324. I think it can be handled as a standalone PR without any additions.

Later on we can do this follow-up tasks in separate PRs:
* add the sell fees to the previous period instead of the current period to improve handling for complete order sales