### PR TITLE
Even out whitespace on the sides of the line chart

### DIFF
--- a/apps/client/src/app/pages/zen/zen-page.html
+++ b/apps/client/src/app/pages/zen/zen-page.html
@@ -26,7 +26,7 @@
           class="chart-container d-flex flex-column col justify-content-center"
         >
           <gf-line-chart
-            class="mr-3"
+            class="mr-3 ml-2"
             symbol="Performance"
             [historicalDataItems]="historicalDataItems"
             [showLoader]="false"


### PR DESCRIPTION
Makes the white space on the left and right "look" the same. Alternatively, it can be `mx-3` or no margin at all (but, then it may look incomplete).