### PR TITLE
Feature/add permissions tests for controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Used the `HasPermission` annotation in endpoints
+
 ## 2.32.0 - 2023-12-26
 
 ### Added

--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -1,5 +1,5 @@
 import { Access } from '@ghostfolio/common/interfaces';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Body,
@@ -19,6 +19,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { AccessService } from './access.service';
 import { CreateAccessDto } from './create-access.dto';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('access')
 export class AccessController {
@@ -59,18 +60,10 @@ export class AccessController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.createAccess)
   public async createAccess(
     @Body() data: CreateAccessDto
   ): Promise<AccessModel> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.createAccess)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.accessService.createAccess({
       alias: data.alias || undefined,
       GranteeUser: data.granteeUserId
@@ -82,11 +75,11 @@ export class AccessController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteAccess)
   public async deleteAccess(@Param('id') id: string): Promise<AccessModel> {
     const access = await this.accessService.access({ id });
 
     if (
-      !hasPermission(this.request.user.permissions, permissions.deleteAccess) ||
       !access ||
       access.userId !== this.request.user.id
     ) {

--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -79,10 +79,7 @@ export class AccessController {
   public async deleteAccess(@Param('id') id: string): Promise<AccessModel> {
     const access = await this.accessService.access({ id });
 
-    if (
-      !access ||
-      access.userId !== this.request.user.id
-    ) {
+    if (!access || access.userId !== this.request.user.id) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
         StatusCodes.FORBIDDEN

--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { Access } from '@ghostfolio/common/interfaces';
 import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
@@ -19,8 +21,6 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { AccessService } from './access.service';
 import { CreateAccessDto } from './create-access.dto';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('access')
 export class AccessController {
@@ -59,9 +59,9 @@ export class AccessController {
     });
   }
 
+  @HasPermission(permissions.createAccess)
   @Post()
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.createAccess)
   public async createAccess(
     @Body() data: CreateAccessDto
   ): Promise<AccessModel> {
@@ -75,8 +75,8 @@ export class AccessController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAccess)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteAccess(@Param('id') id: string): Promise<AccessModel> {
     const access = await this.accessService.access({ id });
 

--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -30,7 +30,7 @@ export class AccessController {
   ) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getAllAccesses(): Promise<Access[]> {
     const accessesWithGranteeUser = await this.accessService.accesses({
       include: {

--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -20,6 +20,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { AccessService } from './access.service';
 import { CreateAccessDto } from './create-access.dto';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('access')
 export class AccessController {
@@ -59,7 +60,7 @@ export class AccessController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createAccess)
   public async createAccess(
     @Body() data: CreateAccessDto
@@ -74,7 +75,7 @@ export class AccessController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAccess)
   public async deleteAccess(@Param('id') id: string): Promise<AccessModel> {
     const access = await this.accessService.access({ id });

--- a/apps/api/src/app/account-balance/account-balance.controller.ts
+++ b/apps/api/src/app/account-balance/account-balance.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
@@ -10,11 +12,10 @@ import {
 } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { AccountBalance } from '@prisma/client';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { StatusCodes, getReasonPhrase } from 'http-status-codes';
+
 import { AccountBalanceService } from './account-balance.service';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('account-balance')
 export class AccountBalanceController {
@@ -23,9 +24,9 @@ export class AccountBalanceController {
     @Inject(REQUEST) private readonly request: RequestWithUser
   ) {}
 
+  @HasPermission(permissions.deleteAccountBalance)
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.deleteAccountBalance)
   public async deleteAccountBalance(
     @Param('id') id: string
   ): Promise<AccountBalance> {

--- a/apps/api/src/app/account-balance/account-balance.controller.ts
+++ b/apps/api/src/app/account-balance/account-balance.controller.ts
@@ -14,6 +14,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { AccountBalance } from '@prisma/client';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 import { AccountBalanceService } from './account-balance.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('account-balance')
 export class AccountBalanceController {
@@ -23,7 +24,7 @@ export class AccountBalanceController {
   ) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAccountBalance)
   public async deleteAccountBalance(
     @Param('id') id: string

--- a/apps/api/src/app/account-balance/account-balance.controller.ts
+++ b/apps/api/src/app/account-balance/account-balance.controller.ts
@@ -1,4 +1,4 @@
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Controller,
@@ -10,11 +10,9 @@ import {
 } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { permissions } from '@ghostfolio/common/permissions';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { AccountBalance } from '@prisma/client';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-
 import { AccountBalanceService } from './account-balance.service';
 
 @Controller('account-balance')

--- a/apps/api/src/app/account-balance/account-balance.controller.ts
+++ b/apps/api/src/app/account-balance/account-balance.controller.ts
@@ -34,10 +34,7 @@ export class AccountBalanceController {
       id
     });
 
-    if (
-      !accountBalance ||
-      accountBalance.userId !== this.request.user.id
-    ) {
+    if (!accountBalance || accountBalance.userId !== this.request.user.id) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
         StatusCodes.FORBIDDEN

--- a/apps/api/src/app/account-balance/account-balance.controller.ts
+++ b/apps/api/src/app/account-balance/account-balance.controller.ts
@@ -10,8 +10,10 @@ import {
 } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { AccountBalance } from '@prisma/client';
+import { permissions } from '@ghostfolio/common/permissions';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
+import { AccountBalance } from '@prisma/client';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 import { AccountBalanceService } from './account-balance.service';
 
@@ -24,6 +26,7 @@ export class AccountBalanceController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteAccountBalance)
   public async deleteAccountBalance(
     @Param('id') id: string
   ): Promise<AccountBalance> {
@@ -32,10 +35,6 @@ export class AccountBalanceController {
     });
 
     if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.deleteAccountBalance
-      ) ||
       !accountBalance ||
       accountBalance.userId !== this.request.user.id
     ) {

--- a/apps/api/src/app/account/account.controller.ts
+++ b/apps/api/src/app/account/account.controller.ts
@@ -7,7 +7,7 @@ import {
   AccountBalancesResponse,
   Accounts
 } from '@ghostfolio/common/interfaces';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type {
   AccountWithValue,
   RequestWithUser
@@ -35,6 +35,7 @@ import { AccountService } from './account.service';
 import { CreateAccountDto } from './create-account.dto';
 import { TransferBalanceDto } from './transfer-balance.dto';
 import { UpdateAccountDto } from './update-account.dto';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('account')
 export class AccountController {
@@ -48,16 +49,8 @@ export class AccountController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteAccount)
   public async deleteAccount(@Param('id') id: string): Promise<AccountModel> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.deleteAccount)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const account = await this.accountService.accountWithOrders(
       {
         id_userId: {
@@ -135,17 +128,10 @@ export class AccountController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.createAccount)
   public async createAccount(
     @Body() data: CreateAccountDto
   ): Promise<AccountModel> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.createAccount)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
 
     if (data.platformId) {
       const platformId = data.platformId;
@@ -174,17 +160,10 @@ export class AccountController {
 
   @Post('transfer-balance')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.updateAccount)
   public async transferAccountBalance(
     @Body() { accountIdFrom, accountIdTo, balance }: TransferBalanceDto
   ) {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.updateAccount)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
 
     const accountsOfUser = await this.accountService.getAccounts(
       this.request.user.id
@@ -236,15 +215,8 @@ export class AccountController {
 
   @Put(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.updateAccount)
   public async update(@Param('id') id: string, @Body() data: UpdateAccountDto) {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.updateAccount)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
 
     const originalAccount = await this.accountService.account({
       id_userId: {

--- a/apps/api/src/app/account/account.controller.ts
+++ b/apps/api/src/app/account/account.controller.ts
@@ -132,7 +132,6 @@ export class AccountController {
   public async createAccount(
     @Body() data: CreateAccountDto
   ): Promise<AccountModel> {
-
     if (data.platformId) {
       const platformId = data.platformId;
       delete data.platformId;
@@ -164,7 +163,6 @@ export class AccountController {
   public async transferAccountBalance(
     @Body() { accountIdFrom, accountIdTo, balance }: TransferBalanceDto
   ) {
-
     const accountsOfUser = await this.accountService.getAccounts(
       this.request.user.id
     );
@@ -217,7 +215,6 @@ export class AccountController {
   @UseGuards(AuthGuard('jwt'))
   @HasPermission(permissions.updateAccount)
   public async update(@Param('id') id: string, @Body() data: UpdateAccountDto) {
-
     const originalAccount = await this.accountService.account({
       id_userId: {
         id,

--- a/apps/api/src/app/account/account.controller.ts
+++ b/apps/api/src/app/account/account.controller.ts
@@ -36,6 +36,7 @@ import { CreateAccountDto } from './create-account.dto';
 import { TransferBalanceDto } from './transfer-balance.dto';
 import { UpdateAccountDto } from './update-account.dto';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('account')
 export class AccountController {
@@ -48,7 +49,7 @@ export class AccountController {
   ) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAccount)
   public async deleteAccount(@Param('id') id: string): Promise<AccountModel> {
     const account = await this.accountService.accountWithOrders(
@@ -127,7 +128,7 @@ export class AccountController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createAccount)
   public async createAccount(
     @Body() data: CreateAccountDto
@@ -158,7 +159,7 @@ export class AccountController {
   }
 
   @Post('transfer-balance')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.updateAccount)
   public async transferAccountBalance(
     @Body() { accountIdFrom, accountIdTo, balance }: TransferBalanceDto
@@ -212,7 +213,7 @@ export class AccountController {
   }
 
   @Put(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.updateAccount)
   public async update(@Param('id') id: string, @Body() data: UpdateAccountDto) {
     const originalAccount = await this.accountService.account({

--- a/apps/api/src/app/account/account.controller.ts
+++ b/apps/api/src/app/account/account.controller.ts
@@ -81,7 +81,7 @@ export class AccountController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(RedactValuesInResponseInterceptor)
   public async getAllAccounts(
     @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId
@@ -96,7 +96,7 @@ export class AccountController {
   }
 
   @Get(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(RedactValuesInResponseInterceptor)
   public async getAccountById(
     @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId,
@@ -116,7 +116,7 @@ export class AccountController {
   }
 
   @Get(':id/balances')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(RedactValuesInResponseInterceptor)
   public async getAccountBalancesById(
     @Param('id') id: string

--- a/apps/api/src/app/account/account.controller.ts
+++ b/apps/api/src/app/account/account.controller.ts
@@ -1,5 +1,7 @@
 import { AccountBalanceService } from '@ghostfolio/api/app/account-balance/account-balance.service';
 import { PortfolioService } from '@ghostfolio/api/app/portfolio/portfolio.service';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { RedactValuesInResponseInterceptor } from '@ghostfolio/api/interceptors/redact-values-in-response.interceptor';
 import { ImpersonationService } from '@ghostfolio/api/services/impersonation/impersonation.service';
 import { HEADER_KEY_IMPERSONATION } from '@ghostfolio/common/config';
@@ -35,8 +37,6 @@ import { AccountService } from './account.service';
 import { CreateAccountDto } from './create-account.dto';
 import { TransferBalanceDto } from './transfer-balance.dto';
 import { UpdateAccountDto } from './update-account.dto';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('account')
 export class AccountController {
@@ -49,8 +49,8 @@ export class AccountController {
   ) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAccount)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteAccount(@Param('id') id: string): Promise<AccountModel> {
     const account = await this.accountService.accountWithOrders(
       {
@@ -127,9 +127,9 @@ export class AccountController {
     });
   }
 
+  @HasPermission(permissions.createAccount)
   @Post()
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.createAccount)
   public async createAccount(
     @Body() data: CreateAccountDto
   ): Promise<AccountModel> {
@@ -158,9 +158,9 @@ export class AccountController {
     }
   }
 
+  @HasPermission(permissions.updateAccount)
   @Post('transfer-balance')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.updateAccount)
   public async transferAccountBalance(
     @Body() { accountIdFrom, accountIdTo, balance }: TransferBalanceDto
   ) {
@@ -212,9 +212,9 @@ export class AccountController {
     });
   }
 
+  @HasPermission(permissions.updateAccount)
   @Put(':id')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.updateAccount)
   public async update(@Param('id') id: string, @Body() data: UpdateAccountDto) {
     const originalAccount = await this.accountService.account({
       id_userId: {

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { TransformDataSourceInRequestInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-request.interceptor';
 import { ApiService } from '@ghostfolio/api/services/api/api.service';
 import { DataGatheringService } from '@ghostfolio/api/services/data-gathering/data-gathering.service';
@@ -47,8 +49,6 @@ import { AdminService } from './admin.service';
 import { UpdateAssetProfileDto } from './update-asset-profile.dto';
 import { UpdateBulkMarketDataDto } from './update-bulk-market-data.dto';
 import { UpdateMarketDataDto } from './update-market-data.dto';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('admin')
 export class AdminController {
@@ -61,22 +61,22 @@ export class AdminController {
   ) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getAdminData(): Promise<AdminData> {
     return this.adminService.get();
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('gather')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async gather7Days(): Promise<void> {
     this.dataGatheringService.gather7Days();
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('gather/max')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async gatherMax(): Promise<void> {
     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
 
@@ -99,9 +99,9 @@ export class AdminController {
     this.dataGatheringService.gatherMax();
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('gather/profile-data')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async gatherProfileData(): Promise<void> {
     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
 
@@ -122,9 +122,9 @@ export class AdminController {
     );
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('gather/profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async gatherProfileDataForSymbol(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
@@ -154,9 +154,9 @@ export class AdminController {
     return;
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('gather/:dataSource/:symbol/:dateString')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async gatherSymbolForDate(
     @Param('dataSource') dataSource: DataSource,
     @Param('dateString') dateString: string,
@@ -206,8 +206,8 @@ export class AdminController {
   }
 
   @Get('market-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getMarketDataBySymbol(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
@@ -215,9 +215,9 @@ export class AdminController {
     return this.adminService.getMarketDataBySymbol({ dataSource, symbol });
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('market-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async updateMarketData(
     @Body() data: UpdateBulkMarketDataDto,
     @Param('dataSource') dataSource: DataSource,
@@ -241,9 +241,9 @@ export class AdminController {
   /**
    * @deprecated
    */
+  @HasPermission(permissions.accessAdminControl)
   @Put('market-data/:dataSource/:symbol/:dateString')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async update(
     @Param('dataSource') dataSource: DataSource,
     @Param('dateString') dateString: string,
@@ -264,9 +264,9 @@ export class AdminController {
     });
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async addProfileData(
     @Param('dataSource') dataSource: DataSource,
@@ -280,8 +280,8 @@ export class AdminController {
   }
 
   @Delete('profile-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteProfileData(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
@@ -289,9 +289,9 @@ export class AdminController {
     return this.adminService.deleteProfileData({ dataSource, symbol });
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Patch('profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async patchAssetProfileData(
     @Body() assetProfileData: UpdateAssetProfileDto,
     @Param('dataSource') dataSource: DataSource,
@@ -304,9 +304,9 @@ export class AdminController {
     });
   }
 
+  @HasPermission(permissions.accessAdminControl)
   @Put('settings/:key')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async updateProperty(
     @Param('key') key: string,
     @Body() data: PropertyDto

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -70,14 +70,14 @@ export class AdminController {
   @UseGuards(AuthGuard('jwt'))
   @HasPermission(permissions.accessAdminControl)
   public async gather7Days(): Promise<void> {
-     this.dataGatheringService.gather7Days();
+    this.dataGatheringService.gather7Days();
   }
 
   @Post('gather/max')
   @UseGuards(AuthGuard('jwt'))
   @HasPermission(permissions.accessAdminControl)
   public async gatherMax(): Promise<void> {
-     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
+    const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
 
     await this.dataGatheringService.addJobsToQueue(
       uniqueAssets.map(({ dataSource, symbol }) => {
@@ -161,7 +161,7 @@ export class AdminController {
     @Param('dateString') dateString: string,
     @Param('symbol') symbol: string
   ): Promise<MarketData> {
-     const date = parseISO(dateString);
+    const date = parseISO(dateString);
 
     if (!isDate(date)) {
       throw new HttpException(
@@ -189,7 +189,7 @@ export class AdminController {
     @Query('sortDirection') sortDirection?: Prisma.SortOrder,
     @Query('take') take?: number
   ): Promise<AdminMarketData> {
-     const filters = this.apiService.buildFiltersFromQueryParams({
+    const filters = this.apiService.buildFiltersFromQueryParams({
       filterByAssetSubClasses,
       filterBySearchQuery
     });
@@ -222,7 +222,7 @@ export class AdminController {
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ) {
-     const dataBulkUpdate: Prisma.MarketDataUpdateInput[] = data.marketData.map(
+    const dataBulkUpdate: Prisma.MarketDataUpdateInput[] = data.marketData.map(
       ({ date, marketPrice }) => ({
         dataSource,
         marketPrice,

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -47,6 +47,7 @@ import { AdminService } from './admin.service';
 import { UpdateAssetProfileDto } from './update-asset-profile.dto';
 import { UpdateBulkMarketDataDto } from './update-bulk-market-data.dto';
 import { UpdateMarketDataDto } from './update-market-data.dto';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('admin')
 export class AdminController {
@@ -60,56 +61,23 @@ export class AdminController {
 
   @Get()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async getAdminData(): Promise<AdminData> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.adminService.get();
   }
 
   @Post('gather')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async gather7Days(): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
-    this.dataGatheringService.gather7Days();
+     this.dataGatheringService.gather7Days();
   }
 
   @Post('gather/max')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async gatherMax(): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
-    const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
+     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
 
     await this.dataGatheringService.addJobsToQueue(
       uniqueAssets.map(({ dataSource, symbol }) => {
@@ -132,19 +100,8 @@ export class AdminController {
 
   @Post('gather/profile-data')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async gatherProfileData(): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
 
     await this.dataGatheringService.addJobsToQueue(
@@ -166,22 +123,11 @@ export class AdminController {
 
   @Post('gather/profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async gatherProfileDataForSymbol(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     await this.dataGatheringService.addJobToQueue({
       data: {
         dataSource,
@@ -197,22 +143,11 @@ export class AdminController {
 
   @Post('gather/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async gatherSymbol(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     this.dataGatheringService.gatherSymbol({ dataSource, symbol });
 
     return;
@@ -220,24 +155,13 @@ export class AdminController {
 
   @Post('gather/:dataSource/:symbol/:dateString')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async gatherSymbolForDate(
     @Param('dataSource') dataSource: DataSource,
     @Param('dateString') dateString: string,
     @Param('symbol') symbol: string
   ): Promise<MarketData> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
-    const date = parseISO(dateString);
+     const date = parseISO(dateString);
 
     if (!isDate(date)) {
       throw new HttpException(
@@ -255,6 +179,7 @@ export class AdminController {
 
   @Get('market-data')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async getMarketData(
     @Query('assetSubClasses') filterByAssetSubClasses?: string,
     @Query('presetId') presetId?: MarketDataPreset,
@@ -264,19 +189,7 @@ export class AdminController {
     @Query('sortDirection') sortDirection?: Prisma.SortOrder,
     @Query('take') take?: number
   ): Promise<AdminMarketData> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
-    const filters = this.apiService.buildFiltersFromQueryParams({
+     const filters = this.apiService.buildFiltersFromQueryParams({
       filterByAssetSubClasses,
       filterBySearchQuery
     });
@@ -293,45 +206,23 @@ export class AdminController {
 
   @Get('market-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async getMarketDataBySymbol(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ): Promise<AdminMarketDataDetails> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.adminService.getMarketDataBySymbol({ dataSource, symbol });
   }
 
   @Post('market-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async updateMarketData(
     @Body() data: UpdateBulkMarketDataDto,
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ) {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
-    const dataBulkUpdate: Prisma.MarketDataUpdateInput[] = data.marketData.map(
+     const dataBulkUpdate: Prisma.MarketDataUpdateInput[] = data.marketData.map(
       ({ date, marketPrice }) => ({
         dataSource,
         marketPrice,
@@ -351,24 +242,13 @@ export class AdminController {
    */
   @Put('market-data/:dataSource/:symbol/:dateString')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async update(
     @Param('dataSource') dataSource: DataSource,
     @Param('dateString') dateString: string,
     @Param('symbol') symbol: string,
     @Body() data: UpdateMarketDataDto
   ) {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const date = parseISO(dateString);
 
     return this.marketDataService.updateMarketData({
@@ -385,22 +265,12 @@ export class AdminController {
 
   @Post('profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async addProfileData(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ): Promise<SymbolProfile | never> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
     return this.adminService.addAssetProfile({
       dataSource,
       symbol,
@@ -410,44 +280,22 @@ export class AdminController {
 
   @Delete('profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async deleteProfileData(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.adminService.deleteProfileData({ dataSource, symbol });
   }
 
   @Patch('profile-data/:dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async patchAssetProfileData(
     @Body() assetProfileData: UpdateAssetProfileDto,
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ): Promise<EnhancedSymbolProfile> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.adminService.patchAssetProfileData({
       ...assetProfileData,
       dataSource,
@@ -457,22 +305,11 @@ export class AdminController {
 
   @Put('settings/:key')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async updateProperty(
     @Param('key') key: string,
     @Body() data: PropertyDto
   ) {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return await this.adminService.putSetting(key, data.value);
   }
 }

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -48,6 +48,7 @@ import { UpdateAssetProfileDto } from './update-asset-profile.dto';
 import { UpdateBulkMarketDataDto } from './update-bulk-market-data.dto';
 import { UpdateMarketDataDto } from './update-market-data.dto';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('admin')
 export class AdminController {
@@ -60,21 +61,21 @@ export class AdminController {
   ) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async getAdminData(): Promise<AdminData> {
     return this.adminService.get();
   }
 
   @Post('gather')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async gather7Days(): Promise<void> {
     this.dataGatheringService.gather7Days();
   }
 
   @Post('gather/max')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async gatherMax(): Promise<void> {
     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
@@ -99,7 +100,7 @@ export class AdminController {
   }
 
   @Post('gather/profile-data')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async gatherProfileData(): Promise<void> {
     const uniqueAssets = await this.dataGatheringService.getUniqueAssets();
@@ -122,7 +123,7 @@ export class AdminController {
   }
 
   @Post('gather/profile-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async gatherProfileDataForSymbol(
     @Param('dataSource') dataSource: DataSource,
@@ -142,7 +143,7 @@ export class AdminController {
   }
 
   @Post('gather/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async gatherSymbol(
     @Param('dataSource') dataSource: DataSource,
@@ -154,7 +155,7 @@ export class AdminController {
   }
 
   @Post('gather/:dataSource/:symbol/:dateString')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async gatherSymbolForDate(
     @Param('dataSource') dataSource: DataSource,
@@ -178,7 +179,7 @@ export class AdminController {
   }
 
   @Get('market-data')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async getMarketData(
     @Query('assetSubClasses') filterByAssetSubClasses?: string,
@@ -205,7 +206,7 @@ export class AdminController {
   }
 
   @Get('market-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async getMarketDataBySymbol(
     @Param('dataSource') dataSource: DataSource,
@@ -215,7 +216,7 @@ export class AdminController {
   }
 
   @Post('market-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async updateMarketData(
     @Body() data: UpdateBulkMarketDataDto,
@@ -241,7 +242,7 @@ export class AdminController {
    * @deprecated
    */
   @Put('market-data/:dataSource/:symbol/:dateString')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async update(
     @Param('dataSource') dataSource: DataSource,
@@ -264,7 +265,7 @@ export class AdminController {
   }
 
   @Post('profile-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async addProfileData(
@@ -279,7 +280,7 @@ export class AdminController {
   }
 
   @Delete('profile-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async deleteProfileData(
     @Param('dataSource') dataSource: DataSource,
@@ -289,7 +290,7 @@ export class AdminController {
   }
 
   @Patch('profile-data/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async patchAssetProfileData(
     @Body() assetProfileData: UpdateAssetProfileDto,
@@ -304,7 +305,7 @@ export class AdminController {
   }
 
   @Put('settings/:key')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async updateProperty(
     @Param('key') key: string,

--- a/apps/api/src/app/admin/queue/queue.controller.ts
+++ b/apps/api/src/app/admin/queue/queue.controller.ts
@@ -1,16 +1,13 @@
 import { AdminJobs } from '@ghostfolio/common/interfaces';
 import { permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Controller,
   Delete,
   Get,
-  Inject,
   Param,
   Query,
   UseGuards
 } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { JobStatus } from 'bull';
 
@@ -19,10 +16,7 @@ import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorat
 
 @Controller('admin/queue')
 export class QueueController {
-  public constructor(
-    private readonly queueService: QueueService,
-    @Inject(REQUEST) private readonly request: RequestWithUser
-  ) {}
+  public constructor(private readonly queueService: QueueService) {}
 
   @Delete('job')
   @UseGuards(AuthGuard('jwt'))

--- a/apps/api/src/app/admin/queue/queue.controller.ts
+++ b/apps/api/src/app/admin/queue/queue.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { AdminJobs } from '@ghostfolio/common/interfaces';
 import { permissions } from '@ghostfolio/common/permissions';
 import {
@@ -12,16 +14,14 @@ import { AuthGuard } from '@nestjs/passport';
 import { JobStatus } from 'bull';
 
 import { QueueService } from './queue.service';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('admin/queue')
 export class QueueController {
   public constructor(private readonly queueService: QueueService) {}
 
   @Delete('job')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteJobs(
     @Query('status') filterByStatus?: string
   ): Promise<void> {
@@ -30,8 +30,8 @@ export class QueueController {
   }
 
   @Get('job')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getJobs(
     @Query('status') filterByStatus?: string
   ): Promise<AdminJobs> {
@@ -40,8 +40,8 @@ export class QueueController {
   }
 
   @Delete('job/:id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteJob(@Param('id') id: string): Promise<void> {
     return this.queueService.deleteJob(id);
   }

--- a/apps/api/src/app/admin/queue/queue.controller.ts
+++ b/apps/api/src/app/admin/queue/queue.controller.ts
@@ -13,13 +13,14 @@ import { JobStatus } from 'bull';
 
 import { QueueService } from './queue.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('admin/queue')
 export class QueueController {
   public constructor(private readonly queueService: QueueService) {}
 
   @Delete('job')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async deleteJobs(
     @Query('status') filterByStatus?: string
@@ -29,7 +30,7 @@ export class QueueController {
   }
 
   @Get('job')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async getJobs(
     @Query('status') filterByStatus?: string
@@ -39,7 +40,7 @@ export class QueueController {
   }
 
   @Delete('job/:id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async deleteJob(@Param('id') id: string): Promise<void> {
     return this.queueService.deleteJob(id);

--- a/apps/api/src/app/admin/queue/queue.controller.ts
+++ b/apps/api/src/app/admin/queue/queue.controller.ts
@@ -1,11 +1,10 @@
 import { AdminJobs } from '@ghostfolio/common/interfaces';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Controller,
   Delete,
   Get,
-  HttpException,
   Inject,
   Param,
   Query,
@@ -14,9 +13,9 @@ import {
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { JobStatus } from 'bull';
-import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { QueueService } from './queue.service';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('admin/queue')
 export class QueueController {
@@ -27,61 +26,28 @@ export class QueueController {
 
   @Delete('job')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async deleteJobs(
     @Query('status') filterByStatus?: string
   ): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const status = <JobStatus[]>filterByStatus?.split(',') ?? undefined;
     return this.queueService.deleteJobs({ status });
   }
 
   @Get('job')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async getJobs(
     @Query('status') filterByStatus?: string
   ): Promise<AdminJobs> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const status = <JobStatus[]>filterByStatus?.split(',') ?? undefined;
     return this.queueService.getJobs({ status });
   }
 
   @Delete('job/:id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async deleteJob(@Param('id') id: string): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.queueService.deleteJob(id);
   }
 }

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -41,8 +41,6 @@ import { SubscriptionModule } from './subscription/subscription.module';
 import { SymbolModule } from './symbol/symbol.module';
 import { TagModule } from './tag/tag.module';
 import { UserModule } from './user/user.module';
-import { APP_GUARD } from '@nestjs/core';
-import { HasPermissionGuard } from '../guards/has-permission.guard';
 
 @Module({
   imports: [

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -93,7 +93,7 @@ import { HasPermissionGuard } from '../guards/has-permission.guard';
               if (SUPPORTED_LANGUAGE_CODES.includes(code)) {
                 languageCode = code;
               }
-            } catch { }
+            } catch {}
 
             res.set('Location', `/${languageCode}`);
             res.statusCode = StatusCodes.MOVED_PERMANENTLY;
@@ -117,4 +117,4 @@ import { HasPermissionGuard } from '../guards/has-permission.guard';
     }
   ]
 })
-export class AppModule { }
+export class AppModule {}

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -41,6 +41,8 @@ import { SubscriptionModule } from './subscription/subscription.module';
 import { SymbolModule } from './symbol/symbol.module';
 import { TagModule } from './tag/tag.module';
 import { UserModule } from './user/user.module';
+import { APP_GUARD } from '@nestjs/core';
+import { HasPermissionGuard } from '../guards/has-permission.guard';
 
 @Module({
   imports: [
@@ -91,7 +93,7 @@ import { UserModule } from './user/user.module';
               if (SUPPORTED_LANGUAGE_CODES.includes(code)) {
                 languageCode = code;
               }
-            } catch {}
+            } catch { }
 
             res.set('Location', `/${languageCode}`);
             res.statusCode = StatusCodes.MOVED_PERMANENTLY;
@@ -107,6 +109,12 @@ import { UserModule } from './user/user.module';
     UserModule
   ],
   controllers: [AppController],
-  providers: [CronService]
+  providers: [
+    CronService,
+    {
+      provide: APP_GUARD,
+      useClass: HasPermissionGuard
+    }
+  ]
 })
-export class AppModule {}
+export class AppModule { }

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -109,12 +109,6 @@ import { HasPermissionGuard } from '../guards/has-permission.guard';
     UserModule
   ],
   controllers: [AppController],
-  providers: [
-    CronService,
-    {
-      provide: APP_GUARD,
-      useClass: HasPermissionGuard
-    }
-  ]
+  providers: [CronService]
 })
 export class AppModule {}

--- a/apps/api/src/app/auth-device/auth-device.controller.ts
+++ b/apps/api/src/app/auth-device/auth-device.controller.ts
@@ -2,13 +2,7 @@ import { AuthDeviceService } from '@ghostfolio/api/app/auth-device/auth-device.s
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
-import {
-  Controller,
-  Delete,
-  Inject,
-  Param,
-  UseGuards
-} from '@nestjs/common';
+import { Controller, Delete, Inject, Param, UseGuards } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 

--- a/apps/api/src/app/auth-device/auth-device.controller.ts
+++ b/apps/api/src/app/auth-device/auth-device.controller.ts
@@ -1,17 +1,16 @@
 import { AuthDeviceService } from '@ghostfolio/api/app/auth-device/auth-device.service';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Controller,
   Delete,
-  HttpException,
   Inject,
   Param,
   UseGuards
 } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 @Controller('auth-device')
 export class AuthDeviceController {
@@ -22,19 +21,8 @@ export class AuthDeviceController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteAuthDevice)
   public async deleteAuthDevice(@Param('id') id: string): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.deleteAuthDevice
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     await this.authDeviceService.deleteAuthDevice({ id });
   }
 }

--- a/apps/api/src/app/auth-device/auth-device.controller.ts
+++ b/apps/api/src/app/auth-device/auth-device.controller.ts
@@ -1,17 +1,12 @@
 import { AuthDeviceService } from '@ghostfolio/api/app/auth-device/auth-device.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 import { permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
-import { Controller, Delete, Inject, Param, UseGuards } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
+import { Controller, Delete, Param, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Controller('auth-device')
 export class AuthDeviceController {
-  public constructor(
-    private readonly authDeviceService: AuthDeviceService,
-    @Inject(REQUEST) private readonly request: RequestWithUser
-  ) {}
+  public constructor(private readonly authDeviceService: AuthDeviceService) {}
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))

--- a/apps/api/src/app/auth-device/auth-device.controller.ts
+++ b/apps/api/src/app/auth-device/auth-device.controller.ts
@@ -1,5 +1,6 @@
 import { AuthDeviceService } from '@ghostfolio/api/app/auth-device/auth-device.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { permissions } from '@ghostfolio/common/permissions';
 import { Controller, Delete, Param, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
@@ -9,7 +10,7 @@ export class AuthDeviceController {
   public constructor(private readonly authDeviceService: AuthDeviceService) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAuthDevice)
   public async deleteAuthDevice(@Param('id') id: string): Promise<void> {
     await this.authDeviceService.deleteAuthDevice({ id });

--- a/apps/api/src/app/auth-device/auth-device.controller.ts
+++ b/apps/api/src/app/auth-device/auth-device.controller.ts
@@ -10,8 +10,8 @@ export class AuthDeviceController {
   public constructor(private readonly authDeviceService: AuthDeviceService) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteAuthDevice)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteAuthDevice(@Param('id') id: string): Promise<void> {
     await this.authDeviceService.deleteAuthDevice({ id });
   }

--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import { WebAuthService } from '@ghostfolio/api/app/auth/web-auth.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
 import { DEFAULT_LANGUAGE_CODE } from '@ghostfolio/common/config';
 import { OAuthResponse } from '@ghostfolio/common/interfaces';
@@ -24,7 +25,6 @@ import {
   AssertionCredentialJSON,
   AttestationCredentialJSON
 } from './interfaces/simplewebauthn';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('auth')
 export class AuthController {

--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import {
   AssertionCredentialJSON,
   AttestationCredentialJSON
 } from './interfaces/simplewebauthn';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -118,13 +119,13 @@ export class AuthController {
   }
 
   @Get('webauthn/generate-registration-options')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async generateRegistrationOptions() {
     return this.webAuthService.generateRegistrationOptions();
   }
 
   @Post('webauthn/verify-attestation')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async verifyAttestation(
     @Body() body: { deviceName: string; credential: AttestationCredentialJSON }
   ) {

--- a/apps/api/src/app/benchmark/benchmark.controller.ts
+++ b/apps/api/src/app/benchmark/benchmark.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { TransformDataSourceInRequestInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-request.interceptor';
 import { TransformDataSourceInResponseInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-response.interceptor';
 import type {
@@ -23,16 +25,14 @@ import { DataSource } from '@prisma/client';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { BenchmarkService } from './benchmark.service';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('benchmark')
 export class BenchmarkController {
   public constructor(private readonly benchmarkService: BenchmarkService) {}
 
+  @HasPermission(permissions.accessAdminControl)
   @Post()
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async addBenchmark(@Body() { dataSource, symbol }: UniqueAsset) {
     try {
       const benchmark = await this.benchmarkService.addBenchmark({
@@ -57,8 +57,8 @@ export class BenchmarkController {
   }
 
   @Delete(':dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteBenchmark(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string

--- a/apps/api/src/app/benchmark/benchmark.controller.ts
+++ b/apps/api/src/app/benchmark/benchmark.controller.ts
@@ -24,13 +24,14 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { BenchmarkService } from './benchmark.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('benchmark')
 export class BenchmarkController {
   public constructor(private readonly benchmarkService: BenchmarkService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async addBenchmark(@Body() { dataSource, symbol }: UniqueAsset) {
     try {
@@ -56,7 +57,7 @@ export class BenchmarkController {
   }
 
   @Delete(':dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async deleteBenchmark(
     @Param('dataSource') dataSource: DataSource,

--- a/apps/api/src/app/benchmark/benchmark.controller.ts
+++ b/apps/api/src/app/benchmark/benchmark.controller.ts
@@ -6,7 +6,6 @@ import type {
   UniqueAsset
 } from '@ghostfolio/common/interfaces';
 import { permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Body,
   Controller,
@@ -19,7 +18,6 @@ import {
   UseGuards,
   UseInterceptors
 } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { DataSource } from '@prisma/client';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
@@ -29,10 +27,7 @@ import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorat
 
 @Controller('benchmark')
 export class BenchmarkController {
-  public constructor(
-    private readonly benchmarkService: BenchmarkService,
-    @Inject(REQUEST) private readonly request: RequestWithUser
-  ) {}
+  public constructor(private readonly benchmarkService: BenchmarkService) {}
 
   @Post()
   @UseGuards(AuthGuard('jwt'))

--- a/apps/api/src/app/benchmark/benchmark.controller.ts
+++ b/apps/api/src/app/benchmark/benchmark.controller.ts
@@ -95,7 +95,7 @@ export class BenchmarkController {
   }
 
   @Get(':dataSource/:symbol/:startDateString')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async getBenchmarkMarketDataBySymbol(
     @Param('dataSource') dataSource: DataSource,

--- a/apps/api/src/app/benchmark/benchmark.controller.ts
+++ b/apps/api/src/app/benchmark/benchmark.controller.ts
@@ -5,7 +5,7 @@ import type {
   BenchmarkResponse,
   UniqueAsset
 } from '@ghostfolio/common/interfaces';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Body,
@@ -25,6 +25,7 @@ import { DataSource } from '@prisma/client';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { BenchmarkService } from './benchmark.service';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('benchmark')
 export class BenchmarkController {
@@ -35,19 +36,8 @@ export class BenchmarkController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async addBenchmark(@Body() { dataSource, symbol }: UniqueAsset) {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     try {
       const benchmark = await this.benchmarkService.addBenchmark({
         dataSource,
@@ -62,7 +52,7 @@ export class BenchmarkController {
       }
 
       return benchmark;
-    } catch {
+    } catch  {
       throw new HttpException(
         getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR),
         StatusCodes.INTERNAL_SERVER_ERROR
@@ -72,22 +62,11 @@ export class BenchmarkController {
 
   @Delete(':dataSource/:symbol')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.accessAdminControl)
   public async deleteBenchmark(
     @Param('dataSource') dataSource: DataSource,
     @Param('symbol') symbol: string
   ) {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     try {
       const benchmark = await this.benchmarkService.deleteBenchmark({
         dataSource,

--- a/apps/api/src/app/benchmark/benchmark.controller.ts
+++ b/apps/api/src/app/benchmark/benchmark.controller.ts
@@ -52,7 +52,7 @@ export class BenchmarkController {
       }
 
       return benchmark;
-    } catch  {
+    } catch {
       throw new HttpException(
         getReasonPhrase(StatusCodes.INTERNAL_SERVER_ERROR),
         StatusCodes.INTERNAL_SERVER_ERROR

--- a/apps/api/src/app/cache/cache.controller.ts
+++ b/apps/api/src/app/cache/cache.controller.ts
@@ -1,39 +1,29 @@
 import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.service';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Controller,
-  HttpException,
   Inject,
   Post,
   UseGuards
 } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 @Controller('cache')
+
 export class CacheController {
   public constructor(
-    private readonly redisCacheService: RedisCacheService,
-    @Inject(REQUEST) private readonly request: RequestWithUser
-  ) {}
+  private readonly redisCacheService: RedisCacheService,
+     @Inject(REQUEST) private readonly request: RequestWithUser
+  ) { }
 
   @Post('flush')
   @UseGuards(AuthGuard('jwt'))
-  public async flushCache(): Promise<void> {
-    if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.accessAdminControl
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
+  @HasPermission(permissions.accessAdminControl) // permission needed
 
+  public async flushCache(): Promise<void> {
     return this.redisCacheService.reset();
   }
 }

--- a/apps/api/src/app/cache/cache.controller.ts
+++ b/apps/api/src/app/cache/cache.controller.ts
@@ -9,9 +9,9 @@ import { AuthGuard } from '@nestjs/passport';
 export class CacheController {
   public constructor(private readonly redisCacheService: RedisCacheService) {}
 
+  @HasPermission(permissions.accessAdminControl)
   @Post('flush')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.accessAdminControl)
   public async flushCache(): Promise<void> {
     return this.redisCacheService.reset();
   }

--- a/apps/api/src/app/cache/cache.controller.ts
+++ b/apps/api/src/app/cache/cache.controller.ts
@@ -1,5 +1,6 @@
 import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { permissions } from '@ghostfolio/common/permissions';
 import { Controller, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
@@ -9,7 +10,7 @@ export class CacheController {
   public constructor(private readonly redisCacheService: RedisCacheService) {}
 
   @Post('flush')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.accessAdminControl)
   public async flushCache(): Promise<void> {
     return this.redisCacheService.reset();

--- a/apps/api/src/app/cache/cache.controller.ts
+++ b/apps/api/src/app/cache/cache.controller.ts
@@ -2,27 +2,20 @@ import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.s
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
-import {
-  Controller,
-  Inject,
-  Post,
-  UseGuards
-} from '@nestjs/common';
+import { Controller, Inject, Post, UseGuards } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 
 @Controller('cache')
-
 export class CacheController {
   public constructor(
-  private readonly redisCacheService: RedisCacheService,
-     @Inject(REQUEST) private readonly request: RequestWithUser
-  ) { }
+    private readonly redisCacheService: RedisCacheService,
+    @Inject(REQUEST) private readonly request: RequestWithUser
+  ) {}
 
   @Post('flush')
   @UseGuards(AuthGuard('jwt'))
   @HasPermission(permissions.accessAdminControl) // permission needed
-
   public async flushCache(): Promise<void> {
     return this.redisCacheService.reset();
   }

--- a/apps/api/src/app/cache/cache.controller.ts
+++ b/apps/api/src/app/cache/cache.controller.ts
@@ -1,21 +1,16 @@
 import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 import { permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
-import { Controller, Inject, Post, UseGuards } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
+import { Controller, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Controller('cache')
 export class CacheController {
-  public constructor(
-    private readonly redisCacheService: RedisCacheService,
-    @Inject(REQUEST) private readonly request: RequestWithUser
-  ) {}
+  public constructor(private readonly redisCacheService: RedisCacheService) {}
 
   @Post('flush')
   @UseGuards(AuthGuard('jwt'))
-  @HasPermission(permissions.accessAdminControl) // permission needed
+  @HasPermission(permissions.accessAdminControl)
   public async flushCache(): Promise<void> {
     return this.redisCacheService.reset();
   }

--- a/apps/api/src/app/exchange-rate/exchange-rate.controller.ts
+++ b/apps/api/src/app/exchange-rate/exchange-rate.controller.ts
@@ -11,6 +11,7 @@ import { parseISO } from 'date-fns';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { ExchangeRateService } from './exchange-rate.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('exchange-rate')
 export class ExchangeRateController {
@@ -19,7 +20,7 @@ export class ExchangeRateController {
   ) {}
 
   @Get(':symbol/:dateString')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getExchangeRate(
     @Param('dateString') dateString: string,
     @Param('symbol') symbol: string

--- a/apps/api/src/app/exchange-rate/exchange-rate.controller.ts
+++ b/apps/api/src/app/exchange-rate/exchange-rate.controller.ts
@@ -1,3 +1,4 @@
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { IDataProviderHistoricalResponse } from '@ghostfolio/api/services/interfaces/interfaces';
 import {
   Controller,
@@ -11,7 +12,6 @@ import { parseISO } from 'date-fns';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { ExchangeRateService } from './exchange-rate.service';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('exchange-rate')
 export class ExchangeRateController {

--- a/apps/api/src/app/export/export.controller.ts
+++ b/apps/api/src/app/export/export.controller.ts
@@ -5,6 +5,7 @@ import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 
 import { ExportService } from './export.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('export')
 export class ExportController {

--- a/apps/api/src/app/export/export.controller.ts
+++ b/apps/api/src/app/export/export.controller.ts
@@ -1,3 +1,4 @@
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { Export } from '@ghostfolio/common/interfaces';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import { Controller, Get, Inject, Query, UseGuards } from '@nestjs/common';
@@ -5,7 +6,6 @@ import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 
 import { ExportService } from './export.service';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('export')
 export class ExportController {

--- a/apps/api/src/app/export/export.controller.ts
+++ b/apps/api/src/app/export/export.controller.ts
@@ -15,7 +15,7 @@ export class ExportController {
   ) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async export(
     @Query('activityIds') activityIds?: string[]
   ): Promise<Export> {

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -36,7 +36,7 @@ export class ImportController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
-  @HasPermission(permissions.createAccount)
+  @HasPermission(permissions.createOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async import(
@@ -44,7 +44,7 @@ export class ImportController {
     @Query('dryRun') isDryRun?: boolean
   ): Promise<ImportResponse> {
     if (
-      !hasPermission(this.request.user.permissions, permissions.createOrder)
+      !hasPermission(this.request.user.permissions, permissions.createAccount)
     ) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -25,6 +25,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { ImportDataDto } from './import-data.dto';
 import { ImportService } from './import.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('import')
 export class ImportController {
@@ -35,7 +36,7 @@ export class ImportController {
   ) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { TransformDataSourceInRequestInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-request.interceptor';
 import { TransformDataSourceInResponseInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-response.interceptor';
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
@@ -24,8 +26,6 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { ImportDataDto } from './import-data.dto';
 import { ImportService } from './import.service';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('import')
 export class ImportController {

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -91,7 +91,7 @@ export class ImportController {
   }
 
   @Get('dividends/:dataSource/:symbol')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async gatherDividends(

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -24,6 +24,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { ImportDataDto } from './import-data.dto';
 import { ImportService } from './import.service';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('import')
 export class ImportController {
@@ -35,6 +36,7 @@ export class ImportController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.createAccount)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async import(
@@ -42,10 +44,6 @@ export class ImportController {
     @Query('dryRun') isDryRun?: boolean
   ): Promise<ImportResponse> {
     if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.createAccount
-      ) ||
       !hasPermission(this.request.user.permissions, permissions.createOrder)
     ) {
       throw new HttpException(

--- a/apps/api/src/app/order/order.controller.ts
+++ b/apps/api/src/app/order/order.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { RedactValuesInResponseInterceptor } from '@ghostfolio/api/interceptors/redact-values-in-response.interceptor';
 import { TransformDataSourceInRequestInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-request.interceptor';
 import { TransformDataSourceInResponseInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-response.interceptor';
@@ -32,8 +34,6 @@ import { CreateOrderDto } from './create-order.dto';
 import { Activities } from './interfaces/activities.interface';
 import { OrderService } from './order.service';
 import { UpdateOrderDto } from './update-order.dto';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('order')
 export class OrderController {
@@ -46,8 +46,8 @@ export class OrderController {
   ) {}
 
   @Delete()
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteOrder)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteOrders(): Promise<number> {
     return this.orderService.deleteOrders({
       userId: this.request.user.id
@@ -114,9 +114,9 @@ export class OrderController {
     return { activities, count };
   }
 
+  @HasPermission(permissions.createOrder)
   @Post()
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.createOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async createOrder(@Body() data: CreateOrderDto): Promise<OrderModel> {
     const order = await this.orderService.createOrder({
@@ -156,9 +156,9 @@ export class OrderController {
     return order;
   }
 
+  @HasPermission(permissions.updateOrder)
   @Put(':id')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.updateOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async update(@Param('id') id: string, @Body() data: UpdateOrderDto) {
     const originalOrder = await this.orderService.order({

--- a/apps/api/src/app/order/order.controller.ts
+++ b/apps/api/src/app/order/order.controller.ts
@@ -33,6 +33,7 @@ import { Activities } from './interfaces/activities.interface';
 import { OrderService } from './order.service';
 import { UpdateOrderDto } from './update-order.dto';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('order')
 export class OrderController {
@@ -45,7 +46,7 @@ export class OrderController {
   ) {}
 
   @Delete()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteOrder)
   public async deleteOrders(): Promise<number> {
     return this.orderService.deleteOrders({
@@ -114,7 +115,7 @@ export class OrderController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async createOrder(@Body() data: CreateOrderDto): Promise<OrderModel> {
@@ -156,7 +157,7 @@ export class OrderController {
   }
 
   @Put(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.updateOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async update(@Param('id') id: string, @Body() data: UpdateOrderDto) {

--- a/apps/api/src/app/order/order.controller.ts
+++ b/apps/api/src/app/order/order.controller.ts
@@ -32,6 +32,7 @@ import { CreateOrderDto } from './create-order.dto';
 import { Activities } from './interfaces/activities.interface';
 import { OrderService } from './order.service';
 import { UpdateOrderDto } from './update-order.dto';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('order')
 export class OrderController {
@@ -45,16 +46,8 @@ export class OrderController {
 
   @Delete()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteOrder)
   public async deleteOrders(): Promise<number> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.deleteOrder)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.orderService.deleteOrders({
       userId: this.request.user.id
     });
@@ -122,17 +115,9 @@ export class OrderController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.createOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async createOrder(@Body() data: CreateOrderDto): Promise<OrderModel> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.createOrder)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const order = await this.orderService.createOrder({
       ...data,
       date: parseISO(data.date),
@@ -172,6 +157,7 @@ export class OrderController {
 
   @Put(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.updateOrder)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   public async update(@Param('id') id: string, @Body() data: UpdateOrderDto) {
     const originalOrder = await this.orderService.order({
@@ -179,7 +165,6 @@ export class OrderController {
     });
 
     if (
-      !hasPermission(this.request.user.permissions, permissions.updateOrder) ||
       !originalOrder ||
       originalOrder.userId !== this.request.user.id
     ) {

--- a/apps/api/src/app/order/order.controller.ts
+++ b/apps/api/src/app/order/order.controller.ts
@@ -164,10 +164,7 @@ export class OrderController {
       id
     });
 
-    if (
-      !originalOrder ||
-      originalOrder.userId !== this.request.user.id
-    ) {
+    if (!originalOrder || originalOrder.userId !== this.request.user.id) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
         StatusCodes.FORBIDDEN

--- a/apps/api/src/app/order/order.controller.ts
+++ b/apps/api/src/app/order/order.controller.ts
@@ -55,7 +55,7 @@ export class OrderController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteOrder(@Param('id') id: string): Promise<OrderModel> {
     const order = await this.orderService.order({ id });
 
@@ -76,7 +76,7 @@ export class OrderController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(RedactValuesInResponseInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async getAllOrders(

--- a/apps/api/src/app/platform/platform.controller.ts
+++ b/apps/api/src/app/platform/platform.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { permissions } from '@ghostfolio/common/permissions';
 import {
   Body,
@@ -17,8 +19,6 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { CreatePlatformDto } from './create-platform.dto';
 import { PlatformService } from './platform.service';
 import { UpdatePlatformDto } from './update-platform.dto';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('platform')
 export class PlatformController {
@@ -30,18 +30,18 @@ export class PlatformController {
     return this.platformService.getPlatformsWithAccountCount();
   }
 
+  @HasPermission(permissions.createPlatform)
   @Post()
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.createPlatform)
   public async createPlatform(
     @Body() data: CreatePlatformDto
   ): Promise<Platform> {
     return this.platformService.createPlatform(data);
   }
 
+  @HasPermission(permissions.updatePlatform)
   @Put(':id')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.updatePlatform)
   public async updatePlatform(
     @Param('id') id: string,
     @Body() data: UpdatePlatformDto
@@ -68,8 +68,8 @@ export class PlatformController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deletePlatform)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deletePlatform(@Param('id') id: string) {
     const originalPlatform = await this.platformService.getPlatform({
       id

--- a/apps/api/src/app/platform/platform.controller.ts
+++ b/apps/api/src/app/platform/platform.controller.ts
@@ -18,6 +18,7 @@ import { CreatePlatformDto } from './create-platform.dto';
 import { PlatformService } from './platform.service';
 import { UpdatePlatformDto } from './update-platform.dto';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('platform')
 export class PlatformController {
@@ -30,7 +31,7 @@ export class PlatformController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createPlatform)
   public async createPlatform(
     @Body() data: CreatePlatformDto
@@ -39,7 +40,7 @@ export class PlatformController {
   }
 
   @Put(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.updatePlatform)
   public async updatePlatform(
     @Param('id') id: string,
@@ -67,7 +68,7 @@ export class PlatformController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deletePlatform)
   public async deletePlatform(@Param('id') id: string) {
     const originalPlatform = await this.platformService.getPlatform({

--- a/apps/api/src/app/platform/platform.controller.ts
+++ b/apps/api/src/app/platform/platform.controller.ts
@@ -25,7 +25,7 @@ export class PlatformController {
   public constructor(private readonly platformService: PlatformService) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getPlatforms() {
     return this.platformService.getPlatformsWithAccountCount();
   }

--- a/apps/api/src/app/platform/platform.controller.ts
+++ b/apps/api/src/app/platform/platform.controller.ts
@@ -1,18 +1,15 @@
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
+import { permissions } from '@ghostfolio/common/permissions';
 import {
   Body,
   Controller,
   Delete,
   Get,
   HttpException,
-  Inject,
   Param,
   Post,
   Put,
   UseGuards
 } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Platform } from '@prisma/client';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
@@ -24,10 +21,7 @@ import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorat
 
 @Controller('platform')
 export class PlatformController {
-  public constructor(
-    private readonly platformService: PlatformService,
-    @Inject(REQUEST) private readonly request: RequestWithUser
-  ) {}
+  public constructor(private readonly platformService: PlatformService) {}
 
   @Get()
   @UseGuards(AuthGuard('jwt'))

--- a/apps/api/src/app/platform/platform.controller.ts
+++ b/apps/api/src/app/platform/platform.controller.ts
@@ -20,6 +20,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { CreatePlatformDto } from './create-platform.dto';
 import { PlatformService } from './platform.service';
 import { UpdatePlatformDto } from './update-platform.dto';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('platform')
 export class PlatformController {
@@ -36,36 +37,20 @@ export class PlatformController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.createPlatform)
   public async createPlatform(
     @Body() data: CreatePlatformDto
   ): Promise<Platform> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.createPlatform)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.platformService.createPlatform(data);
   }
 
   @Put(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.updatePlatform)
   public async updatePlatform(
     @Param('id') id: string,
     @Body() data: UpdatePlatformDto
   ) {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.updatePlatform)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const originalPlatform = await this.platformService.getPlatform({
       id
     });
@@ -89,16 +74,8 @@ export class PlatformController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deletePlatform)
   public async deletePlatform(@Param('id') id: string) {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.deletePlatform)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const originalPlatform = await this.platformService.getPlatform({
       id
     });

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -47,6 +47,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { PortfolioPositionDetail } from './interfaces/portfolio-position-detail.interface';
 import { PortfolioPositions } from './interfaces/portfolio-positions.interface';
 import { PortfolioService } from './portfolio.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('portfolio')
 export class PortfolioController {
@@ -61,7 +62,7 @@ export class PortfolioController {
   ) {}
 
   @Get('details')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(RedactValuesInResponseInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async getDetails(
@@ -204,7 +205,7 @@ export class PortfolioController {
   }
 
   @Get('dividends')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getDividends(
     @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId: string,
     @Query('accounts') filterByAccounts?: string,
@@ -254,7 +255,7 @@ export class PortfolioController {
   }
 
   @Get('investments')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getInvestments(
     @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId: string,
     @Query('accounts') filterByAccounts?: string,
@@ -315,7 +316,7 @@ export class PortfolioController {
   }
 
   @Get('performance')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   @Version('2')
   public async getPerformanceV2(
@@ -405,7 +406,7 @@ export class PortfolioController {
   }
 
   @Get('positions')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(RedactValuesInResponseInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async getPositions(
@@ -500,7 +501,7 @@ export class PortfolioController {
   @UseInterceptors(RedactValuesInResponseInterceptor)
   @UseInterceptors(TransformDataSourceInRequestInterceptor)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getPosition(
     @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId: string,
     @Param('dataSource') dataSource,
@@ -523,7 +524,7 @@ export class PortfolioController {
   }
 
   @Get('report')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getReport(
     @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId: string
   ): Promise<PortfolioReport> {

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -1,5 +1,6 @@
 import { AccessService } from '@ghostfolio/api/app/access/access.service';
 import { UserService } from '@ghostfolio/api/app/user/user.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import {
   hasNotDefinedValuesInObject,
   nullifyValuesInObject
@@ -47,7 +48,6 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { PortfolioPositionDetail } from './interfaces/portfolio-position-detail.interface';
 import { PortfolioPositions } from './interfaces/portfolio-positions.interface';
 import { PortfolioService } from './portfolio.service';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('portfolio')
 export class PortfolioController {

--- a/apps/api/src/app/subscription/subscription.controller.ts
+++ b/apps/api/src/app/subscription/subscription.controller.ts
@@ -1,3 +1,4 @@
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
 import {
@@ -25,7 +26,6 @@ import { Request, Response } from 'express';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { SubscriptionService } from './subscription.service';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('subscription')
 export class SubscriptionController {

--- a/apps/api/src/app/subscription/subscription.controller.ts
+++ b/apps/api/src/app/subscription/subscription.controller.ts
@@ -25,6 +25,7 @@ import { Request, Response } from 'express';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { SubscriptionService } from './subscription.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('subscription')
 export class SubscriptionController {
@@ -37,7 +38,7 @@ export class SubscriptionController {
 
   @Post('redeem-coupon')
   @HttpCode(StatusCodes.OK)
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async redeemCoupon(@Body() { couponCode }: { couponCode: string }) {
     if (!this.request.user) {
       throw new HttpException(
@@ -109,7 +110,7 @@ export class SubscriptionController {
   }
 
   @Post('stripe/checkout-session')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async createCheckoutSession(
     @Body() { couponId, priceId }: { couponId: string; priceId: string }
   ) {

--- a/apps/api/src/app/symbol/symbol.controller.ts
+++ b/apps/api/src/app/symbol/symbol.controller.ts
@@ -1,3 +1,4 @@
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { TransformDataSourceInRequestInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-request.interceptor';
 import { TransformDataSourceInResponseInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-response.interceptor';
 import { IDataProviderHistoricalResponse } from '@ghostfolio/api/services/interfaces/interfaces';
@@ -22,7 +23,6 @@ import { isDate, isEmpty } from 'lodash';
 import { LookupItem } from './interfaces/lookup-item.interface';
 import { SymbolItem } from './interfaces/symbol-item.interface';
 import { SymbolService } from './symbol.service';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('symbol')
 export class SymbolController {

--- a/apps/api/src/app/symbol/symbol.controller.ts
+++ b/apps/api/src/app/symbol/symbol.controller.ts
@@ -22,6 +22,7 @@ import { isDate, isEmpty } from 'lodash';
 import { LookupItem } from './interfaces/lookup-item.interface';
 import { SymbolItem } from './interfaces/symbol-item.interface';
 import { SymbolService } from './symbol.service';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('symbol')
 export class SymbolController {
@@ -34,7 +35,7 @@ export class SymbolController {
    * Must be before /:symbol
    */
   @Get('lookup')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @UseInterceptors(TransformDataSourceInResponseInterceptor)
   public async lookupSymbol(
     @Query('includeIndices') includeIndices: boolean = false,
@@ -88,7 +89,7 @@ export class SymbolController {
   }
 
   @Get(':dataSource/:symbol/:dateString')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async gatherSymbolForDate(
     @Param('dataSource') dataSource: DataSource,
     @Param('dateString') dateString: string,

--- a/apps/api/src/app/tag/tag.controller.ts
+++ b/apps/api/src/app/tag/tag.controller.ts
@@ -1,18 +1,15 @@
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
-import type { RequestWithUser } from '@ghostfolio/common/types';
+import { permissions } from '@ghostfolio/common/permissions';
 import {
   Body,
   Controller,
   Delete,
   Get,
   HttpException,
-  Inject,
   Param,
   Post,
   Put,
   UseGuards
 } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Tag } from '@prisma/client';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
@@ -24,10 +21,7 @@ import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorat
 
 @Controller('tag')
 export class TagController {
-  public constructor(
-    @Inject(REQUEST) private readonly request: RequestWithUser,
-    private readonly tagService: TagService
-  ) {}
+  public constructor(private readonly tagService: TagService) {}
 
   @Get()
   @UseGuards(AuthGuard('jwt'))

--- a/apps/api/src/app/tag/tag.controller.ts
+++ b/apps/api/src/app/tag/tag.controller.ts
@@ -25,7 +25,7 @@ export class TagController {
   public constructor(private readonly tagService: TagService) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getTags() {
     return this.tagService.getTagsWithActivityCount();
   }

--- a/apps/api/src/app/tag/tag.controller.ts
+++ b/apps/api/src/app/tag/tag.controller.ts
@@ -18,6 +18,7 @@ import { CreateTagDto } from './create-tag.dto';
 import { TagService } from './tag.service';
 import { UpdateTagDto } from './update-tag.dto';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('tag')
 export class TagController {
@@ -30,14 +31,14 @@ export class TagController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createTag)
   public async createTag(@Body() data: CreateTagDto): Promise<Tag> {
     return this.tagService.createTag(data);
   }
 
   @Put(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.updateTag)
   public async updateTag(@Param('id') id: string, @Body() data: UpdateTagDto) {
     const originalTag = await this.tagService.getTag({
@@ -62,7 +63,7 @@ export class TagController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteTag)
   public async deleteTag(@Param('id') id: string) {
     const originalTag = await this.tagService.getTag({

--- a/apps/api/src/app/tag/tag.controller.ts
+++ b/apps/api/src/app/tag/tag.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { permissions } from '@ghostfolio/common/permissions';
 import {
   Body,
@@ -17,8 +19,6 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { CreateTagDto } from './create-tag.dto';
 import { TagService } from './tag.service';
 import { UpdateTagDto } from './update-tag.dto';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('tag')
 export class TagController {
@@ -31,15 +31,15 @@ export class TagController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.createTag)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async createTag(@Body() data: CreateTagDto): Promise<Tag> {
     return this.tagService.createTag(data);
   }
 
+  @HasPermission(permissions.updateTag)
   @Put(':id')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
-  @HasPermission(permissions.updateTag)
   public async updateTag(@Param('id') id: string, @Body() data: UpdateTagDto) {
     const originalTag = await this.tagService.getTag({
       id
@@ -63,8 +63,8 @@ export class TagController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteTag)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteTag(@Param('id') id: string) {
     const originalTag = await this.tagService.getTag({
       id

--- a/apps/api/src/app/tag/tag.controller.ts
+++ b/apps/api/src/app/tag/tag.controller.ts
@@ -20,6 +20,7 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { CreateTagDto } from './create-tag.dto';
 import { TagService } from './tag.service';
 import { UpdateTagDto } from './update-tag.dto';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('tag')
 export class TagController {
@@ -36,27 +37,15 @@ export class TagController {
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.createTag)
   public async createTag(@Body() data: CreateTagDto): Promise<Tag> {
-    if (!hasPermission(this.request.user.permissions, permissions.createTag)) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     return this.tagService.createTag(data);
   }
 
   @Put(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.updateTag)
   public async updateTag(@Param('id') id: string, @Body() data: UpdateTagDto) {
-    if (!hasPermission(this.request.user.permissions, permissions.updateTag)) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const originalTag = await this.tagService.getTag({
       id
     });
@@ -80,14 +69,8 @@ export class TagController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteTag)
   public async deleteTag(@Param('id') id: string) {
-    if (!hasPermission(this.request.user.permissions, permissions.deleteTag)) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     const originalTag = await this.tagService.getTag({
       id
     });

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -1,6 +1,6 @@
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
 import { User, UserSettings } from '@ghostfolio/common/interfaces';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Body,
@@ -25,6 +25,7 @@ import { size } from 'lodash';
 import { UserItem } from './interfaces/user-item.interface';
 import { UpdateUserSettingDto } from './update-user-setting.dto';
 import { UserService } from './user.service';
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 
 @Controller('user')
 export class UserController {
@@ -37,10 +38,9 @@ export class UserController {
 
   @Delete(':id')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.deleteUser)
   public async deleteUser(@Param('id') id: string): Promise<UserModel> {
-    if (
-      !hasPermission(this.request.user.permissions, permissions.deleteUser) ||
-      id === this.request.user.id
+    if (id === this.request.user.id
     ) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
@@ -93,6 +93,7 @@ export class UserController {
 
   @Put('setting')
   @UseGuards(AuthGuard('jwt'))
+  @HasPermission(permissions.updateUserSettings)
   public async updateUserSetting(@Body() data: UpdateUserSettingDto) {
     if (
       size(data) === 1 &&
@@ -100,16 +101,6 @@ export class UserController {
       this.request.user.role === 'DEMO'
     ) {
       // Allow benchmark or date range change for demo user
-    } else if (
-      !hasPermission(
-        this.request.user.permissions,
-        permissions.updateUserSettings
-      )
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
     }
 
     const userSettings: UserSettings = {

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -26,6 +26,7 @@ import { UserItem } from './interfaces/user-item.interface';
 import { UpdateUserSettingDto } from './update-user-setting.dto';
 import { UserService } from './user.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('user')
 export class UserController {
@@ -37,7 +38,7 @@ export class UserController {
   ) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteUser)
   public async deleteUser(@Param('id') id: string): Promise<UserModel> {
     if (id === this.request.user.id) {

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -54,7 +54,7 @@ export class UserController {
   }
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getUser(
     @Headers('accept-language') acceptLanguage: string
   ): Promise<User> {
@@ -92,7 +92,7 @@ export class UserController {
   }
 
   @Put('setting')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async updateUserSetting(@Body() data: UpdateUserSettingDto) {
     if (
       size(data) === 1 &&

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -1,6 +1,6 @@
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
 import { User, UserSettings } from '@ghostfolio/common/interfaces';
-import { permissions } from '@ghostfolio/common/permissions';
+import { hasPermission, permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 import {
   Body,
@@ -92,7 +92,6 @@ export class UserController {
 
   @Put('setting')
   @UseGuards(AuthGuard('jwt'))
-  @HasPermission(permissions.updateUserSettings)
   public async updateUserSetting(@Body() data: UpdateUserSettingDto) {
     if (
       size(data) === 1 &&
@@ -100,6 +99,16 @@ export class UserController {
       this.request.user.role === 'DEMO'
     ) {
       // Allow benchmark or date range change for demo user
+    } else if (
+      !hasPermission(
+        this.request.user.permissions,
+        permissions.updateUserSettings
+      )
+    ) {
+      throw new HttpException(
+        getReasonPhrase(StatusCodes.FORBIDDEN),
+        StatusCodes.FORBIDDEN
+      );
     }
 
     const userSettings: UserSettings = {

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -1,3 +1,5 @@
+import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
+import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
 import { User, UserSettings } from '@ghostfolio/common/interfaces';
 import { hasPermission, permissions } from '@ghostfolio/common/permissions';
@@ -25,8 +27,6 @@ import { size } from 'lodash';
 import { UserItem } from './interfaces/user-item.interface';
 import { UpdateUserSettingDto } from './update-user-setting.dto';
 import { UserService } from './user.service';
-import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
-import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 
 @Controller('user')
 export class UserController {
@@ -38,8 +38,8 @@ export class UserController {
   ) {}
 
   @Delete(':id')
-  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   @HasPermission(permissions.deleteUser)
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async deleteUser(@Param('id') id: string): Promise<UserModel> {
     if (id === this.request.user.id) {
       throw new HttpException(

--- a/apps/api/src/app/user/user.controller.ts
+++ b/apps/api/src/app/user/user.controller.ts
@@ -40,8 +40,7 @@ export class UserController {
   @UseGuards(AuthGuard('jwt'))
   @HasPermission(permissions.deleteUser)
   public async deleteUser(@Param('id') id: string): Promise<UserModel> {
-    if (id === this.request.user.id
-    ) {
+    if (id === this.request.user.id) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
         StatusCodes.FORBIDDEN

--- a/apps/api/src/guards/has-permission.guard.spec.ts
+++ b/apps/api/src/guards/has-permission.guard.spec.ts
@@ -1,6 +1,7 @@
 import { HttpException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+
 import { HasPermissionGuard } from './has-permission.guard';
 
 describe('HasPermissionGuard', () => {

--- a/apps/api/src/guards/has-permission.guard.spec.ts
+++ b/apps/api/src/guards/has-permission.guard.spec.ts
@@ -1,8 +1,6 @@
 import { HttpException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
-import { Test, TestingModule } from '@nestjs/testing';
-
 import { HasPermissionGuard } from './has-permission.guard';
 
 describe('HasPermissionGuard', () => {
@@ -10,12 +8,8 @@ describe('HasPermissionGuard', () => {
   let reflector: Reflector;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [HasPermissionGuard, Reflector]
-    }).compile();
-
-    guard = module.get<HasPermissionGuard>(HasPermissionGuard);
-    reflector = module.get<Reflector>(Reflector);
+    reflector = new Reflector();
+    guard = new HasPermissionGuard(reflector);
   });
 
   function setupReflectorSpy(returnValue: string) {

--- a/apps/api/src/guards/has-permission.guard.ts
+++ b/apps/api/src/guards/has-permission.guard.ts
@@ -20,6 +20,9 @@ export class HasPermissionGuard implements CanActivate {
       context.getHandler()
     );
 
+    console.log('requiredPermission', requiredPermission);
+    console.log('user', user);
+
     if (!requiredPermission) {
       return true; // No specific permissions required
     }

--- a/apps/api/src/guards/has-permission.guard.ts
+++ b/apps/api/src/guards/has-permission.guard.ts
@@ -11,9 +11,12 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 @Injectable()
 export class HasPermissionGuard implements CanActivate {
-  public constructor(private reflector: Reflector) {}
+  public constructor(private reflector: Reflector) {
+  }
 
   public canActivate(context: ExecutionContext): boolean {
+
+    const { user } = context.switchToHttp().getRequest();
     const requiredPermission = this.reflector.get<string>(
       HAS_PERMISSION_KEY,
       context.getHandler()
@@ -23,7 +26,7 @@ export class HasPermissionGuard implements CanActivate {
       return true; // No specific permissions required
     }
 
-    const { user } = context.switchToHttp().getRequest();
+
 
     if (!user || !hasPermission(user.permissions, requiredPermission)) {
       throw new HttpException(

--- a/apps/api/src/guards/has-permission.guard.ts
+++ b/apps/api/src/guards/has-permission.guard.ts
@@ -20,11 +20,9 @@ export class HasPermissionGuard implements CanActivate {
       context.getHandler()
     );
 
-    console.log('requiredPermission', requiredPermission);
-    console.log('user', user);
-
     if (!requiredPermission) {
-      return true; // No specific permissions required
+      // No specific permissions required
+      return true;
     }
 
     if (!user || !hasPermission(user.permissions, requiredPermission)) {

--- a/apps/api/src/guards/has-permission.guard.ts
+++ b/apps/api/src/guards/has-permission.guard.ts
@@ -11,11 +11,9 @@ import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 @Injectable()
 export class HasPermissionGuard implements CanActivate {
-  public constructor(private reflector: Reflector) {
-  }
+  public constructor(private reflector: Reflector) {}
 
   public canActivate(context: ExecutionContext): boolean {
-
     const { user } = context.switchToHttp().getRequest();
     const requiredPermission = this.reflector.get<string>(
       HAS_PERMISSION_KEY,
@@ -25,8 +23,6 @@ export class HasPermissionGuard implements CanActivate {
     if (!requiredPermission) {
       return true; // No specific permissions required
     }
-
-
 
     if (!user || !hasPermission(user.permissions, requiredPermission)) {
       throw new HttpException(


### PR DESCRIPTION
Updated the controllers to make use of the HasPermission guard and decorator instead of explicit verification of permissions.  each time.   There were some edge cases, which I've left alone in this initial p/r

- the case DEMO role in updateUserSettings user.controller.ts
- few cases where business rules are also being verified (as per our discussion)
- few cases where multiple permissions are being checked (example: ImportController)  

i suggest to deal with these in a seperate P/R. 