### PR TITLE
Feature/Experimental/ Add more date ranges to pick from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Extended the date range support by week to date (`WTD`) and month to date (`MTD`) in the portfolio service
+- Extended the date range support by week to date (`WTD`) and month to date (`MTD`) in the assistant (experimental)
 - Added `healthcheck` for the _Ghostfolio_ service to the `docker-compose` files (`docker-compose.yml` and `docker-compose.build.yml`)
 
 ## 2.42.0 - 2024-01-21

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1660,7 +1660,10 @@ export class PortfolioService {
       case 'wtd':
         portfolioStart = max([
           portfolioStart,
-          startOfWeek(new Date().setHours(0, 0, 0, 0), { weekStartsOn: 1 })
+          subDays(
+            startOfWeek(new Date().setHours(0, 0, 0, 0), { weekStartsOn: 1 }),
+            1
+          )
         ]);
         break;
       case 'ytd':
@@ -1682,6 +1685,7 @@ export class PortfolioService {
         ]);
         break;
     }
+
     return portfolioStart;
   }
 

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1654,7 +1654,7 @@ export class PortfolioService {
       case 'mtd':
         portfolioStart = max([
           portfolioStart,
-          startOfMonth(new Date().setHours(0, 0, 0, 0))
+          subDays(startOfMonth(new Date().setHours(0, 0, 0, 0)), 1)
         ]);
         break;
       case 'wtd':
@@ -1669,7 +1669,7 @@ export class PortfolioService {
       case 'ytd':
         portfolioStart = max([
           portfolioStart,
-          startOfYear(new Date().setHours(0, 0, 0, 0))
+          subDays(startOfYear(new Date().setHours(0, 0, 0, 0)), 1)
         ]);
         break;
       case '1y':

--- a/libs/ui/src/lib/assistant/assistant.component.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.ts
@@ -17,7 +17,6 @@ import {
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatMenuTrigger } from '@angular/material/menu';
-import { ToggleComponent } from '@ghostfolio/client/components/toggle/toggle.component';
 import { AdminService } from '@ghostfolio/client/services/admin.service';
 import { DataService } from '@ghostfolio/client/services/data.service';
 import { User } from '@ghostfolio/common/interfaces';
@@ -91,8 +90,26 @@ export class AssistantComponent implements OnChanges, OnDestroy, OnInit {
   assistantListItems: QueryList<AssistantListItemComponent>;
 
   public static readonly SEARCH_RESULTS_DEFAULT_LIMIT = 5;
+  public dateRangeFormControl = new FormControl<string>(undefined);
 
-  public dateRangeOptions = ToggleComponent.DEFAULT_DATE_RANGE_OPTIONS;
+  public readonly dateRangeOptions = [
+    { label: $localize`Today`, value: '1d' },
+    {
+      label: $localize`Week to date` + ' (' + $localize`WTD` + ')',
+      value: 'wtd'
+    },
+    {
+      label: $localize`Month to date` + ' (' + $localize`MTD` + ')',
+      value: 'mtd'
+    },
+    {
+      label: $localize`Year to date` + ' (' + $localize`YTD` + ')',
+      value: 'ytd'
+    },
+    { label: $localize`1Y`, value: '1y' },
+    { label: $localize`5Y`, value: '5y' },
+    { label: $localize`Max`, value: 'max' }
+  ];
   public isLoading = false;
   public isOpen = false;
   public placeholder = $localize`Find holding...`;
@@ -163,6 +180,7 @@ export class AssistantComponent implements OnChanges, OnDestroy, OnInit {
   }
 
   public ngOnChanges() {
+    this.dateRangeFormControl.setValue(this.user?.settings?.dateRange ?? null);
     this.tagsFormControl.setValue(
       this.user?.settings?.['filters.tags']?.[0] ?? null
     );

--- a/libs/ui/src/lib/assistant/assistant.component.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.ts
@@ -90,8 +90,8 @@ export class AssistantComponent implements OnChanges, OnDestroy, OnInit {
   assistantListItems: QueryList<AssistantListItemComponent>;
 
   public static readonly SEARCH_RESULTS_DEFAULT_LIMIT = 5;
-  public dateRangeFormControl = new FormControl<string>(undefined);
 
+  public dateRangeFormControl = new FormControl<string>(undefined);
   public readonly dateRangeOptions = [
     { label: $localize`Today`, value: '1d' },
     {

--- a/libs/ui/src/lib/assistant/assistant.html
+++ b/libs/ui/src/lib/assistant/assistant.html
@@ -102,12 +102,17 @@
           >Date Range</span
         ></ng-template
       >
-      <div class="d-flex justify-content-center py-3">
-        <gf-toggle
-          [defaultValue]="user?.settings?.dateRange"
-          [options]="dateRangeOptions"
-          (change)="onChangeDateRange($event.value)"
-        ></gf-toggle>
+      <div class="p-3">
+        <mat-form-field appearance="outline" class="w-100 without-hint">
+          <mat-select
+            [formControl]="dateRangeFormControl"
+            (selectionChange)="onChangeDateRange($event.value)"
+          >
+            @for (range of dateRangeOptions; track range) {
+            <mat-option [value]="range.value">{{ range.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
       </div>
     </mat-tab>
     <mat-tab>

--- a/libs/ui/src/lib/assistant/assistant.module.ts
+++ b/libs/ui/src/lib/assistant/assistant.module.ts
@@ -11,6 +11,9 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { GfAssistantListItemModule } from './assistant-list-item/assistant-list-item.module';
 import { AssistantComponent } from './assistant.component';
 
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+
 @NgModule({
   declarations: [AssistantComponent],
   exports: [AssistantComponent],
@@ -20,7 +23,9 @@ import { AssistantComponent } from './assistant.component';
     GfAssistantListItemModule,
     GfToggleModule,
     MatButtonModule,
+    MatFormFieldModule,
     MatRadioModule,
+    MatSelectModule,
     MatTabsModule,
     NgxSkeletonLoaderModule,
     ReactiveFormsModule,

--- a/libs/ui/src/lib/assistant/assistant.module.ts
+++ b/libs/ui/src/lib/assistant/assistant.module.ts
@@ -2,17 +2,15 @@ import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
-import { GfToggleModule } from '@ghostfolio/client/components/toggle/toggle.module';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 
 import { GfAssistantListItemModule } from './assistant-list-item/assistant-list-item.module';
 import { AssistantComponent } from './assistant.component';
-
-import { MatSelectModule } from '@angular/material/select';
-import { MatFormFieldModule } from '@angular/material/form-field';
 
 @NgModule({
   declarations: [AssistantComponent],
@@ -21,7 +19,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     CommonModule,
     FormsModule,
     GfAssistantListItemModule,
-    GfToggleModule,
     MatButtonModule,
     MatFormFieldModule,
     MatRadioModule,


### PR DESCRIPTION
- Add `Week to date` and `Month to date` to the list of possible date ranges to pick from.
- Instead of using toggle buttons, the date range is picked using a drop down selection.

Fixes #2903

# Todo

- [x] replace `dateRangeOptions` with extra values in `AssistantComponent`
- [x] replace `gf-toggle` by `mat-select`
- [x] by default have the entry matching `user?.settings?.dateRange` selected.