### PR TITLE
Improved holdings table showing cash position also when the filter contains accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the alignment of the performance column header in the holdings table
 - Removed the unnecessary sort header of the comment column in the activities table
 - Fixed the targets in `proxy.conf.json` from `http://localhost:3333` to `http://0.0.0.0:3333` for local development
+- Improved the holdings table by showing the cash position also when the filter contains the accounts, so that we can see the total allocation for that account
 
 ## 1.258.0 - 2023-04-20
 

--- a/apps/api/src/app/order/order.controller.ts
+++ b/apps/api/src/app/order/order.controller.ts
@@ -5,7 +5,7 @@ import { ApiService } from '@ghostfolio/api/services/api/api.service';
 import { ImpersonationService } from '@ghostfolio/api/services/impersonation/impersonation.service';
 import { HEADER_KEY_IMPERSONATION } from '@ghostfolio/common/config';
 import { hasPermission, permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
+import { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Body,
   Controller,
@@ -76,6 +76,23 @@ export class OrderController {
 
     return this.orderService.deleteOrder({
       id
+    });
+  }
+
+  @Delete()
+  @UseGuards(AuthGuard('jwt'))
+  public async deleteOrders(): Promise<number> {
+    if (
+      !hasPermission(this.request.user.permissions, permissions.deleteOrder)
+    ) {
+      throw new HttpException(
+        getReasonPhrase(StatusCodes.FORBIDDEN),
+        StatusCodes.FORBIDDEN
+      );
+    }
+
+    return this.orderService.deleteOrders({
+      userId: this.request.user.id
     });
   }
 

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -462,16 +462,16 @@ export class PortfolioService {
     });
 
     const holdings: PortfolioDetails['holdings'] = {};
-    const totalInvestmentInBaseCurrency = currentPositions.currentValue.plus(
+    const totalValueInBaseCurrency = currentPositions.currentValue.plus(
       cashDetails.balanceInBaseCurrency
     );
 
-    const isFilteredByAccount = filters.some(
-      (filter) => filter.type === 'ACCOUNT'
-    );
+    const isFilteredByAccount = filters.some((filter) => {
+      return filter.type === 'ACCOUNT';
+    });
 
     let filteredValueInBaseCurrency = isFilteredByAccount
-      ? totalInvestmentInBaseCurrency
+      ? totalValueInBaseCurrency
       : currentPositions.currentValue;
 
     if (
@@ -571,9 +571,9 @@ export class PortfolioService {
       };
     }
 
-    const isFilteredByCash = filters.some(
-      (filter) => filter.type === 'ASSET_CLASS' && filter.id === 'CASH'
-    );
+    const isFilteredByCash = filters.some((filter) => {
+      return filter.type === 'ASSET_CLASS' && filter.id === 'CASH';
+    });
 
     if (filters.length === 0 || isFilteredByCash || isFilteredByAccount) {
       const cashPositions = await this.getCashPositions({

--- a/apps/client/src/app/services/data.service.ts
+++ b/apps/client/src/app/services/data.service.ts
@@ -154,6 +154,10 @@ export class DataService {
     return this.http.delete<any>(`/api/v1/order/${aId}`);
   }
 
+  public deleteAllOrders() {
+    return this.http.delete<any>(`/api/v1/order/`);
+  }
+
   public deleteUser(aId: string) {
     return this.http.delete<any>(`/api/v1/user/${aId}`);
   }

--- a/libs/ui/src/lib/activities-table/activities-table.component.html
+++ b/libs/ui/src/lib/activities-table/activities-table.component.html
@@ -59,7 +59,7 @@
       (click)="onDeleteAllActivities()"
     >
       <ion-icon class="mr-2" name="trash-outline"></ion-icon>
-      <span i18n>Delete all Activities</span>
+      <span i18n>Delete all activities</span>
     </button>
   </mat-menu>
 </div>

--- a/libs/ui/src/lib/activities-table/activities-table.component.ts
+++ b/libs/ui/src/lib/activities-table/activities-table.component.ts
@@ -53,6 +53,7 @@ export class ActivitiesTableComponent implements OnChanges, OnDestroy, OnInit {
   @Output() export = new EventEmitter<string[]>();
   @Output() exportDrafts = new EventEmitter<string[]>();
   @Output() import = new EventEmitter<void>();
+  @Output() deleteAllActivities = new EventEmitter<void>();
   @Output() importDividends = new EventEmitter<UniqueAsset>();
   @Output() selectedActivities = new EventEmitter<Activity[]>();
 


### PR DESCRIPTION
We have 2 accounts, Account A (Mine) has 2 stocks, Account B (Familly) 1 stock:
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/2421483/233481724-481ff1fb-3093-4135-96e1-bf3625328940.png">

Then if I filter by Account A, I want to see my cash position and how much is allocated on that account:
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/2421483/233481948-e4c9dc10-9361-4da4-8386-1d58b7b2db6e.png">

The same for Account B:
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/2421483/233482166-135dc7dc-6c76-43ae-b026-6a8ba85fae40.png">

And if we select both, should give is the same initial result when we had no filters, since we only have 2 accounts:
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/2421483/233482390-3688eee2-d43b-49ac-932d-82f0a67868d4.png">


