### PR TITLE
Feature/Add `wtd` and `mtd` as possible values for date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Extended the date range support by week to date (`WTD`) and month to date (`MTD`) in the portfolio service
 - Added `healthcheck` for the _Ghostfolio_ service to the `docker-compose` files (`docker-compose.yml` and `docker-compose.build.yml`)
 
 ## 2.42.0 - 2024-01-21
@@ -274,7 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Handled reading items from missing transaction point while getting the position (`getPosition()`) in portfolio service
+- Handled reading items from missing transaction point while getting the position (`getPosition()`) in the portfolio service
 
 ## 2.24.0 - 2023-11-16
 

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -73,7 +73,9 @@ import {
   min,
   parseISO,
   set,
-  setDayOfYear,
+  startOfWeek,
+  startOfMonth,
+  startOfYear,
   subDays,
   subYears
 } from 'date-fns';
@@ -1652,7 +1654,19 @@ export class PortfolioService {
       case 'ytd':
         portfolioStart = max([
           portfolioStart,
-          setDayOfYear(new Date().setHours(0, 0, 0, 0), 1)
+          startOfYear(new Date().setHours(0, 0, 0, 0))
+        ]);
+        break;
+      case 'mtd':
+        portfolioStart = max([
+          portfolioStart,
+          startOfMonth(new Date().setHours(0, 0, 0, 0))
+        ]);
+        break;
+      case 'wtd':
+        portfolioStart = max([
+          portfolioStart,
+          startOfWeek(new Date().setHours(0, 0, 0, 0), { weekStartsOn: 1 })
         ]);
         break;
       case '1y':

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1651,12 +1651,6 @@ export class PortfolioService {
           subDays(new Date().setHours(0, 0, 0, 0), 1)
         ]);
         break;
-      case 'ytd':
-        portfolioStart = max([
-          portfolioStart,
-          startOfYear(new Date().setHours(0, 0, 0, 0))
-        ]);
-        break;
       case 'mtd':
         portfolioStart = max([
           portfolioStart,
@@ -1667,6 +1661,12 @@ export class PortfolioService {
         portfolioStart = max([
           portfolioStart,
           startOfWeek(new Date().setHours(0, 0, 0, 0), { weekStartsOn: 1 })
+        ]);
+        break;
+      case 'ytd':
+        portfolioStart = max([
+          portfolioStart,
+          startOfYear(new Date().setHours(0, 0, 0, 0))
         ]);
         break;
       case '1y':

--- a/apps/api/src/app/user/update-user-setting.dto.ts
+++ b/apps/api/src/app/user/update-user-setting.dto.ts
@@ -30,7 +30,7 @@ export class UpdateUserSettingDto {
   @IsOptional()
   colorScheme?: ColorScheme;
 
-  @IsIn(<DateRange[]>['1d', '1y', '5y', 'max', 'ytd'])
+  @IsIn(<DateRange[]>['1d', '1y', '5y', 'max', 'mtd', 'wtd', 'ytd'])
   @IsOptional()
   dateRange?: DateRange;
 

--- a/libs/common/src/lib/types/date-range.type.ts
+++ b/libs/common/src/lib/types/date-range.type.ts
@@ -1,1 +1,1 @@
-export type DateRange = '1d' | '1y' | '5y' | 'max' | 'ytd';
+export type DateRange = '1d' | '1y' | '5y' | 'max' | 'mtd' | 'wtd' | 'ytd';


### PR DESCRIPTION
This commit adds support for the following date ranges
- 'wtd': week-to-date (from the start of the week)
- 'mtd': month-to-date (from the start of the month)

fixes #2900