### PR TITLE
Market data database decimation

### DIFF
--- a/apps/api/src/app/portfolio/current-rate.service.mock.ts
+++ b/apps/api/src/app/portfolio/current-rate.service.mock.ts
@@ -3,6 +3,7 @@ import { parseDate, resetHours } from '@ghostfolio/common/helper';
 import { addDays, endOfDay, isBefore, isSameDay } from 'date-fns';
 
 import { GetValueObject } from './interfaces/get-value-object.interface';
+import { GetValueRangeParams } from './interfaces/get-value-range-params.interface';
 import { GetValuesObject } from './interfaces/get-values-object.interface';
 import { GetValuesParams } from './interfaces/get-values-params.interface';
 
@@ -100,6 +101,29 @@ export const CurrentRateServiceMock = {
             symbol: dataGatheringItem.symbol
           });
         }
+      }
+    }
+
+    return Promise.resolve({ values, dataProviderInfos: [], errors: [] });
+  },
+  getValueRange: ({
+    dataGatheringItems,
+    dateRange: { start, end, step }
+  }: GetValueRangeParams): Promise<GetValuesObject> => {
+    const values: GetValueObject[] = [];
+
+    for (
+      let date = resetHours(start);
+      isBefore(date, endOfDay(end));
+      date = addDays(date, step)
+    ) {
+      for (const dataGatheringItem of dataGatheringItems) {
+        values.push({
+          date,
+          dataSource: dataGatheringItem.dataSource,
+          marketPrice: mockGetValue(dataGatheringItem.symbol, date).marketPrice,
+          symbol: dataGatheringItem.symbol
+        });
       }
     }
 

--- a/apps/api/src/app/portfolio/current-rate.service.ts
+++ b/apps/api/src/app/portfolio/current-rate.service.ts
@@ -15,6 +15,7 @@ import { isBefore, isToday } from 'date-fns';
 import { flatten, isEmpty, uniqBy } from 'lodash';
 
 import { GetValueObject } from './interfaces/get-value-object.interface';
+import { GetValueRangeParams } from './interfaces/get-value-range-params.interface';
 import { GetValuesObject } from './interfaces/get-values-object.interface';
 import { GetValuesParams } from './interfaces/get-values-params.interface';
 
@@ -161,6 +162,34 @@ export class CurrentRateService {
     }
 
     return response;
+  }
+
+  public async getValueRange({
+    dataGatheringItems,
+    dateRange
+  }: GetValueRangeParams): Promise<GetValuesObject> {
+    const values = await this.marketDataService
+      .getDecimatedRange({
+        dateRange,
+        dataSources: dataGatheringItems.map((x) => x.dataSource),
+        symbols: dataGatheringItems.map((x) => x.symbol)
+      })
+      .then((data) => {
+        return data.map(({ dataSource, date, marketPrice, symbol }) => {
+          return {
+            dataSource,
+            date,
+            marketPrice,
+            symbol
+          };
+        });
+      });
+
+    return {
+      dataProviderInfos: [],
+      errors: [],
+      values
+    };
   }
 
   private containsToday(dates: Date[]): boolean {

--- a/apps/api/src/app/portfolio/interfaces/date-range.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/date-range.interface.ts
@@ -1,0 +1,5 @@
+export interface DateRange {
+  start: Date;
+  end: Date;
+  step: number;
+}

--- a/apps/api/src/app/portfolio/interfaces/get-value-range-params.interface.ts
+++ b/apps/api/src/app/portfolio/interfaces/get-value-range-params.interface.ts
@@ -1,0 +1,8 @@
+import { IDataGatheringItem } from '@ghostfolio/api/services/interfaces/interfaces';
+
+import { DateRange } from './date-range.interface';
+
+export interface GetValueRangeParams {
+  dataGatheringItems: IDataGatheringItem[];
+  dateRange: DateRange;
+}

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -223,6 +223,8 @@ export class PortfolioCalculator {
         }
       });
 
+    const dates = uniq(marketSymbols.map((x) => x.date));
+
     this.dataProviderInfos = dataProviderInfos;
 
     const marketSymbolMap: {
@@ -289,10 +291,10 @@ export class PortfolioCalculator {
         timeWeightedInvestmentValues,
         timeWeightedInvestmentValuesWithCurrencyEffect
       } = this.getSymbolMetrics({
-        end,
+        end: dates?.[dates.length - 1] ?? end,
         marketSymbolMap,
-        start,
-        step,
+        start: dates?.[0] ?? start,
+        step: dates.length > 1 ? differenceInDays(dates[1], dates[0]) : 1,
         symbol,
         exchangeRates:
           exchangeRatesByCurrency[`${currencies[symbol]}${this.currency}`],

--- a/apps/api/src/app/portfolio/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/portfolio-calculator.ts
@@ -199,20 +199,8 @@ export class PortfolioCalculator {
       }) ?? [];
 
     const currencies: { [symbol: string]: string } = {};
-    const dates: Date[] = [];
     const dataGatheringItems: IDataGatheringItem[] = [];
     const firstIndex = transactionPointsBeforeEndDate.length;
-
-    let day = start;
-
-    while (isBefore(day, end)) {
-      dates.push(resetHours(day));
-      day = addDays(day, step);
-    }
-
-    if (!isSameDay(last(dates), end)) {
-      dates.push(resetHours(end));
-    }
 
     if (transactionPointsBeforeEndDate.length > 0) {
       for (const item of transactionPointsBeforeEndDate[firstIndex - 1].items) {
@@ -226,10 +214,12 @@ export class PortfolioCalculator {
     }
 
     const { dataProviderInfos, values: marketSymbols } =
-      await this.currentRateService.getValues({
+      await this.currentRateService.getValueRange({
         dataGatheringItems,
-        dateQuery: {
-          in: dates
+        dateRange: {
+          start,
+          end,
+          step
         }
       });
 
@@ -322,9 +312,7 @@ export class PortfolioCalculator {
       };
     }
 
-    for (const currentDate of dates) {
-      const dateString = format(currentDate, DATE_FORMAT);
-
+    for (const dateString of Object.keys(marketSymbolMap)) {
       for (const symbol of Object.keys(valuesBySymbol)) {
         const symbolValues = valuesBySymbol[symbol];
 


### PR DESCRIPTION
Second part of the discussion in #3116. Added a method to get decimated market data directly from the database. This way we don't have to query for a big array of dates.