### PR TITLE
Fix tab buttons overlap on iOS `Add to Home screen`

### DIFF
--- a/apps/client/src/app/pages/home/home-page.scss
+++ b/apps/client/src/app/pages/home/home-page.scss
@@ -61,6 +61,7 @@
 
       .mat-tab-header {
         border-top: 0;
+        margin-bottom: 1rem;
 
         .mat-ink-bar {
           visibility: hidden !important;

--- a/apps/client/src/app/pages/zen/zen-page.scss
+++ b/apps/client/src/app/pages/zen/zen-page.scss
@@ -56,6 +56,7 @@
 
       .mat-tab-header {
         border-top: 0;
+        margin-bottom: 1rem;
 
         .mat-ink-bar {
           visibility: hidden !important;


### PR DESCRIPTION
On iOS, using the Add to Homescreen feature, the browser bar at the bottom doesn't show up, so the site takes the full screen. The bottom bar buttons then overlap with the white stripe for minimising the app. This adds a bit of margin to fix the issue :-)