### PR TITLE
Fix Memory Leak on Data Gathering when server TZ is behind UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the timeout in _EOD Historical Data_ requests
 - Fixed an issue with the portfolio summary caused by the language localization for Dutch (`nl`)
+- Fixed a memory leak related to the server's timezone (behind UTC) in the data gathering
 
 ## 2.0.0 - 2023-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a memory leak related to the server's timezone (behind UTC) in the data gathering
+
 ## 2.3.0 - 2023-09-17
 
 ### Added
@@ -48,7 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the timeout in _EOD Historical Data_ requests
 - Fixed an issue with the portfolio summary caused by the language localization for Dutch (`nl`)
-- Fixed a memory leak related to the server's timezone (behind UTC) in the data gathering
 
 ## 2.0.0 - 2023-09-09
 

--- a/apps/api/src/services/data-gathering/data-gathering.processor.ts
+++ b/apps/api/src/services/data-gathering/data-gathering.processor.ts
@@ -102,14 +102,7 @@ export class DataGatheringProcessor {
         }
 
         // Count month one up for iteration
-        currentDate = new Date(
-          Date.UTC(
-            getYear(currentDate),
-            getMonth(currentDate),
-            getDate(currentDate) + 1,
-            0
-          )
-        );
+        currentDate.setDate(currentDate.getDate() + 1);
       }
 
       await this.marketDataService.updateMany({ data });

--- a/apps/api/src/services/data-gathering/data-gathering.processor.ts
+++ b/apps/api/src/services/data-gathering/data-gathering.processor.ts
@@ -18,7 +18,8 @@ import {
   getMonth,
   getYear,
   isBefore,
-  parseISO
+  parseISO,
+  addDays
 } from 'date-fns';
 
 import { DataGatheringService } from './data-gathering.service';
@@ -101,8 +102,7 @@ export class DataGatheringProcessor {
           });
         }
 
-        // Count month one up for iteration
-        currentDate.setDate(currentDate.getDate() + 1);
+        currentDate = addDays(currentDate, 1);
       }
 
       await this.marketDataService.updateMany({ data });

--- a/apps/api/src/services/data-gathering/data-gathering.processor.ts
+++ b/apps/api/src/services/data-gathering/data-gathering.processor.ts
@@ -13,13 +13,13 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { Job } from 'bull';
 import {
+  addDays,
   format,
   getDate,
   getMonth,
   getYear,
   isBefore,
-  parseISO,
-  addDays
+  parseISO
 } from 'date-fns';
 
 import { DataGatheringService } from './data-gathering.service';


### PR DESCRIPTION
For timezones behind UTC, the current code would convert to one day before (local time) and when adding a day, it would result in the same day after converting back to UTC and thus generating an infinite loop

Fixes issue #2088 