### PR TITLE
Feature/Better login dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the usability of the login dialog
 - Disabled the caching in the health check endpoints for data providers
 - Improved the content of the Frequently Asked Questions (FAQ) page
 - Upgraded `prisma` from version `4.15.0` to `4.16.2`

--- a/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.component.ts
+++ b/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.component.ts
@@ -16,7 +16,7 @@ import { TokenStorageService } from '@ghostfolio/client/services/token-storage.s
   templateUrl: 'login-with-access-token-dialog.html'
 })
 export class LoginWithAccessTokenDialog {
-  public hide = true;
+  public isAccessTokenHidden = true;
 
   public constructor(
     @Inject(MAT_DIALOG_DATA) public data: any,
@@ -40,6 +40,12 @@ export class LoginWithAccessTokenDialog {
     this.dialogRef.close();
   }
 
+  public onLoginWithAccessToken() {
+    if (this.data.accessToken) {
+      this.dialogRef.close(this.data);
+    }
+  }
+
   public async onLoginWithInternetIdentity() {
     try {
       const { authToken } = await this.internetIdentityService.login();
@@ -48,11 +54,5 @@ export class LoginWithAccessTokenDialog {
       this.dialogRef.close();
       this.router.navigate(['/']);
     } catch {}
-  }
-
-  public onSubmit() {
-    if (this.data.accessToken) {
-      this.dialogRef.close(this.data);
-    }
   }
 }

--- a/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.component.ts
+++ b/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.component.ts
@@ -16,6 +16,8 @@ import { TokenStorageService } from '@ghostfolio/client/services/token-storage.s
   templateUrl: 'login-with-access-token-dialog.html'
 })
 export class LoginWithAccessTokenDialog {
+  public hide = true;
+
   public constructor(
     @Inject(MAT_DIALOG_DATA) public data: any,
     public dialogRef: MatDialogRef<LoginWithAccessTokenDialog>,
@@ -46,5 +48,11 @@ export class LoginWithAccessTokenDialog {
       this.dialogRef.close();
       this.router.navigate(['/']);
     } catch {}
+  }
+
+  public onSubmit() {
+    if (this.data.accessToken) {
+      this.dialogRef.close(this.data);
+    }
   }
 }

--- a/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.html
+++ b/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.html
@@ -6,18 +6,25 @@
 
 <div class="py-3" mat-dialog-content>
   <div class="align-items-center d-flex flex-column">
-    <form id="login" class="display-contents" (ngSubmit)="onSubmit()">
+    <form class="w-100" (ngSubmit)="onLoginWithAccessToken()">
       <mat-form-field appearance="outline" class="without-hint w-100">
         <mat-label i18n>Security Token</mat-label>
         <input
           matInput
-          [type]="hide ? 'password' : 'text'"
           name="password"
+          [type]="isAccessTokenHidden ? 'password' : 'text'"
           [(ngModel)]="data.accessToken"
         />
-        <div id="hide-password" matSuffix (click)="hide = !hide">
-          <ion-icon name="{{hide ? 'eye-outline' : 'eye-off-outline'}}"></ion-icon>
-        </div>
+        <button
+          mat-button
+          matSuffix
+          type="button"
+          (click)="isAccessTokenHidden = !isAccessTokenHidden"
+        >
+          <ion-icon
+            [name]="isAccessTokenHidden ? 'eye-outline' : 'eye-off-outline'"
+          ></ion-icon>
+        </button>
       </mat-form-field>
     </form>
     <ng-container *ngIf="data.hasPermissionToUseSocialLogin">

--- a/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.html
+++ b/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.html
@@ -6,15 +6,20 @@
 
 <div class="py-3" mat-dialog-content>
   <div class="align-items-center d-flex flex-column">
-    <mat-form-field appearance="outline" class="without-hint w-100">
-      <mat-label i18n>Security Token</mat-label>
-      <textarea
-        cdkTextareaAutosize
-        matInput
-        type="text"
-        [(ngModel)]="data.accessToken"
-      ></textarea>
-    </mat-form-field>
+    <form id="login" class="display-contents" (ngSubmit)="onSubmit()">
+      <mat-form-field appearance="outline" class="without-hint w-100">
+        <mat-label i18n>Security Token</mat-label>
+        <input
+          matInput
+          [type]="hide ? 'password' : 'text'"
+          name="password"
+          [(ngModel)]="data.accessToken"
+        />
+        <div id="hide-password" matSuffix (click)="hide = !hide">
+          <ion-icon name="{{hide ? 'eye-outline' : 'eye-off-outline'}}"></ion-icon>
+        </div>
+      </mat-form-field>
+    </form>
     <ng-container *ngIf="data.hasPermissionToUseSocialLogin">
       <div class="my-3 text-center text-muted" i18n>or</div>
       <div class="d-flex flex-column">

--- a/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.scss
+++ b/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.scss
@@ -1,3 +1,14 @@
 :host {
   display: block;
+
+  .display-contents {
+    display: contents;
+  }
+
+  #hide-password {
+    padding: 10px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+  }
 }

--- a/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.scss
+++ b/apps/client/src/app/components/login-with-access-token-dialog/login-with-access-token-dialog.scss
@@ -1,14 +1,3 @@
 :host {
   display: block;
-
-  .display-contents {
-    display: contents;
-  }
-
-  #hide-password {
-    padding: 10px;
-    min-height: 44px;
-    display: flex;
-    align-items: center;
-  }
 }


### PR DESCRIPTION
Better login dialog:
- the token is hidden by default,
- hide/show button with the usual eye icon,
- hitting the enter key send the login request,
- the input field should be detected by password manager (I only tested Kee), because of `<form id="login">` and `<input name="password">`.

Now:
![Screenshot](https://github.com/ghostfolio/ghostfolio/assets/47859535/bdb2c53f-55b0-49c6-a98d-5aac49a47a24)

With this PR:
![Screenshot](https://github.com/ghostfolio/ghostfolio/assets/47859535/a7f3c854-6b7e-4704-b6dc-59e7c215f3c0)
![Screenshot](https://github.com/ghostfolio/ghostfolio/assets/47859535/11ca3a3f-2f60-4080-b46d-f869556d8c68)

