### PR TITLE
import localize in first story fixes issue

### DIFF
--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -1,3 +1,1 @@
-import '@angular/localize/init';
-
 import '!style-loader!css-loader!sass-loader!../../../apps/client/src/styles.scss';

--- a/libs/ui/src/lib/fire-calculator/fire-calculator.component.stories.ts
+++ b/libs/ui/src/lib/fire-calculator/fire-calculator.component.stories.ts
@@ -1,3 +1,4 @@
+import '@angular/localize/init';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';


### PR DESCRIPTION
Closes #1323 

The `preview.js` is not working as expected here for Storybook and is not including the import globally. When attempting to utilize other Storybook versions that are compatible with this version of Angular I was still unsuccessful at getting the `preview.js` to work as Storybook intends it. 

However, importing within a single story makes the localize package available to all stories and allows Storybook to run without error.