### PR TITLE
Feature/toggle account is excluded from accounts table

### DIFF
--- a/apps/client/src/app/components/accounts-table/accounts-table.component.html
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.html
@@ -5,9 +5,10 @@
       class="d-none d-lg-table-cell px-1"
       mat-header-cell
     ></th>
-    <td *matCellDef="let element" class="d-none d-lg-table-cell px-1" mat-cell>
+    <td *matCellDef="let element" class="d-none d-lg-table-cell px-1" mat-cell (click)="onToggleExcluded(element); $event.stopPropagation()">
       <div class="d-flex justify-content-center">
-        <ion-icon *ngIf="element.isExcluded" name="eye-off-outline"></ion-icon>
+        <ion-icon *ngIf="element.isExcluded" id="isExcluded-icon" name="eye-off-outline"></ion-icon>
+        <ion-icon *ngIf="!element.isExcluded" id="isNotExcluded-icon" name="eye-outline"></ion-icon>
       </div>
     </td>
     <td

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.html
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.html
@@ -5,23 +5,18 @@
       class="d-none d-lg-table-cell px-1"
       mat-header-cell
     ></th>
-    <td
-      *matCellDef="let element"
-      class="d-none d-lg-table-cell px-1"
-      mat-cell
-      (click)="onToggleExcluded(element); $event.stopPropagation()"
-    >
+    <td *matCellDef="let element" class="d-none d-lg-table-cell px-1" mat-cell>
       <div class="d-flex justify-content-center">
-        <ion-icon
-          *ngIf="element.isExcluded"
-          id="isExcluded-icon"
-          name="eye-off-outline"
-        ></ion-icon>
-        <ion-icon
-          *ngIf="!element.isExcluded"
-          id="isNotExcluded-icon"
-          name="eye-outline"
-        ></ion-icon>
+        <button
+          class="mx-1 no-min-width px-2"
+          mat-button
+          (click)="onToggleExcluded(element); $event.stopPropagation()"
+        >
+          <ion-icon
+            [name]="element.isExcluded ? 'eye-off-outline' : 'eye-outline'"
+            [ngClass]="{ 'text-muted': !element.isExcluded }"
+          ></ion-icon>
+        </button>
       </div>
     </td>
     <td

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.html
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.html
@@ -5,10 +5,23 @@
       class="d-none d-lg-table-cell px-1"
       mat-header-cell
     ></th>
-    <td *matCellDef="let element" class="d-none d-lg-table-cell px-1" mat-cell (click)="onToggleExcluded(element); $event.stopPropagation()">
+    <td
+      *matCellDef="let element"
+      class="d-none d-lg-table-cell px-1"
+      mat-cell
+      (click)="onToggleExcluded(element); $event.stopPropagation()"
+    >
       <div class="d-flex justify-content-center">
-        <ion-icon *ngIf="element.isExcluded" id="isExcluded-icon" name="eye-off-outline"></ion-icon>
-        <ion-icon *ngIf="!element.isExcluded" id="isNotExcluded-icon" name="eye-outline"></ion-icon>
+        <ion-icon
+          *ngIf="element.isExcluded"
+          id="isExcluded-icon"
+          name="eye-off-outline"
+        ></ion-icon>
+        <ion-icon
+          *ngIf="!element.isExcluded"
+          id="isNotExcluded-icon"
+          name="eye-outline"
+        ></ion-icon>
       </div>
     </td>
     <td

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.html
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.html
@@ -7,7 +7,13 @@
     ></th>
     <td *matCellDef="let element" class="d-none d-lg-table-cell px-1" mat-cell>
       <div class="d-flex justify-content-center">
+        <mat-spinner
+          *ngIf="element.isLoading"
+          [diameter]="20"
+          (click)="$event.stopPropagation()"
+        ></mat-spinner>
         <button
