### PR TITLE
feat: extend asset profile dialog form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added support to edit the name, asset class and asset sub class of asset profiles with `MANUAL` data source in the asset profile details dialog of the admin control panel
+
 ### Changed
 
 - Improved the style and wording of the position detail dialog

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -303,15 +303,21 @@ export class AdminService {
   }
 
   public async patchAssetProfileData({
+    assetClass,
+    assetSubClass,
     comment,
     dataSource,
+    name,
     scraperConfiguration,
     symbol,
     symbolMapping
   }: Prisma.SymbolProfileUpdateInput & UniqueAsset) {
     await this.symbolProfileService.updateSymbolProfile({
+      assetClass,
+      assetSubClass,
       comment,
       dataSource,
+      name,
       scraperConfiguration,
       symbol,
       symbolMapping

--- a/apps/api/src/app/admin/update-asset-profile.dto.ts
+++ b/apps/api/src/app/admin/update-asset-profile.dto.ts
@@ -1,10 +1,22 @@
-import { Prisma } from '@prisma/client';
-import { IsObject, IsOptional, IsString } from 'class-validator';
+import { AssetClass, AssetSubClass, Prisma } from '@prisma/client';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 
 export class UpdateAssetProfileDto {
+  @IsEnum(AssetClass, { each: true })
+  @IsOptional()
+  assetClass?: AssetClass;
+
+  @IsEnum(AssetSubClass, { each: true })
+  @IsOptional()
+  assetSubClass?: AssetSubClass;
+
   @IsString()
   @IsOptional()
   comment?: string;
+
+  @IsString()
+  @IsOptional()
+  name?: string;
 
   @IsObject()
   @IsOptional()

--- a/apps/api/src/services/symbol-profile/symbol-profile.service.ts
+++ b/apps/api/src/services/symbol-profile/symbol-profile.service.ts
@@ -13,7 +13,7 @@ import { continents, countries } from 'countries-list';
 
 @Injectable()
 export class SymbolProfileService {
-  public constructor(private readonly prismaService: PrismaService) {}
+  public constructor(private readonly prismaService: PrismaService) { }
 
   public async add(
     assetProfile: Prisma.SymbolProfileCreateInput
@@ -86,14 +86,24 @@ export class SymbolProfileService {
   }
 
   public updateSymbolProfile({
+    assetClass,
+    assetSubClass,
     comment,
     dataSource,
+    name,
     scraperConfiguration,
     symbol,
     symbolMapping
   }: Prisma.SymbolProfileUpdateInput & UniqueAsset) {
     return this.prismaService.symbolProfile.update({
-      data: { comment, scraperConfiguration, symbolMapping },
+      data: {
+        assetClass,
+        assetSubClass,
+        comment,
+        name,
+        scraperConfiguration,
+        symbolMapping
+      },
       where: { dataSource_symbol: { dataSource, symbol } }
     });
   }

--- a/apps/api/src/services/symbol-profile/symbol-profile.service.ts
+++ b/apps/api/src/services/symbol-profile/symbol-profile.service.ts
@@ -13,7 +13,7 @@ import { continents, countries } from 'countries-list';
 
 @Injectable()
 export class SymbolProfileService {
-  public constructor(private readonly prismaService: PrismaService) { }
+  public constructor(private readonly prismaService: PrismaService) {}
 
   public async add(
     assetProfile: Prisma.SymbolProfileCreateInput

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
@@ -79,7 +79,7 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
     private dataService: DataService,
     public dialogRef: MatDialogRef<AssetProfileDialog>,
     private formBuilder: FormBuilder
-  ) { }
+  ) {}
 
   public ngOnInit(): void {
     this.benchmarks = this.dataService.fetchInfo().benchmarks;
@@ -152,14 +152,14 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
     this.adminService
       .gatherProfileDataBySymbol({ dataSource, symbol })
       .pipe(takeUntil(this.unsubscribeSubject))
-      .subscribe(() => { });
+      .subscribe(() => {});
   }
 
   public onGatherSymbol({ dataSource, symbol }: UniqueAsset) {
     this.adminService
       .gatherSymbol({ dataSource, symbol })
       .pipe(takeUntil(this.unsubscribeSubject))
-      .subscribe(() => { });
+      .subscribe(() => {});
   }
 
   public onImportHistoricalData() {
@@ -212,13 +212,13 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
       scraperConfiguration = JSON.parse(
         this.assetProfileForm.controls['scraperConfiguration'].value
       );
-    } catch { }
+    } catch {}
 
     try {
       symbolMapping = JSON.parse(
         this.assetProfileForm.controls['symbolMapping'].value
       );
-    } catch { }
+    } catch {}
 
     const assetProfileData: UpdateAssetProfileDto = {
       assetClass: this.assetProfileForm.controls['assetClass'].value,

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -112,7 +112,11 @@
         >
       </div>
       <div class="col-6 mb-3">
-        <gf-value i18n size="medium" [hidden]="!assetClass" [value]="assetClass"
+        <gf-value
+          i18n
+          size="medium"
+          [hidden]="!assetProfileClass"
+          [value]="assetProfileClass"
           >Asset Class</gf-value
         >
       </div>
@@ -120,8 +124,8 @@
         <gf-value
           i18n
           size="medium"
-          [hidden]="!assetSubClass"
-          [value]="assetSubClass"
+          [hidden]="!assetProfileSubClass"
+          [value]="assetProfileSubClass"
           >Asset Sub Class</gf-value
         >
       </div>
@@ -173,6 +177,38 @@
           </div>
         </ng-template>
       </ng-container>
+    </div>
+    <div *ngIf="assetProfile?.dataSource === 'MANUAL'" class="mt-3">
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label i18n>Name</mat-label>
+        <input formControlName="name" matInput type="text" />
+      </mat-form-field>
+    </div>
+    <div *ngIf="assetProfile?.dataSource === 'MANUAL'" class="mt-3">
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label i18n>Asset Class</mat-label>
+        <mat-select formControlName="assetClass">
+          <mat-option [value]="null"></mat-option>
+          <mat-option
+            *ngFor="let assetClass of assetClasses"
+            [value]="assetClass.id"
+            >{{ assetClass.label }}</mat-option
+          >
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div *ngIf="assetProfile?.dataSource === 'MANUAL'" class="mt-3">
+      <mat-form-field appearance="outline" class="w-100">
+        <mat-label i18n>Asset Sub Class</mat-label>
+        <mat-select formControlName="assetSubClass">
+          <mat-option [value]="null"></mat-option>
+          <mat-option
+            *ngFor="let assetSubClass of assetSubClasses"
+            [value]="assetSubClass.id"
+            >{{ assetSubClass.label }}</mat-option
+          >
+        </mat-select>
+      </mat-form-field>
     </div>
     <div class="d-flex my-3">
       <div class="w-50">

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.module.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.module.ts
@@ -7,12 +7,12 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatSelectModule } from '@angular/material/select';
 import { GfAdminMarketDataDetailModule } from '@ghostfolio/client/components/admin-market-data-detail/admin-market-data-detail.module';
 import { GfPortfolioProportionChartModule } from '@ghostfolio/ui/portfolio-proportion-chart/portfolio-proportion-chart.module';
 import { GfValueModule } from '@ghostfolio/ui/value';
 
 import { AssetProfileDialog } from './asset-profile-dialog.component';
-import { MatSelectModule } from '@angular/material/select';
 
 @NgModule({
   declarations: [AssetProfileDialog],

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.module.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.module.ts
@@ -12,6 +12,7 @@ import { GfPortfolioProportionChartModule } from '@ghostfolio/ui/portfolio-propo
 import { GfValueModule } from '@ghostfolio/ui/value';
 
 import { AssetProfileDialog } from './asset-profile-dialog.component';
+import { MatSelectModule } from '@angular/material/select';
 
 @NgModule({
   declarations: [AssetProfileDialog],
@@ -26,6 +27,7 @@ import { AssetProfileDialog } from './asset-profile-dialog.component';
     MatDialogModule,
     MatInputModule,
     MatMenuModule,
+    MatSelectModule,
     ReactiveFormsModule,
     TextFieldModule
   ],

--- a/apps/client/src/app/services/admin.service.ts
+++ b/apps/client/src/app/services/admin.service.ts
@@ -203,15 +203,25 @@ export class AdminService {
   }
 
   public patchAssetProfile({
+    assetClass,
+    assetSubClass,
     comment,
     dataSource,
+    name,
     scraperConfiguration,
     symbol,
     symbolMapping
   }: UniqueAsset & UpdateAssetProfileDto) {
     return this.http.patch<EnhancedSymbolProfile>(
       `/api/v1/admin/profile-data/${dataSource}/${symbol}`,
-      { comment, scraperConfiguration, symbolMapping }
+      {
+        assetClass,
+        assetSubClass,
+        comment,
+        name,
+        scraperConfiguration,
+        symbolMapping
+      }
     );
   }
 


### PR DESCRIPTION
Closes #2524

- Added name (required), assetClass and assetSubClass inputs.
- Handled the form data in frontend and backend.

Attachment:

![asset_dialog](https://github.com/ghostfolio/ghostfolio/assets/53973174/f0423dd1-7a56-454c-adfa-10dbfb10080f)

