### PR TITLE
Add test case

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,11 @@
       "name": "Debug Jest File",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/@angular/cli/bin/ng",
+      "program": "${workspaceFolder}/node_modules/@nrwl/cli/bin/nx",
       "args": [
         "test",
         "--codeCoverage=false",
-        "--testFile=${workspaceFolder}/apps/api/src/models/portfolio.spec.ts"
+        "--testFile=${workspaceFolder}/apps/api/src/app/portfolio/portfolio-calculator-novn-buy-and-sell.spec.ts"
       ],
       "cwd": "${workspaceFolder}",
       "console": "internalConsole"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restructured the actions in the admin control panel
 
+### Fixed
+
+- Fixed the calculation in the portfolio evolution chart
+
 ## 1.207.0 - 31.10.2022
 
 ### Added

--- a/apps/api/src/app/portfolio/portfolio-calculator-novn-buy-and-sell.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator-novn-buy-and-sell.spec.ts
@@ -1,0 +1,130 @@
+import { CurrentRateService } from '@ghostfolio/api/app/portfolio/current-rate.service';
+import { parseDate } from '@ghostfolio/common/helper';
+import Big from 'big.js';
+
+import { CurrentRateServiceMock } from './current-rate.service.mock';
+import { PortfolioCalculator } from './portfolio-calculator';
+
+jest.mock('@ghostfolio/api/app/portfolio/current-rate.service', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    CurrentRateService: jest.fn().mockImplementation(() => {
+      return CurrentRateServiceMock;
+    })
+  };
+});
+
+describe('PortfolioCalculator', () => {
+  let currentRateService: CurrentRateService;
+
+  beforeEach(() => {
+    currentRateService = new CurrentRateService(null, null, null);
+  });
+
+  describe('get current positions', () => {
+    it.only('with NOVN.SW buy and sell', async () => {
+      const portfolioCalculator = new PortfolioCalculator({
+        currentRateService,
+        currency: 'CHF',
+        orders: [
+          {
+            currency: 'CHF',
+            date: '2022-03-07',
+            dataSource: 'YAHOO',
+            fee: new Big(0),
+            name: 'Novartis AG',
+            quantity: new Big(2),
+            symbol: 'NOVN.SW',
+            type: 'BUY',
+            unitPrice: new Big(75.8)
+          },
+          {
+            currency: 'CHF',
+            date: '2022-04-08',
+            dataSource: 'YAHOO',
+            fee: new Big(0),
+            name: 'Novartis AG',
+            quantity: new Big(2),
+            symbol: 'NOVN.SW',
+            type: 'SELL',
+            unitPrice: new Big(85.73)
+          }
+        ]
+      });
+
+      portfolioCalculator.computeTransactionPoints();
+
+      const spy = jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => parseDate('2022-04-11').getTime());
+
+      const chartData = await portfolioCalculator.getChartData(
+        parseDate('2022-03-07')
+      );
+
+      const currentPositions = await portfolioCalculator.getCurrentPositions(
+        parseDate('2022-03-07')
+      );
+
+      const investments = portfolioCalculator.getInvestments();
+
+      const investmentsByMonth = portfolioCalculator.getInvestmentsByMonth();
+
+      spy.mockRestore();
+
+      expect(chartData[0]).toEqual({
+        date: '2022-03-07',
+        netPerformanceInPercentage: 0,
+        netPerformance: 0,
+        totalInvestment: 151.6,
+        value: 151.6
+      });
+
+      expect(chartData[chartData.length - 1]).toEqual({
+        date: '2022-04-11',
+        netPerformanceInPercentage: 13.100263852242744,
+        netPerformance: 19.86,
+        totalInvestment: 0,
+        value: 19.86
+      });
+
+      expect(currentPositions).toEqual({
+        currentValue: new Big('0'),
+        errors: [],
+        grossPerformance: new Big('19.86'),
+        grossPerformancePercentage: new Big('0.13100263852242744063'),
+        hasErrors: false,
+        netPerformance: new Big('15.61'),
+        netPerformancePercentage: new Big('0.1029683377308707124'),
+        positions: [
+          {
+            averagePrice: new Big('0'),
+            currency: 'CHF',
+            dataSource: 'YAHOO',
+            firstBuyDate: '2022-03-07',
+            grossPerformance: new Big('19.86'),
+            grossPerformancePercentage: new Big('0.13100263852242744063'),
+            investment: new Big('0'),
+            netPerformance: new Big('15.61'),
+            netPerformancePercentage: new Big('0.1029683377308707124'),
+            marketPrice: 87.8,
+            quantity: new Big('0'),
+            symbol: 'NOVN.SW',
+            transactionCount: 2
+          }
+        ],
+        totalInvestment: new Big('0')
+      });
+
+      expect(investments).toEqual([
+        { date: '2022-03-07', investment: new Big('151.6') },
+        { date: '2022-04-08', investment: new Big('0') }
+      ]);
+
+      expect(investmentsByMonth).toEqual([
+        { date: '2022-03-01', investment: new Big('151.6') },
+        { date: '2022-04-01', investment: new Big('-171.46') }
+      ]);
+    });
+  });
+});