+          *ngIf="!element.isLoading"
           class="mx-1 no-min-width px-2"
           mat-button
           (click)="onToggleExcluded(element); $event.stopPropagation()"

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.scss
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.scss
@@ -4,6 +4,15 @@
   display: block;
 
   .mat-mdc-table {
+    #isExcluded-icon {
+      font-size: 125%;
+    }
+
+    #isNotExcluded-icon {
+      font-size: 125%;
+      color: gray;
+    }
+
     th {
       ::ng-deep {
         .mat-sort-header-container {

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.scss
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.scss
@@ -4,15 +4,6 @@
   display: block;
 
   .mat-mdc-table {
-    #isExcluded-icon {
-      font-size: 125%;
-    }
-
-    #isNotExcluded-icon {
-      font-size: 125%;
-      color: gray;
-    }
-
     th {
       ::ng-deep {
         .mat-sort-header-container {

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.ts
@@ -12,7 +12,8 @@ import {
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { Router } from '@angular/router';
-import { Account as AccountModel } from '@prisma/client';
+import { AccountWithValue as AccountModel } from '@ghostfolio/common/types';
+
 import { get } from 'lodash';
 import { Subject, Subscription } from 'rxjs';
 
@@ -99,6 +100,7 @@ export class AccountsTableComponent implements OnChanges, OnDestroy, OnInit {
   }
 
   public onToggleExcluded(aAccount: AccountModel) {
+    aAccount.isLoading = true;
     this.accountToggleExcluded.emit(aAccount);
   }
 

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.ts
@@ -33,6 +33,7 @@ export class AccountsTableComponent implements OnChanges, OnDestroy, OnInit {
   @Input() transactionCount: number;
 
   @Output() accountDeleted = new EventEmitter<string>();
+  @Output() accountToggleExcluded = new EventEmitter<AccountModel>();
   @Output() accountToUpdate = new EventEmitter<AccountModel>();
 
   @ViewChild(MatSort) sort: MatSort;
@@ -85,6 +86,10 @@ export class AccountsTableComponent implements OnChanges, OnDestroy, OnInit {
     if (confirmation) {
       this.accountDeleted.emit(aId);
     }
+  }
+
+  public onToggleExcluded(aAccount: AccountModel) {
+    this.accountToggleExcluded.emit(aAccount);
   }
 
   public onOpenAccountDetailDialog(accountId: string) {

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.ts
@@ -88,10 +88,6 @@ export class AccountsTableComponent implements OnChanges, OnDestroy, OnInit {
     }
   }
 
-  public onToggleExcluded(aAccount: AccountModel) {
-    this.accountToggleExcluded.emit(aAccount);
-  }
-
   public onOpenAccountDetailDialog(accountId: string) {
     this.router.navigate([], {
       queryParams: { accountId, accountDetailDialog: true }
@@ -100,6 +96,10 @@ export class AccountsTableComponent implements OnChanges, OnDestroy, OnInit {
 
   public onOpenComment(aComment: string) {
     alert(aComment);
+  }
+
+  public onToggleExcluded(aAccount: AccountModel) {
+    this.accountToggleExcluded.emit(aAccount);
   }
 
   public onUpdateAccount(aAccount: AccountModel) {

--- a/apps/client/src/app/components/accounts-table/accounts-table.module.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.module.ts
@@ -8,6 +8,7 @@ import { RouterModule } from '@angular/router';
 import { GfSymbolIconModule } from '@ghostfolio/client/components/symbol-icon/symbol-icon.module';
 import { GfValueModule } from '@ghostfolio/ui/value';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { AccountsTableComponent } from './accounts-table.component';
 
@@ -22,6 +23,7 @@ import { AccountsTableComponent } from './accounts-table.component';
     MatMenuModule,
     MatSortModule,
     MatTableModule,
+    MatProgressSpinnerModule,
     NgxSkeletonLoaderModule,
     RouterModule
   ],

--- a/apps/client/src/app/pages/accounts/accounts-page.component.ts
+++ b/apps/client/src/app/pages/accounts/accounts-page.component.ts
@@ -151,10 +151,10 @@ export class AccountsPageComponent implements OnDestroy, OnInit {
       comment: aAccount.comment,
       currency: aAccount.currency,
       id: aAccount.id,
-      isExcluded: !(aAccount.isExcluded),
+      isExcluded: !aAccount.isExcluded,
       name: aAccount.name,
       platformId: aAccount.platformId
-    }
+    };
     this.dataService
       .putAccount(account)
       .pipe(takeUntil(this.unsubscribeSubject))

--- a/apps/client/src/app/pages/accounts/accounts-page.component.ts
+++ b/apps/client/src/app/pages/accounts/accounts-page.component.ts
@@ -144,6 +144,32 @@ export class AccountsPageComponent implements OnDestroy, OnInit {
       });
   }
 
+  public onToggleExcluded(aAccount: AccountModel) {
+    let account: UpdateAccountDto = {
+      accountType: aAccount.accountType,
+      balance: aAccount.balance,
+      comment: aAccount.comment,
+      currency: aAccount.currency,
+      id: aAccount.id,
+      isExcluded: !(aAccount.isExcluded),
+      name: aAccount.name,
+      platformId: aAccount.platformId
+    }
+    this.dataService
+      .putAccount(account)
+      .pipe(takeUntil(this.unsubscribeSubject))
+      .subscribe({
+        next: () => {
+          this.userService
+            .get(true)
+            .pipe(takeUntil(this.unsubscribeSubject))
+            .subscribe();
+
+          this.fetchAccounts();
+        }
+      });
+  }
+
   public onUpdateAccount(aAccount: AccountModel) {
     this.router.navigate([], {
       queryParams: { accountId: aAccount.id, editDialog: true }

--- a/apps/client/src/app/pages/accounts/accounts-page.component.ts
+++ b/apps/client/src/app/pages/accounts/accounts-page.component.ts
@@ -144,19 +144,27 @@ export class AccountsPageComponent implements OnDestroy, OnInit {
       });
   }
 
-  public onToggleExcluded(aAccount: AccountModel) {
-    let account: UpdateAccountDto = {
-      accountType: aAccount.accountType,
-      balance: aAccount.balance,
-      comment: aAccount.comment,
-      currency: aAccount.currency,
-      id: aAccount.id,
-      isExcluded: !aAccount.isExcluded,
-      name: aAccount.name,
-      platformId: aAccount.platformId
-    };
+  public onToggleExcludedAccount({
+    accountType,
+    balance,
+    comment,
+    currency,
+    id,
+    isExcluded,
+    name,
+    platformId
+  }: AccountModel) {
     this.dataService
-      .putAccount(account)
+      .putAccount({
+        accountType,
+        balance,
+        comment,
+        currency,
+        id,
+        isExcluded: !isExcluded,
+        name,
+        platformId
+      })
       .pipe(takeUntil(this.unsubscribeSubject))
       .subscribe({
         next: () => {

--- a/apps/client/src/app/pages/accounts/accounts-page.html
+++ b/apps/client/src/app/pages/accounts/accounts-page.html
@@ -13,6 +13,7 @@
           [totalValueInBaseCurrency]="totalValueInBaseCurrency"
           [transactionCount]="transactionCount"
           (accountDeleted)="onDeleteAccount($event)"
+          (accountToggleExcluded)="onToggleExcluded($event)"
           (accountToUpdate)="onUpdateAccount($event)"
         ></gf-accounts-table>
       </div>

--- a/apps/client/src/app/pages/accounts/accounts-page.html
+++ b/apps/client/src/app/pages/accounts/accounts-page.html
@@ -13,7 +13,7 @@
           [totalValueInBaseCurrency]="totalValueInBaseCurrency"
           [transactionCount]="transactionCount"
           (accountDeleted)="onDeleteAccount($event)"
-          (accountToggleExcluded)="onToggleExcluded($event)"
+          (accountToggleExcluded)="onToggleExcludedAccount($event)"
           (accountToUpdate)="onUpdateAccount($event)"
         ></gf-accounts-table>
       </div>

--- a/libs/common/src/lib/types/account-with-value.type.ts
+++ b/libs/common/src/lib/types/account-with-value.type.ts
@@ -2,6 +2,7 @@ import { Account as AccountModel, Platform } from '@prisma/client';
 
 export type AccountWithValue = AccountModel & {
   balanceInBaseCurrency: number;
+  isLoading?: boolean;
   Platform?: Platform;
   transactionCount: number;
   value: number;


### PR DESCRIPTION
When I want to toggle the visibility of an account, going through the create-or-update-account-dialog is too long (burger menu -> edit -> "Exclude from Analysis" -> Save). The visibility indicator (the crossed eye) should be a button that toggles the visibility of the account.
Now:
![](https://user-images.githubusercontent.com/47859535/252158951-16693441-39a4-430b-a48f-0cff6e06f77b.png)
With this PR:
![toggleAccountVisibility](https://github.com/ghostfolio/ghostfolio/assets/47859535/6e5e63ea-64f0-45e5-a994-254efeb73a08)

I unintentionally closed the previous PR (https://github.com/ghostfolio/ghostfolio/pull/2137), this one is an improved version.