### PR TITLE
New endpoint for Dividends aggregated per month

### DIFF
--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -210,18 +210,21 @@ export class PortfolioService {
   public async getInvestments({
     dateRange,
     impersonationId,
-    groupBy
+    groupBy,
+    orderTypes = ['BUY', 'SELL']
   }: {
     dateRange: DateRange;
     impersonationId: string;
     groupBy?: GroupBy;
+    orderTypes?: TypeOfOrder[]
   }): Promise<InvestmentItem[]> {
     const userId = await this.getUserId(impersonationId, this.request.user.id);
 
     const { portfolioOrders, transactionPoints } =
       await this.getTransactionPoints({
         userId,
-        includeDrafts: true
+        includeDrafts: true,
+        orderTypes: orderTypes
       });
 
     const portfolioCalculator = new PortfolioCalculator({
@@ -1370,12 +1373,14 @@ export class PortfolioService {
     filters,
     includeDrafts = false,
     userId,
-    withExcludedAccounts
+    withExcludedAccounts,
+    orderTypes = ['BUY', 'SELL']
   }: {
     filters?: Filter[];
     includeDrafts?: boolean;
     userId: string;
     withExcludedAccounts?: boolean;
+    orderTypes?: TypeOfOrder[]
   }): Promise<{
     transactionPoints: TransactionPoint[];
     orders: OrderWithAccount[];
@@ -1390,7 +1395,7 @@ export class PortfolioService {
       userCurrency,
       userId,
       withExcludedAccounts,
-      types: ['BUY', 'SELL']
+      types: orderTypes
     });
 
     if (orders.length <= 0) {

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -34,6 +34,7 @@ export class AnalysisPageComponent implements OnDestroy, OnInit {
   public hasImpersonationId: boolean;
   public investments: InvestmentItem[];
   public investmentsByMonth: InvestmentItem[];
+  public dividendsByMonth: InvestmentItem[];
   public isLoadingBenchmarkComparator: boolean;
   public isLoadingInvestmentChart: boolean;
   public mode: GroupBy = 'month';
@@ -165,7 +166,7 @@ export class AnalysisPageComponent implements OnDestroy, OnInit {
         this.changeDetectorRef.markForCheck();
       });
 
-    this.dataService
+      this.dataService
       .fetchInvestments({
         groupBy: 'month',
         range: this.user?.settings?.dateRange
@@ -177,7 +178,7 @@ export class AnalysisPageComponent implements OnDestroy, OnInit {
         this.changeDetectorRef.markForCheck();
       });
 
-    this.dataService
+      this.dataService
       .fetchPositions({ range: this.user?.settings?.dateRange })
       .pipe(takeUntil(this.unsubscribeSubject))
       .subscribe(({ positions }) => {
@@ -193,6 +194,18 @@ export class AnalysisPageComponent implements OnDestroy, OnInit {
         } else {
           this.bottom3 = [];
         }
+
+        this.changeDetectorRef.markForCheck();
+      });
+
+      this.dataService
+      .fetchDividends({
+        groupBy: 'month',
+        range: this.user?.settings?.dateRange
+      })
+      .pipe(takeUntil(this.unsubscribeSubject))
+      .subscribe(({ dividends }) => {
+        this.dividendsByMonth = dividends;
 
         this.changeDetectorRef.markForCheck();
       });

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.html
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.html
@@ -168,4 +168,40 @@
       </div>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-lg">
+      <div class="align-items-center d-flex mb-4">
+        <div
+          class="align-items-center d-flex flex-grow-1 h5 mb-0 text-truncate"
+        >
+          <span i18n>Dividends Timeline</span>
+          <gf-premium-indicator
+            *ngIf="user?.subscription?.type === 'Basic'"
+            class="ml-1"
+          ></gf-premium-indicator>
+        </div>
+        <gf-toggle
+          class="d-none d-lg-block"
+          [defaultValue]="mode"
+          [isLoading]="false"
+          [options]="modeOptions"
+          (change)="onChangeGroupBy($event.value)"
+        ></gf-toggle>
+      </div>
+      <div class="chart-container">
+        <gf-investment-chart
+          class="h-100"
+          groupBy="month"
+          [benchmarkDataItems]="dividendsByMonth"
+          [currency]="user?.settings?.baseCurrency"
+          [daysInMarket]="daysInMarket"
+          [isInPercent]="hasImpersonationId || user.settings.isRestrictedView"
+          [locale]="user?.settings?.locale"
+          [range]="user?.settings?.dateRange"
+          [savingsRate]="(hasImpersonationId || user.settings.isRestrictedView) ? undefined : user?.settings?.savingsRate"
+        ></gf-investment-chart>
+      </div>
+    </div>
+  </div>
 </div>

--- a/apps/client/src/app/services/data.service.ts
+++ b/apps/client/src/app/services/data.service.ts
@@ -26,6 +26,7 @@ import {
   InfoItem,
   OAuthResponse,
   PortfolioDetails,
+  PortfolioDividends,
   PortfolioInvestments,
   PortfolioPerformanceResponse,
   PortfolioPublicDetails,
@@ -178,6 +179,19 @@ export class DataService {
   }) {
     return this.http.get<PortfolioInvestments>(
       '/api/v1/portfolio/investments',
+      { params: { groupBy, range } }
+    );
+  }
+
+  public fetchDividends({
+    groupBy,
+    range
+  }: {
+    groupBy?: 'month';
+    range: DateRange;
+  }) {
+    return this.http.get<PortfolioDividends>(
+      '/api/v1/portfolio/dividends',
       { params: { groupBy, range } }
     );
   }

--- a/libs/common/src/lib/interfaces/index.ts
+++ b/libs/common/src/lib/interfaces/index.ts
@@ -19,6 +19,7 @@ import { InfoItem } from './info-item.interface';
 import { LineChartItem } from './line-chart-item.interface';
 import { PortfolioChart } from './portfolio-chart.interface';
 import { PortfolioDetails } from './portfolio-details.interface';
+import { PortfolioDividends } from './portfolio-dividends.interface';
 import { PortfolioInvestments } from './portfolio-investments.interface';
 import { PortfolioItem } from './portfolio-item.interface';
 import { PortfolioOverview } from './portfolio-overview.interface';
@@ -63,6 +64,7 @@ export {
   PortfolioChart,
   PortfolioDetails,
   PortfolioInvestments,
+  PortfolioDividends,
   PortfolioItem,
   PortfolioOverview,
   PortfolioPerformance,

--- a/libs/common/src/lib/interfaces/portfolio-dividends.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-dividends.interface.ts
@@ -1,0 +1,5 @@
+import { InvestmentItem } from './investment-item.interface';
+
+export interface PortfolioDividends {
+  dividends: InvestmentItem[];
+}


### PR DESCRIPTION
Here's the first draft of the new `/dividends` endpoint powering the _"Dividend Timeline"_ graph under the _"Analysis"_ page. 
I've tried to leverage as much as possible on the existing logic powering the _"Investment Timeline"_ graph of that same page, but please let me know if you'd prefer to have those logics and concerns separated.

I'm still owing (1) some tests and (2) reviewing the `.controller` code, which could be extracted into a private method since it's basically the same logic as the `/investment` endpoint.