--- a/apps/api/src/app/portfolio/portfolio-calculator-novn-buy-and-sell.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator-novn-buy-and-sell.spec.ts
@@ -94,8 +94,8 @@ describe('PortfolioCalculator', () => {
         grossPerformance: new Big('19.86'),
         grossPerformancePercentage: new Big('0.13100263852242744063'),
         hasErrors: false,
-        netPerformance: new Big('15.61'),
-        netPerformancePercentage: new Big('0.1029683377308707124'),
+        netPerformance: new Big('19.86'),
+        netPerformancePercentage: new Big('0.13100263852242744063'),
         positions: [
           {
             averagePrice: new Big('0'),
@@ -105,8 +105,8 @@ describe('PortfolioCalculator', () => {
             grossPerformance: new Big('19.86'),
             grossPerformancePercentage: new Big('0.13100263852242744063'),
             investment: new Big('0'),
-            netPerformance: new Big('15.61'),
-            netPerformancePercentage: new Big('0.1029683377308707124'),
+            netPerformance: new Big('19.86'),
+            netPerformancePercentage: new Big('0.13100263852242744063'),
             marketPrice: 87.8,
             quantity: new Big('0'),
             symbol: 'NOVN.SW',

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -1273,6 +1273,7 @@ export class PortfolioCalculator {
         Average price: ${averagePriceAtStartDate.toFixed(
           2
         )} -> ${averagePriceAtEndDate.toFixed(2)}
+        Total investment: ${totalInvestment.toFixed(2)}
         Max. total investment: ${maxTotalInvestment.toFixed(2)}
         Gross performance: ${totalGrossPerformance.toFixed(
           2
@@ -1280,9 +1281,7 @@ export class PortfolioCalculator {
         Fees per unit: ${feesPerUnit.toFixed(2)}
         Net performance: ${totalNetPerformance.toFixed(
           2
-        )} / ${netPerformancePercentage.mul(100).toFixed(2)}%
-        Investment at end date: ${totalInvestment}
-        `
+        )} / ${netPerformancePercentage.mul(100).toFixed(2)}%`
       );
     }
 

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -40,7 +40,7 @@ export class PortfolioCalculator {
   private static readonly CALCULATE_PERCENTAGE_PERFORMANCE_WITH_MAX_INVESTMENT =
     true;
 
-  private static readonly ENABLE_LOGGING = false;
+  private static readonly ENABLE_LOGGING = true;
 
   private currency: string;
   private currentRateService: CurrentRateService;
@@ -287,7 +287,9 @@ export class PortfolioCalculator {
         date,
         netPerformanceInPercentage,
         netPerformance: totalNetPerformanceValues[date].toNumber(),
+        // TODO
         totalInvestment: totalInvestmentValues[date].toNumber(),
+        // TODO
         value: totalInvestmentValues[date]
           .plus(totalNetPerformanceValues[date])
           .toNumber()
@@ -1262,7 +1264,9 @@ export class PortfolioCalculator {
         Fees per unit: ${feesPerUnit.toFixed(2)}
         Net performance: ${totalNetPerformance.toFixed(
           2
-        )} / ${netPerformancePercentage.mul(100).toFixed(2)}%`
+        )} / ${netPerformancePercentage.mul(100).toFixed(2)}%
+        Investment at end date: ${totalInvestment}
+        `
       );
     }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "start:server": "nx run api:serve --watch",
     "start:storybook": "nx run ui:storybook",
     "test": "nx test",
-    "test:single": "nx test --test-file portfolio-calculator-novn-buy-and-sell-partially.spec.ts",
+    "test:single": "nx test --test-file portfolio-calculator-novn-buy-and-sell.spec.ts",
     "ts-node": "ts-node",
     "update": "nx migrate latest",
     "watch:server": "nx run api:build --watch",

--- a/test/import/ok-novn-buy-and-sell.json
+++ b/test/import/ok-novn-buy-and-sell.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "date": "2022-07-21T21:28:05.857Z",
+    "version": "dev"
+  },
+  "activities": [
+    {
+      "fee": 0,
+      "quantity": 2,
+      "type": "SELL",
+      "unitPrice": 85.73,
+      "currency": "CHF",
+      "dataSource": "YAHOO",
+      "date": "2022-04-07T22:00:00.000Z",
+      "symbol": "NOVN.SW"
+    },
+    {
+      "fee": 0,
+      "quantity": 2,
+      "type": "BUY",
+      "unitPrice": 75.8,
+      "currency": "CHF",
+      "dataSource": "YAHOO",
+      "date": "2022-03-06T23:00:00.000Z",
+      "symbol": "NOVN.SW"
+    }
+  ]
+}


### PR DESCRIPTION
Current implementation: `maxTotalInvestment` (https://github.com/ghostfolio/ghostfolio/blob/main/apps/api/src/app/portfolio/portfolio-calculator.ts#L1171)
<img width="594" alt="analysis-current" src="https://user-images.githubusercontent.com/4159106/197854105-529d574e-4eab-42db-adfe-ecdb8675cb1d.png">

Alternative implementation: `totalInvestment` (https://github.com/ghostfolio/ghostfolio/blob/main/apps/api/src/app/portfolio/portfolio-calculator.ts#L1171)
<img width="594" alt="analysis-total-investment" src="https://user-images.githubusercontent.com/4159106/199578129-9dd336b2-2e48-481d-874c-37253385d13a.png">