### PR TITLE
fix: prevent empty form submission in account dialog

### DIFF
--- a/apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html
+++ b/apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html
@@ -13,7 +13,7 @@
         <input
           formControlName="name"
           matInput
-          (keydown.enter)="$event.preventDefault()"
+          (keydown.enter)="$event.stopPropagation()"
         />
       </mat-form-field>
     </div>
@@ -34,7 +34,7 @@
           formControlName="balance"
           matInput
           type="number"
-          (keydown.enter)="$event.preventDefault()"
+          (keydown.enter)="$event.stopPropagation()"
         />
         <span class="ml-2" matTextSuffix>{{ data.account.currency }}</span>
       </mat-form-field>
@@ -75,7 +75,7 @@
     </div>
   </div>
   <div class="justify-content-end" mat-dialog-actions>
-    <button i18n mat-button (click)="onCancel()">Cancel</button>
+    <button i18n mat-button type="button" (click)="onCancel()">Cancel</button>
     <button
       color="primary"
       mat-flat-button

--- a/apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html
+++ b/apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html
@@ -10,7 +10,11 @@
     <div>
       <mat-form-field appearance="outline" class="w-100">
         <mat-label i18n>Name</mat-label>
-        <input formControlName="name" matInput />
+        <input
+          formControlName="name"
+          matInput
+          (keydown.enter)="$event.preventDefault()"
+        />
       </mat-form-field>
     </div>
     <div>
@@ -26,7 +30,12 @@
     <div>
       <mat-form-field appearance="outline" class="w-100">
         <mat-label i18n>Cash Balance</mat-label>
-        <input formControlName="balance" matInput type="number" />
+        <input
+          formControlName="balance"
+          matInput
+          type="number"
+          (keydown.enter)="$event.preventDefault()"
+        />
         <span class="ml-2" matTextSuffix>{{ data.account.currency }}</span>
       </mat-form-field>
     </div>


### PR DESCRIPTION
Fixes #2418

Changed default behavior of {keydown.enter} in `<input>` which previously led to form submissions when fields were empty