### PR TITLE
Feat: Extended market data with preset by activitiesCount and date

### DIFF
--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -378,10 +378,11 @@ export class AdminService {
       _count: true,
       by: ['dataSource', 'symbol']
     });
-
+    let earliestDate = new Date();
+    let activityCount = 0;
     const marketData: AdminMarketDataItem[] = this.exchangeRateDataService
       .getCurrencyPairs()
-      .map(({ dataSource, symbol }) => {
+      .map(({ dataSource, symbol, date }) => {
         const marketDataItemCount =
           marketDataItems.find((marketDataItem) => {
             return (
@@ -389,13 +390,17 @@ export class AdminService {
               marketDataItem.symbol === symbol
             );
           })?._count ?? 0;
-
+        if (date < earliestDate) {
+          earliestDate = date;
+        }
         return {
           dataSource,
           marketDataItemCount,
           symbol,
+          activitiesCount: activityCount,
           assetClass: 'CASH',
           countriesCount: 0,
+          date: earliestDate,
           currency: symbol.replace(DEFAULT_CURRENCY, ''),
           name: symbol,
           sectorsCount: 0


### PR DESCRIPTION
#3006 

<img width="1792" alt="Screenshot 2024-02-18 at 21 28 03" src="https://github.com/ghostfolio/ghostfolio/assets/63906998/7061e345-f225-4b1f-ba80-9ff544fde5d6">


I've added attributes `activitesCount` and `date`(First Activity) on the market data with `presetId` = `CURRENCIES` as you can see in the screenshot. Let me know if I need to make any changes.