### PR TITLE
Update postgres to version 15 in docker-compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Harmonized the logger output: <symbol> (<dataSource>)
 - Improved the language localization for Dutch (`nl`)
+- Ugraded _Postgres_ from version `12` to `15` in the `docker-compose` files
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Harmonized the logger output: <symbol> (<dataSource>)
 - Improved the language localization for Dutch (`nl`)
-- Ugraded _Postgres_ from version `12` to `15` in the `docker-compose` files
+- Upgraded _Postgres_ from version `12` to `15` in the `docker-compose` files
 
 ### Fixed
 

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -17,7 +17,7 @@ services:
       redis:
         condition: service_healthy
   postgres:
-    image: postgres:12
+    image: postgres:15
     env_file:
       - ../.env
     healthcheck:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   postgres:
-    image: postgres:12
+    image: postgres:15
     container_name: postgres
     restart: unless-stopped
     env_file:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       redis:
         condition: service_healthy
   postgres:
-    image: postgres:12
+    image: postgres:15
     env_file:
       - ../.env
     healthcheck:


### PR DESCRIPTION
While doing my node update, I noticed that the postgres versions in docker-compose are behind. I tested ghostfolio with postgres 15 on my server and thought I provide a PR for this aswell. If it breaks your development environment or you think it's too risky for potential incompability - just ignore it ;)