### PR TITLE
automate database setup and upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ FROM node:16-alpine
 COPY --from=builder /ghostfolio/dist/apps /ghostfolio/apps
 WORKDIR /ghostfolio/apps/api
 EXPOSE 3333
-CMD [ "node", "main" ]
+CMD [  "yarn", "start:prod" ]

--- a/README.md
+++ b/README.md
@@ -114,14 +114,6 @@ Run the following command to start the Docker images from [Docker Hub](https://h
 docker-compose --env-file ./.env -f docker/docker-compose.yml up -d
 ```
 
-##### Setup Database
-
-Run the following command to setup the database once Ghostfolio is running:
-
-```bash
-docker-compose --env-file ./.env -f docker/docker-compose.yml exec ghostfolio yarn database:setup
-```
-
 #### b. Build and run environment
 
 Run the following commands to build and start the Docker images:
@@ -129,14 +121,6 @@ Run the following commands to build and start the Docker images:
 ```bash
 docker-compose --env-file ./.env -f docker/docker-compose.build.yml build
 docker-compose --env-file ./.env -f docker/docker-compose.build.yml up -d
-```
-
-##### Setup Database
-
-Run the following command to setup the database once Ghostfolio is running:
-
-```bash
-docker-compose --env-file ./.env -f docker/docker-compose.build.yml exec ghostfolio yarn database:setup
 ```
 
 #### Fetch Historical Data
@@ -150,8 +134,8 @@ Open http://localhost:3333 in your browser and accomplish these steps:
 #### Upgrade Version
 
 1. Increase the version of the `ghostfolio/ghostfolio` Docker image in `docker/docker-compose.yml`
-1. Run the following command to start the new Docker image: `docker-compose --env-file ./.env -f docker/docker-compose.yml up -d`
-1. Then, run the following command to keep your database schema in sync: `docker-compose --env-file ./.env -f docker/docker-compose.yml exec ghostfolio yarn database:migrate`
+1. Run the following command to start the new Docker image: `docker-compose --env-file ./.env -f docker/docker-compose.yml up -d`  
+At each start container will automatically upgrade database schema if needed.
 
 ### Run with _Unraid_ (Community)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build:dev": "nx run api:build && nx run client:build && yarn replace-placeholders-in-build",
     "build:storybook": "nx run ui:build-storybook",
     "clean": "rimraf dist",
-    "database:baseline": "sh ./prisma/baseline.sh",
     "database:format-schema": "prisma format",
     "database:generate-typings": "prisma generate",
     "database:gui": "prisma studio",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "replace-placeholders-in-build": "node ./replace.build.js",
     "start": "node dist/apps/api/main",
     "start:client": "ng serve client --configuration=development-en --hmr -o",
-    "start:prod": "node apps/api/main",
+    "start:prod": "yarn database:migrate && yarn database:seed && node main",
     "start:server": "nx serve api --watch",
     "start:storybook": "nx run ui:storybook",
     "test": "nx test",

--- a/prisma/baseline.sh
+++ b/prisma/baseline.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# List all migration scripts based on the directory name and mark the migration as "applied"
-
-for directory in ./prisma/migrations/*/; do 
-	migration=$(echo "$directory" | sed 's/.\/prisma\/migrations\///' | sed 's/\///')
-	yarn prisma migrate resolve --applied $migration
-done


### PR DESCRIPTION
Run database:migrate and database:seed at each startup so database will be automatically setup and upgraded. No command needed, just launch the container.

database:migrate on an empty instance create the schema and apply migration. Baseline is not need because database:migrate automatically baseline.
On next start, if no migration script is found nothing is done, if migration script is found databse:migrate will apply it.

database:seed create the base data (live demo account, platform info,...), if database is empty it create data, if database is already existing seed is apply again but I did see any issue with user data.

Please could you confirm that it safe to apply database:seed on existing database with user data ? I no you can remove it from command line. Database migrate will create schema and upgrade it's the most important.

I hope it will help. My main concern is to not run manual command when deploying docker container, like I use to with other app (database setup and upgrade is automatic).