### PR TITLE
Fix sorting by performance field in positions table

### DIFF
--- a/apps/client/src/app/components/positions-table/positions-table.component.html
+++ b/apps/client/src/app/components/positions-table/positions-table.component.html
@@ -1,9 +1,9 @@
 <table
   class="gf-table w-100"
+  mat-table
   matSort
   matSortActive="allocationCurrent"
   matSortDirection="desc"
-  mat-table
   [dataSource]="dataSource"
 >
   <ng-container matColumnDef="icon">
@@ -51,7 +51,7 @@
     >
       <ng-container i18n>Value</ng-container>
     </th>
-    <td class="d-none d-lg-table-cell px-1" mat-cell *matCellDef="let element">
+    <td *matCellDef="let element" class="d-none d-lg-table-cell px-1" mat-cell>
       <div class="d-flex justify-content-end">
         <gf-value
           [isCurrency]="true"
@@ -87,6 +87,7 @@
       *matHeaderCellDef
       class="d-none d-lg-table-cell px-1 text-right"
       mat-header-cell
+      mat-sort-header="netPerformancePercent"
     >
       <ng-container i18n>Performance</ng-container>
     </th>


### PR DESCRIPTION
Fixes https://github.com/ghostfolio/ghostfolio/issues/1419
- Added `mat-sort-header` directive with the key of the data object instead of the column name
- Also fixed couple of linting issues

UI Preview:
https://user-images.githubusercontent.com/39493102/205328656-de902ff3-f060-4352-98ab-68150e007e8c.mov

