### PR TITLE
Allow updating name of asset profile in Admin Control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added support to override the name of an asset profile in the asset profile details dialog of the admin control
+
 ## 2.67.0 - 2024-03-26
 
 ### Added

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -331,39 +331,33 @@ export class AdminService {
     symbol,
     symbolMapping
   }: Prisma.SymbolProfileUpdateInput & UniqueAsset) {
-    let updatedSymbolProfile: Prisma.SymbolProfileUpdateInput & UniqueAsset = {
-      assetClass,
-      assetSubClass,
-      comment,
-      countries,
-      currency,
-      dataSource,
-      scraperConfiguration,
-      sectors,
-      symbol,
-      symbolMapping
-    };
-
-    if (dataSource === 'MANUAL') {
-      updatedSymbolProfile = {
-        ...updatedSymbolProfile,
-        name
+    const updatedSymbolProfile: Prisma.SymbolProfileUpdateInput & UniqueAsset =
+      {
+        assetClass,
+        assetSubClass,
+        comment,
+        countries,
+        currency,
+        dataSource,
+        scraperConfiguration,
+        sectors,
+        symbol,
+        symbolMapping,
+        ...(dataSource === 'MANUAL'
+          ? { name }
+          : {
+              SymbolProfileOverrides: {
+                upsert: {
+                  create: {
+                    name: name as string
+                  },
+                  update: {
+                    name: name as string
+                  }
+                }
+              }
+            })
       };
-    } else {
-      updatedSymbolProfile = {
-        ...updatedSymbolProfile,
-        SymbolProfileOverrides: {
-          upsert: {
-            create: {
-              name: name as string
-            },
-            update: {
-              name: name as string
-            }
-          }
-        }
-      };
-    }
 
     await this.symbolProfileService.updateSymbolProfile(updatedSymbolProfile);
 

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -331,19 +331,41 @@ export class AdminService {
     symbol,
     symbolMapping
   }: Prisma.SymbolProfileUpdateInput & UniqueAsset) {
-    await this.symbolProfileService.updateSymbolProfile({
+    let updatedSymbolProfile: Prisma.SymbolProfileUpdateInput & UniqueAsset = {
       assetClass,
       assetSubClass,
       comment,
       countries,
       currency,
       dataSource,
-      name,
       scraperConfiguration,
       sectors,
       symbol,
       symbolMapping
-    });
+    };
+
+    if (dataSource === 'MANUAL') {
+      updatedSymbolProfile = {
+        ...updatedSymbolProfile,
+        name
+      };
+    } else {
+      updatedSymbolProfile = {
+        ...updatedSymbolProfile,
+        SymbolProfileOverrides: {
+          upsert: {
+            create: {
+              name: name as string
+            },
+            update: {
+              name: name as string
+            }
+          }
+        }
+      };
+    }
+
+    await this.symbolProfileService.updateSymbolProfile(updatedSymbolProfile);
 
     const [symbolProfile] = await this.symbolProfileService.getSymbolProfiles([
       {

--- a/apps/api/src/services/symbol-profile/symbol-profile.service.ts
+++ b/apps/api/src/services/symbol-profile/symbol-profile.service.ts
@@ -97,7 +97,8 @@ export class SymbolProfileService {
     scraperConfiguration,
     sectors,
     symbol,
-    symbolMapping
+    symbolMapping,
+    SymbolProfileOverrides
   }: Prisma.SymbolProfileUpdateInput & UniqueAsset) {
     return this.prismaService.symbolProfile.update({
       data: {
@@ -109,7 +110,8 @@ export class SymbolProfileService {
         name,
         scraperConfiguration,
         sectors,
-        symbolMapping
+        symbolMapping,
+        SymbolProfileOverrides
       },
       where: { dataSource_symbol: { dataSource, symbol } }
     });

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -205,7 +205,7 @@
         }
       </ng-container>
     </div>
-    <div *ngIf="assetProfile?.dataSource === 'MANUAL'" class="mt-3">
+    <div class="mt-3">
       <mat-form-field appearance="outline" class="w-100 without-hint">
         <mat-label i18n>Name</mat-label>
         <input formControlName="name" matInput type="text" />


### PR DESCRIPTION
Closes #3151 

- Removes the restriction of only allowing an update to the name if the data source is manual in the client form
- For a data source that is manual, update the name on the symbol profile
- Create/update symbol profile override and set the name in the override if the data source is anything other than manual