### PR TITLE
Add links to Home Assistant add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ docker compose --env-file ./.env -f docker/docker-compose.build.yml up -d
 
 ### Home Server Systems (Community)
 
-Ghostfolio is available for various home server systems, including [CasaOS](https://github.com/bigbeartechworld/big-bear-casaos), Home Assistant, [Runtipi](https://www.runtipi.io/docs/apps-available), [TrueCharts](https://truecharts.org/charts/stable/ghostfolio), [Umbrel](https://apps.umbrel.com/app/ghostfolio), and [Unraid](https://unraid.net/community/apps?q=ghostfolio).
+Ghostfolio is available for various home server systems, including [CasaOS](https://github.com/bigbeartechworld/big-bear-casaos), [Home Assistant](https://github.com/lildude/ha-addon-ghostfolio), [Runtipi](https://www.runtipi.io/docs/apps-available), [TrueCharts](https://truecharts.org/charts/stable/ghostfolio), [Umbrel](https://apps.umbrel.com/app/ghostfolio), and [Unraid](https://unraid.net/community/apps?q=ghostfolio).
 
 ## Development
 

--- a/apps/client/src/app/pages/faq/self-hosting/self-hosting-page.html
+++ b/apps/client/src/app/pages/faq/self-hosting/self-hosting-page.html
@@ -30,8 +30,10 @@
           systems, including
           <a href="https://github.com/bigbeartechworld/big-bear-casaos"
             >CasaOS</a
-          >, <a href="https://github.com/lildude/ha-addon-ghostfolio">Home Assistant</a>,
-          <a href="https://www.runtipi.io/docs/apps-available">Runtipi</a>,
+          >,
+          <a href="https://github.com/lildude/ha-addon-ghostfolio"
+            >Home Assistant</a
+          >, <a href="https://www.runtipi.io/docs/apps-available">Runtipi</a>,
           <a href="https://truecharts.org/charts/stable/ghostfolio"
             >TrueCharts</a
           >, <a href="https://apps.umbrel.com/app/ghostfolio">Umbrel</a>, and

--- a/apps/client/src/app/pages/faq/self-hosting/self-hosting-page.html
+++ b/apps/client/src/app/pages/faq/self-hosting/self-hosting-page.html
@@ -30,7 +30,7 @@
           systems, including
           <a href="https://github.com/bigbeartechworld/big-bear-casaos"
             >CasaOS</a
-          >, Home Assistant,
+          >, <a href="https://github.com/lildude/ha-addon-ghostfolio">Home Assistant</a>,
           <a href="https://www.runtipi.io/docs/apps-available">Runtipi</a>,
           <a href="https://truecharts.org/charts/stable/ghostfolio"
             >TrueCharts</a


### PR DESCRIPTION
Thanks for adding a mention of Home Assistant in https://github.com/ghostfolio/ghostfolio/pull/3291 🙇 This PR adds links to the add-on repo for easier discoverability.