### PR TITLE
Enable tini from docker compose instead of adding it to dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Set up the language localization for Chinese (`zh`)
+- Added `init: true` to the `docker-compose` files (`docker-compose.yml` and `docker-compose.build.yml`) to avoid zombie processes
 - Set up _Webpack Bundle Analyzer_
 
 ### Changed
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the duplicated tags in the position detail dialog
+- Removed `Tini` from the docker image
 
 ## 2.69.0 - 2024-03-30
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,6 @@ RUN apt update && apt install -y \
     openssl \
     && rm -rf /var/lib/apt/lists/*
 
-# Add tini, which is an init process that handles signaling within the container
-# and with the host. See https://github.com/krallin/tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
-
 COPY --from=builder /ghostfolio/dist/apps /ghostfolio/apps
 COPY ./docker/entrypoint.sh /ghostfolio/entrypoint.sh
 WORKDIR /ghostfolio/apps/api

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -2,6 +2,7 @@ version: '3.9'
 services:
   ghostfolio:
     build: ../
+    init: true
     env_file:
       - ../.env
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.9'
 services:
   ghostfolio:
     image: ghostfolio/ghostfolio:latest
+    init: true
     env_file:
       - ../.env
     environment:


### PR DESCRIPTION
This discussion: https://github.com/ghostfolio/ghostfolio/discussions/3216 raised an issue where `tini` would not be executable on platforms other than `linux/amd64`.

`Tini` supports different architectures, but it would require to modify the build steps and have an image per architecture, which is cumbersome and not user-friendly.

Add it instead to `docker-compose` so the docker daemon handles setting up tini, no matter the architecture. 

