### PR TITLE
Bugfix - issue with total value of activites not showing

### DIFF
--- a/libs/ui/src/lib/activities-table/activities-table.component.ts
+++ b/libs/ui/src/lib/activities-table/activities-table.component.ts
@@ -399,7 +399,7 @@ export class ActivitiesTableComponent implements OnChanges, OnDestroy, OnInit {
           type === 'LIABILITY' ||
           type === 'SELL'
         ) {
-          return null;
+          continue;
         }
       } else {
         return null;


### PR DESCRIPTION
For more informations it's best to check issue #2363.

It's a small fix which prevents "null" from showing to the user.
So basically, if we have one of these activities: **Dividend, Fee, Interest, Liability** or **Sell** we will just ignore them and continue with our loop which counts the total value of types **Buy** and **Item**.

![image](https://github.com/ghostfolio/ghostfolio/assets/37557775/2ea9fde4-f88e-4fad-8022-1875d1f371c3)

In this picture we can see that totalValue is now being properly displayed and counted.
You can find a picture with bug in the issue #2363.