### PR TITLE
Bugfix/add git when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY ./package.json package.json
 COPY ./yarn.lock yarn.lock
 COPY ./prisma/schema.prisma prisma/schema.prisma
 
-RUN apk add --no-cache python3 g++ make openssl
+RUN apk add --no-cache python3 g++ make openssl git
 RUN yarn install
 
 # See https://github.com/nrwl/nx/issues/6586 for further details


### PR DESCRIPTION
From the docker image build output, it seems that `git` is needed. 

```
Step 20/31 : RUN yarn build:all
 ---> Running in 4d4c61719cf2
yarn run v1.22.19
$ nx run api:build:production && nx run client:build:production && yarn replace-placeholders-in-build
/bin/sh: git: not found
/bin/sh: git: not found

> nx run api:build:production

chunk (runtime: main) main.js (main) 612 KiB (javascript) 937 bytes (runtime) [entry] [rendered]
webpack compiled successfully (9455d51dfb7c2c62)

 

 >  NX   Successfully ran target build for project api


/bin/sh: git: not found
   See Nx Cloud run details at https://nx.app/runs/fSLgNABKYR0

/bin/sh: git: not found

 >  NX   Running target build for project client and 1 task(s) it depends on

 
/bin/sh: git: not found

> nx run client:build:production

- Generating browser application bundles (phase: setup)...
```