### PR TITLE
Improve style on about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the breadcrumb navigation style in the blog post pages for mobile
+- Improved the style of the _Changelog & License_ button on the about page
 
 ## 1.271.0 - 2023-05-20
 

--- a/apps/client/src/app/pages/about/about-page.html
+++ b/apps/client/src/app/pages/about/about-page.html
@@ -221,7 +221,7 @@
     </div>
     <div
       class="col-md-3 col-xs-12 my-2"
-      [ngClass]="{ 'offset-md-4': !hasPermissionForBlog }"
+      [ngClass]="{ 'mx-auto': !hasPermissionForBlog }"
     >
       <a
         class="py-4 w-100"


### PR DESCRIPTION
Hello, I just recently started self-hosting and checking out Ghostfolio and it is a cool project! One thing I noticed on the About page is that the Changelog & License button is not centered. I decided to put in a PR to fix this. Thanks :D

BEFORE:
![image](https://github.com/ghostfolio/ghostfolio/assets/85003930/b5b7531a-f65c-487f-948f-f3315f9eadc3)

AFTER:
![image](https://github.com/ghostfolio/ghostfolio/assets/85003930/9f827d1c-ed23-4ee1-bed5-e718120c8375)
