### PR TITLE
Adjusts Dockerfile to enable healthcheck introduced in 5fc84a0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the installation of `curl` in the `Dockerfile` so that the healthcheck introduced in `v2.43.0` works.
+
 ## 2.43.0 - 2024-01-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- Fixed the installation of `curl` in the `Dockerfile` so that the healthcheck introduced in `v2.43.0` works.
-
 ## 2.43.0 - 2024-01-23
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN yarn database:generate-typings
 # Image to run, copy everything needed from builder
 FROM node:18-slim
 RUN apt update && apt install -y \
-    openssl \
     curl \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /ghostfolio/dist/apps /ghostfolio/apps

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY ./.yarnrc .yarnrc
 COPY ./prisma/schema.prisma prisma/schema.prisma
 
 RUN apt update && apt install -y \
-    curl \
     g++ \
     git \
     make \
@@ -54,6 +53,7 @@ RUN yarn database:generate-typings
 FROM node:18-slim
 RUN apt update && apt install -y \
     openssl \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /ghostfolio/dist/apps /ghostfolio/apps


### PR DESCRIPTION
Fixes #2912

Testing the fix locally:

1. `docker build -t localtests/ghostfolio .`
2. Adjust the `image` in `docker/docker-compose.yml` to `localtests/ghostfolio`
3. `docker compose -f docker/docker-compose.yml --env-file .env.example up -d`
4. `watch docker ps`
5. Ghostfolio container should become healthy 10-20s after startup.