### PR TITLE
build(prisma): fix populating database when attributes have null value

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -159,12 +159,12 @@ async function main() {
       {
         assetClass: 'CASH',
         assetSubClass: 'CRYPTOCURRENCY',
-        countries: null,
+        countries: undefined,
         currency: 'USD',
         dataSource: DataSource.YAHOO,
         id: 'fdc42ea6-1321-44f5-9fb0-d7f1f2cf9b1e',
         name: 'Bitcoin USD',
-        sectors: null,
+        sectors: undefined,
         symbol: 'BTCUSD'
       },
       {


### PR DESCRIPTION
This PR fixes database population.

When trying to populate the database for the first time, prisma complained about some attributes having `null` value.
In this PR we changed these attributes' values from `null` to `undefined` in order to fix this issue.