### PR TITLE
Handle reducing empty array when no exchange rate data retrieved

### DIFF
--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -76,9 +76,13 @@ export class ExchangeRateDataService {
       const dateStrings = Object.keys(
         exchangeRatesByCurrency[`${currency}${targetCurrency}`]
       );
-      const lastDateString = dateStrings.reduce((a, b) => {
-        return a > b ? a : b;
-      });
+
+      const lastDateString =
+        dateStrings.length > 0
+          ? dateStrings.reduce((a, b) => {
+              return a > b ? a : b;
+            })
+          : startDate.toISOString().slice(0, 10);
 
       let previousExchangeRate =
         exchangeRatesByCurrency[`${currency}${targetCurrency}`]?.[


### PR DESCRIPTION
Fixes #3150

Default to using start date if exchange rate data returns no dates