### PR TITLE
Fix debugging with VS Code due to missing Source Map

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -13,6 +13,7 @@
         "deleteOutputPath": false,
         "main": "apps/api/src/main.ts",
         "outputPath": "dist/apps/api",
+        "sourceMap": true,
         "target": "node",
         "tsConfig": "apps/api/tsconfig.app.json",
         "webpackConfig": "apps/api/webpack.config.js"


### PR DESCRIPTION
Fixes #2801

Issue is due to missing source map which causes Visual Studio Code to throw an error.

![image](https://github.com/ghostfolio/ghostfolio/assets/5653344/8173cc17-4a16-40e1-900c-524254ff6e54)
