### PR TITLE
Better signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the date range support in the activities table on the portfolio activities page (experimental)
 - Extended the date range support by specific years (`2023`, `2022`, `2021`, etc.) in the assistant (experimental)
+- Set up `Tini` to avoid zombie processes and perform signal forwarding in docker image
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,14 @@ RUN apt update && apt install -y \
     openssl \
     && rm -rf /var/lib/apt/lists/*
 
+# Add tini, which is an init process that handles signaling within the container
+# and with the host. See https://github.com/krallin/tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 COPY --from=builder /ghostfolio/dist/apps /ghostfolio/apps
-WORKDIR /ghostfolio/apps/api
+COPY ./docker/entrypoint.sh /ghostfolio/entrypoint.sh
 EXPOSE ${PORT:-3333}
-CMD [ "yarn", "start:production" ]
+CMD [ "/ghostfolio/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,5 +65,6 @@ ENTRYPOINT ["/tini", "--"]
 
 COPY --from=builder /ghostfolio/dist/apps /ghostfolio/apps
 COPY ./docker/entrypoint.sh /ghostfolio/entrypoint.sh
+WORKDIR /ghostfolio/apps/api
 EXPOSE ${PORT:-3333}
 CMD [ "/ghostfolio/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+echo "Running database migrations"
+npx prisma migrate deploy
+
+echo "Seeding the database"
+npx prisma db seed
+
+echo "Starting the server"
+node main


### PR DESCRIPTION
In this PR: https://github.com/ghostfolio/ghostfolio/pull/3168/files the workdir argument was removed, so the entrypoint script was run from `/`, and couldn't find the files required to run the migration and seeding. Set back the workdir so the script is instead evaluated from `/ghostfolio/apps/api` where the necessary files are located.