### PR TITLE
Add support for armv7 processors

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.output.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.output.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added the configuration to publish a `linux/arm/v7` docker image
+
 ## 1.237.0 - 2023-02-19
 
 ### Added
@@ -757,7 +763,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the alias to the `Access` database schema
 - Added support for translated time distances
-- Added a _GitHub Action_ to create an `arm64` docker image
+- Added a _GitHub Action_ to create an `linux/arm64` docker image
 
 ### Changed
 


### PR DESCRIPTION
Hello,

#1134 was a very nice addition towards home computer like raspberry PI.
Unfortunately the contribution is targeting users of latest [raspbian 64 bit](https://www.raspberrypi.com/news/raspberry-pi-os-64-bit/) whereas the [32bit version is still the recommended version](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit).

This pull request want to bring the support of armv7 (32bit) built image:
- Current QEMU setup can support [all platforms](https://github.com/ghostfolio/ghostfolio/actions/runs/4217583783/jobs/7321469369#step:4:4)
- QEMU step uses the [binfmt image](https://github.com/tonistiigi/binfmt) that supports [the armv7 platform](https://github.com/tonistiigi/binfmt/blob/master/README.md?plain=1#L35)
- node:18-slim [supports armv7](https://github.com/nodejs/docker-node/blob/e75fa5270326ffaff8fee03153f3bf16860084d4/18/bullseye-slim/Dockerfile#L14)

Regards




