### PR TITLE
Show market data for missing months in Market Data display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Added missing dates to edit historical market data in the asset profile details dialog of the admin control panel
+
 ## 2.68.0 - 2024-03-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the chart tooltip of the benchmark comparator
 - Fixed an issue with names in the activities table on the portfolio activities page while using symbol profile overrides
+- Added missing dates to edit historical market data in the asset profile details dialog of the admin control panel
 
 ## 2.67.0 - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the chart tooltip of the benchmark comparator
 - Fixed an issue with names in the activities table on the portfolio activities page while using symbol profile overrides
-- Added missing dates to edit historical market data in the asset profile details dialog of the admin control panel
 
 ## 2.67.0 - 2024-03-26
 

--- a/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.html
+++ b/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.html
@@ -9,11 +9,7 @@
     [showYAxis]="true"
     [symbol]="symbol"
   />
-  <div
-    *ngFor="let itemByMonth of marketDataByMonth | keyvalue"
-    class="d-flex"
-    [hidden]="!marketData.length > 0"
-  >
+  <div *ngFor="let itemByMonth of marketDataByMonth | keyvalue" class="d-flex">
     <div class="date px-1 text-nowrap">{{ itemByMonth.key }}</div>
     <div class="align-items-center d-flex flex-grow-1 px-1">
       <div

--- a/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.ts
+++ b/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.ts
@@ -19,7 +19,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { DataSource, MarketData } from '@prisma/client';
 import {
   addDays,
+  addMonths,
   format,
+  isAfter,
   isBefore,
   isSameDay,
   isToday,
@@ -134,6 +136,19 @@ export class AdminMarketDataDetailComponent implements OnChanges, OnInit {
         day: currentDay,
         marketPrice: marketDataItem.marketPrice
       };
+    }
+
+    const dates = Object.keys(this.marketDataByMonth).sort();
+    const startDate = parseISO(dates[0]);
+    const endDate = parseISO(last(dates));
+
+    let currentDate = startDate;
+    while (!isAfter(currentDate, endDate)) {
+      const key = format(currentDate, 'yyyy-MM');
+      if (!this.marketDataByMonth[key]) {
+        this.marketDataByMonth[key] = {};
+      }
+      currentDate = addMonths(currentDate, 1);
     }
   }
 

--- a/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.ts
+++ b/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.ts
@@ -139,7 +139,7 @@ export class AdminMarketDataDetailComponent implements OnChanges, OnInit {
     }
 
     if (this.dateOfFirstActivity) {
-      // Fill up missing gaps
+      // Fill up missing months
       const dates = Object.keys(this.marketDataByMonth).sort();
       const startDate = min([
         parseISO(this.dateOfFirstActivity),

--- a/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.ts
+++ b/apps/client/src/app/components/admin-market-data-detail/admin-market-data-detail.component.ts
@@ -21,15 +21,15 @@ import {
   addDays,
   addMonths,
   format,
-  isAfter,
   isBefore,
   isSameDay,
   isToday,
   isValid,
+  min,
   parse,
   parseISO
 } from 'date-fns';
-import { last } from 'lodash';
+import { first, last } from 'lodash';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { Subject, takeUntil } from 'rxjs';
 
@@ -138,17 +138,25 @@ export class AdminMarketDataDetailComponent implements OnChanges, OnInit {
       };
     }
 
-    const dates = Object.keys(this.marketDataByMonth).sort();
-    const startDate = parseISO(dates[0]);
-    const endDate = parseISO(last(dates));
+    if (this.dateOfFirstActivity) {
+      // Fill up missing gaps
+      const dates = Object.keys(this.marketDataByMonth).sort();
+      const startDate = min([
+        parseISO(this.dateOfFirstActivity),
+        parseISO(first(dates))
+      ]);
+      const endDate = parseISO(last(dates));
 
-    let currentDate = startDate;
-    while (!isAfter(currentDate, endDate)) {
-      const key = format(currentDate, 'yyyy-MM');
-      if (!this.marketDataByMonth[key]) {
-        this.marketDataByMonth[key] = {};
+      let currentDate = startDate;
+
+      while (isBefore(currentDate, endDate)) {
+        const key = format(currentDate, 'yyyy-MM');
+        if (!this.marketDataByMonth[key]) {
+          this.marketDataByMonth[key] = {};
+        }
+
+        currentDate = addMonths(currentDate, 1);
       }
-      currentDate = addMonths(currentDate, 1);
     }
   }
 


### PR DESCRIPTION
Resolves #2539 

For months that have no market data defined, a month will be added with empty data (similar to how red boxes for days with no data are added) i.e
![image](https://github.com/ghostfolio/ghostfolio/assets/40535546/d1896207-6122-4a04-8994-35d45574ed73)