### PR TITLE
Feature/Hide null average unit price in the detailed activity dialog

### DIFF
--- a/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.component.ts
+++ b/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.component.ts
@@ -113,17 +113,13 @@ export class PositionDetailDialog implements OnDestroy, OnInit {
           this.grossPerformancePercent = grossPerformancePercent;
           this.historicalDataItems = historicalData.map(
             (historicalDataItem) => {
-              if (historicalDataItem.averagePrice) {
-                this.benchmarkDataItems.push({
-                  date: historicalDataItem.date,
-                  value: historicalDataItem.averagePrice
-                });
-              } else {
-                this.benchmarkDataItems.push({
-                  date: historicalDataItem.date,
-                  value: null
-                });
-              }
+              this.benchmarkDataItems.push({
+                date: historicalDataItem.date,
+                value:
+                  historicalDataItem.averagePrice > 0
+                    ? historicalDataItem.averagePrice
+                    : null
+              });
 
               return {
                 date: historicalDataItem.date,

--- a/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.component.ts
+++ b/apps/client/src/app/components/position/position-detail-dialog/position-detail-dialog.component.ts
@@ -113,10 +113,17 @@ export class PositionDetailDialog implements OnDestroy, OnInit {
           this.grossPerformancePercent = grossPerformancePercent;
           this.historicalDataItems = historicalData.map(
             (historicalDataItem) => {
-              this.benchmarkDataItems.push({
-                date: historicalDataItem.date,
-                value: historicalDataItem.averagePrice
-              });
+              if (historicalDataItem.averagePrice) {
+                this.benchmarkDataItems.push({
+                  date: historicalDataItem.date,
+                  value: historicalDataItem.averagePrice
+                });
+              } else {
+                this.benchmarkDataItems.push({
+                  date: historicalDataItem.date,
+                  value: null
+                });
+              }
 
               return {
                 date: historicalDataItem.date,

--- a/libs/ui/src/lib/line-chart/line-chart.component.ts
+++ b/libs/ui/src/lib/line-chart/line-chart.component.ts
@@ -168,7 +168,10 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     this.historicalDataItems?.forEach((historicalDataItem, index) => {
       data.datasets[0].data.push(this.benchmarkDataItems?.[index]?.value);
-      if (this.benchmarkDataItems?.[index]?.value === null) {
+      if (
+        this.benchmarkDataItems?.[index]?.value === null &&
+        data.datasets[0].data.some((value) => value !== null)
+      ) {
         data.datasets.unshift({
           borderColor: `rgb(${secondaryColorRgb.r}, ${secondaryColorRgb.g}, ${secondaryColorRgb.b})`,
           borderWidth: 1,

--- a/libs/ui/src/lib/line-chart/line-chart.component.ts
+++ b/libs/ui/src/lib/line-chart/line-chart.component.ts
@@ -118,12 +118,10 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   private initialize() {
     this.isLoading = true;
-    const benchmarkPrices = [];
     const labels: string[] = [];
     const marketPrices = [];
 
-    this.historicalDataItems?.forEach((historicalDataItem, index) => {
-      benchmarkPrices.push(this.benchmarkDataItems?.[index]?.value);
+    this.historicalDataItems?.forEach((historicalDataItem) => {
       labels.push(historicalDataItem.date);
       marketPrices.push(historicalDataItem.value);
     });
@@ -151,7 +149,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
         {
           borderColor: `rgb(${secondaryColorRgb.r}, ${secondaryColorRgb.g}, ${secondaryColorRgb.b})`,
           borderWidth: 1,
-          data: benchmarkPrices,
+          data: [],
           fill: false,
           label: this.benchmarkLabel,
           pointRadius: 0
@@ -167,6 +165,20 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
         }
       ]
     };
+
+    this.historicalDataItems?.forEach((historicalDataItem, index) => {
+      data.datasets[0].data.push(this.benchmarkDataItems?.[index]?.value);
+      if (this.benchmarkDataItems?.[index]?.value === null) {
+        data.datasets.unshift({
+          borderColor: `rgb(${secondaryColorRgb.r}, ${secondaryColorRgb.g}, ${secondaryColorRgb.b})`,
+          borderWidth: 1,
+          data: Array(data.datasets[0].data.length).fill(null),
+          fill: false,
+          label: this.benchmarkLabel,
+          pointRadius: 0
+        });
+      }
+    });
 
     if (this.chartCanvas) {
       if (this.chart) {


### PR DESCRIPTION
If I sell out a position then buy it again, the chart in the detailed activity dialog shows a null average unit price, the line goes to zero. It makes the chart less readable. It would make more sens that the line is interrupted when the position was closed.

Now:
![Screenshot 2023-07-05 at 19-48-44 ${title}](https://github.com/ghostfolio/ghostfolio/assets/47859535/2590a2a3-203f-4f72-b542-7fc9dd2c4a9b)

With this PR:
![Screenshot 2023-07-05 at 19-48-56 ${title}](https://github.com/ghostfolio/ghostfolio/assets/47859535/29fad734-1062-4233-86a0-293f49c085a4)


