### PR TITLE
Feature/support copy assets target on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for the cryptocurrency _CyberConnect_
+- Added support for the `copy-assets` `Nx` target on _Windows_
 
 ### Changed
 

--- a/apps/client/project.json
+++ b/apps/client/project.json
@@ -99,40 +99,40 @@
       "options": {
         "commands": [
           {
-            "command": "mkdir -p dist/apps/client"
+            "command": "cross-env mkdir -p dist/apps/client"
           },
           {
-            "command": "cp -r apps/client/src/assets dist/apps/client"
+            "command": "cross-env cp -r apps/client/src/assets dist/apps/client"
           },
           {
-            "command": "cp -r apps/client/src/assets/.well-known dist/apps/client"
+            "command": "cross-env cp -r apps/client/src/assets/.well-known dist/apps/client"
           },
           {
-            "command": "cp apps/client/src/assets/favicon.ico dist/apps/client"
+            "command": "cross-env cp apps/client/src/assets/favicon.ico dist/apps/client"
           },
           {
-            "command": "cp apps/client/src/assets/index.html dist/apps/client"
+            "command": "cross-env cp apps/client/src/assets/index.html dist/apps/client"
           },
           {
-            "command": "cp apps/client/src/assets/robots.txt dist/apps/client"
+            "command": "cross-env cp apps/client/src/assets/robots.txt dist/apps/client"
           },
           {
-            "command": "cp apps/client/src/assets/site.webmanifest dist/apps/client"
+            "command": "cross-env cp apps/client/src/assets/site.webmanifest dist/apps/client"
           },
           {
-            "command": "cp node_modules/ionicons/dist/index.js dist/apps/client"
+            "command": "cross-env cp node_modules/ionicons/dist/index.js dist/apps/client"
           },
           {
-            "command": "cp node_modules/ionicons/dist/ionicons.js dist/apps/client"
+            "command": "cross-env cp node_modules/ionicons/dist/ionicons.js dist/apps/client"
           },
           {
-            "command": "cp -r node_modules/ionicons/dist/ionicons dist/apps/client/ionicons"
+            "command": "cross-env cp -r node_modules/ionicons/dist/ionicons dist/apps/client/ionicons"
           },
           {
-            "command": "cp CHANGELOG.md dist/apps/client/assets"
+            "command": "cross-env cp CHANGELOG.md dist/apps/client/assets"
           },
           {
-            "command": "cp LICENSE dist/apps/client/assets"
+            "command": "cross-env cp LICENSE dist/apps/client/assets"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "@typescript-eslint/eslint-plugin": "5.51.0",
     "@typescript-eslint/parser": "5.51.0",
     "codelyzer": "6.0.1",
+    "cross-env": "7.0.3",
     "cypress": "6.2.1",
     "eslint": "8.33.0",
     "eslint-config-prettier": "8.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8684,6 +8684,13 @@ cron@2.4.0:
   dependencies:
     luxon "^3.2.1"
 
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.0.5:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
@@ -8702,7 +8709,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Error on Windows when running `yarn start:client`:

```
The syntax of the command is incorrect.
cp: cannot overwrite non-directory 'dist/apps/client/assets' with directory 'apps/client/src/assets'
Warning: run-commands command "mkdir -p dist/apps/client" exited with non-zero status codeWarning: run-commands command "cp -r apps/client/src/assets dist/apps/client" exited with non-zero status code
```