### PR TITLE
fixed blank index page when self-hosting or developing (Issue #1680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `chart.js` from version `4.0.1` to `4.2.0`
 - Upgraded `prettier` from version `2.8.1` to `2.8.4`
 
+### Fixed
+
+- Fixed the Index page when self-hosting or developing for Ghostfolio
+
 ## 1.233.0 - 2023-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the Index page when self-hosting or developing for Ghostfolio
+- Fixed an issue on the landing page caused by the global heat map of subscribers
 
 ## 1.233.0 - 2023-02-09
 

--- a/apps/client/src/app/pages/landing/landing-page.component.ts
+++ b/apps/client/src/app/pages/landing/landing-page.component.ts
@@ -55,10 +55,12 @@ export class LandingPageComponent implements OnDestroy, OnInit {
     const { countriesOfSubscribers, globalPermissions, statistics } =
       this.dataService.fetchInfo();
 
-    for (const country of countriesOfSubscribers) {
-      this.countriesOfSubscribersMap[country] = {
-        value: 1
-      };
+    if (countriesOfSubscribers) {
+      for (const country of countriesOfSubscribers) {
+        this.countriesOfSubscribersMap[country] = {
+          value: 1
+        };
+      }
     }
 
     this.hasPermissionForStatistics = hasPermission(

--- a/apps/client/src/app/pages/landing/landing-page.component.ts
+++ b/apps/client/src/app/pages/landing/landing-page.component.ts
@@ -52,15 +52,16 @@ export class LandingPageComponent implements OnDestroy, OnInit {
     private dataService: DataService,
     private deviceService: DeviceDetectorService
   ) {
-    const { countriesOfSubscribers, globalPermissions, statistics } =
-      this.dataService.fetchInfo();
+    const {
+      countriesOfSubscribers = [],
+      globalPermissions,
+      statistics
+    } = this.dataService.fetchInfo();
 
-    if (countriesOfSubscribers) {
-      for (const country of countriesOfSubscribers) {
-        this.countriesOfSubscribersMap[country] = {
-          value: 1
-        };
-      }
+    for (const country of countriesOfSubscribers) {
+      this.countriesOfSubscribersMap[country] = {
+        value: 1
+      };
     }
 
     this.hasPermissionForStatistics = hasPermission(


### PR DESCRIPTION
I started checking out the source code more today and walked into the same problem as Issue #1680. It turns out this has been around since the introduction of the heat-map! The landing page assumes that the `countriesOfSubscribers` is always not undefined, so it error-ed out when loading the index page. Looking at the info.service.ts file, we can see that the default value is defined for `countriesOfSubscribers`, but only when the feature is enabled.

This pull request simply wraps the heat-map data entry with an if statement to see if the `countriesOfSubscribers` is defined before adding the data.