### PR TITLE
fix: CoinGecko GetQuotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue to get quotes in the _CoinGecko_ service
 - Loosened the validation in the activities import (expects values greater than or equal to 0 for `fee`, `quantity` and `unitPrice`)
 
 ## 2.17.0 - 2023-11-02

--- a/apps/api/src/services/data-provider/coingecko/coingecko.service.ts
+++ b/apps/api/src/services/data-provider/coingecko/coingecko.service.ts
@@ -139,10 +139,10 @@ export class CoinGeckoService implements DataProviderInterface {
   }: {
     symbols: string[];
   }): Promise<{ [symbol: string]: IDataProviderResponse }> {
-    const quotes: { [symbol: string]: IDataProviderResponse } = {};
+    const response: { [symbol: string]: IDataProviderResponse } = {};
 
     if (symbols.length <= 0) {
-      return quotes;
+      return response;
     }
 
     try {
@@ -152,7 +152,7 @@ export class CoinGeckoService implements DataProviderInterface {
         abortController.abort();
       }, DEFAULT_REQUEST_TIMEOUT);
 
-      const response = await got(
+      const quotes = await got(
         `${this.URL}/simple/price?ids=${symbols.join(
           ','
         )}&vs_currencies=${DEFAULT_CURRENCY.toLowerCase()}`,
@@ -162,24 +162,20 @@ export class CoinGeckoService implements DataProviderInterface {
         }
       ).json<any>();
 
-      for (const symbol in response) {
-        if (Object.prototype.hasOwnProperty.call(response, symbol)) {
-          const quote: IDataProviderResponse = {
-            currency: DEFAULT_CURRENCY,
-            dataProviderInfo: this.getDataProviderInfo(),
-            dataSource: DataSource.COINGECKO,
-            marketPrice: response[symbol][DEFAULT_CURRENCY.toLowerCase()],
-            marketState: 'open'
-          };
-
-          quotes[symbol] = quote;
-        }
+      for (const symbol in quotes) {
+        response[symbol] = {
+          currency: DEFAULT_CURRENCY,
+          dataProviderInfo: this.getDataProviderInfo(),
+          dataSource: DataSource.COINGECKO,
+          marketPrice: quotes[symbol][DEFAULT_CURRENCY.toLowerCase()],
+          marketState: 'open'
+        };
       }
     } catch (error) {
       Logger.error(error, 'CoinGeckoService');
     }
 
-    return quotes;
+    return response;
   }
 
   public getTestSymbol() {

--- a/apps/api/src/services/data-provider/coingecko/coingecko.service.ts
+++ b/apps/api/src/services/data-provider/coingecko/coingecko.service.ts
@@ -139,10 +139,10 @@ export class CoinGeckoService implements DataProviderInterface {
   }: {
     symbols: string[];
   }): Promise<{ [symbol: string]: IDataProviderResponse }> {
-    const response: { [symbol: string]: IDataProviderResponse } = {};
+    const quotes: { [symbol: string]: IDataProviderResponse } = {};
 
     if (symbols.length <= 0) {
-      return response;
+      return quotes;
     }
 
     try {
@@ -164,20 +164,22 @@ export class CoinGeckoService implements DataProviderInterface {
 
       for (const symbol in response) {
         if (Object.prototype.hasOwnProperty.call(response, symbol)) {
-          response[symbol] = {
+          const quote: IDataProviderResponse = {
             currency: DEFAULT_CURRENCY,
             dataProviderInfo: this.getDataProviderInfo(),
             dataSource: DataSource.COINGECKO,
             marketPrice: response[symbol][DEFAULT_CURRENCY.toLowerCase()],
             marketState: 'open'
           };
+
+          quotes[symbol] = quote;
         }
       }
     } catch (error) {
       Logger.error(error, 'CoinGeckoService');
     }
 
-    return response;
+    return quotes;
   }
 
   public getTestSymbol() {


### PR DESCRIPTION
Found Ghostfolio today and wanted to try it out. 

I have noticed that I couldn't add crypto activities as `/api/v1/symbol/COINGECKO/<coin>` is always returning 404s. (The const `response` gets redeclared once the API call is made, which makes the function error out.) 

This should fix it. 


