### PR TITLE
Validate account balance creation/update using DTO

### DIFF
--- a/apps/client/src/app/components/account-detail-dialog/account-detail-dialog.component.ts
+++ b/apps/client/src/app/components/account-detail-dialog/account-detail-dialog.component.ts
@@ -1,3 +1,4 @@
+import { CreateAccountBalanceDto } from '@ghostfolio/api/app/account-balance/create-account-balance.dto';
 import { Activity } from '@ghostfolio/api/app/order/interfaces/activities.interface';
 import { DataService } from '@ghostfolio/client/services/data.service';
 import { UserService } from '@ghostfolio/client/services/user/user.service';
@@ -95,19 +96,9 @@ export class AccountDetailDialog implements OnDestroy, OnInit {
     this.dialogRef.close();
   }
 
-  public onAddAccountBalance({
-    balance,
-    date
-  }: {
-    balance: number;
-    date: Date;
-  }) {
+  public onAddAccountBalance(balance: CreateAccountBalanceDto) {
     this.dataService
-      .postAccountBalance({
-        balance,
-        date,
-        accountId: this.data.accountId
-      })
+      .postAccountBalance(balance)
       .pipe(takeUntil(this.unsubscribeSubject))
       .subscribe(() => {
         this.fetchAccount();

--- a/apps/client/src/app/components/account-detail-dialog/account-detail-dialog.component.ts
+++ b/apps/client/src/app/components/account-detail-dialog/account-detail-dialog.component.ts
@@ -96,9 +96,9 @@ export class AccountDetailDialog implements OnDestroy, OnInit {
     this.dialogRef.close();
   }
 
-  public onAddAccountBalance(balance: CreateAccountBalanceDto) {
+  public onAddAccountBalance(accountBalance: CreateAccountBalanceDto) {
     this.dataService
-      .postAccountBalance(balance)
+      .postAccountBalance(accountBalance)
       .pipe(takeUntil(this.unsubscribeSubject))
       .subscribe(() => {
         this.fetchAccount();

--- a/apps/client/src/app/services/data.service.ts
+++ b/apps/client/src/app/services/data.service.ts
@@ -1,4 +1,5 @@
 import { CreateAccessDto } from '@ghostfolio/api/app/access/create-access.dto';
+import { CreateAccountBalanceDto } from '@ghostfolio/api/app/account-balance/create-account-balance.dto';
 import { CreateAccountDto } from '@ghostfolio/api/app/account/create-account.dto';
 import { TransferBalanceDto } from '@ghostfolio/api/app/account/transfer-balance.dto';
 import { UpdateAccountDto } from '@ghostfolio/api/app/account/update-account.dto';
@@ -618,20 +619,8 @@ export class DataService {
     return this.http.post<OrderModel>(`/api/v1/account`, aAccount);
   }
 
-  public postAccountBalance({
-    accountId,
-    balance,
-    date
-  }: {
-    accountId: string;
-    balance: number;
-    date: Date;
-  }) {
-    return this.http.post<AccountBalance>(`/api/v1/account-balance`, {
-      accountId,
-      balance,
-      date
-    });
+  public postAccountBalance(aBalance: CreateAccountBalanceDto) {
+    return this.http.post<AccountBalance>(`/api/v1/account-balance`, aBalance);
   }
 
   public postBenchmark(benchmark: UniqueAsset) {

--- a/apps/client/src/app/services/data.service.ts
+++ b/apps/client/src/app/services/data.service.ts
@@ -619,8 +619,11 @@ export class DataService {
     return this.http.post<OrderModel>(`/api/v1/account`, aAccount);
   }
 
-  public postAccountBalance(aBalance: CreateAccountBalanceDto) {
-    return this.http.post<AccountBalance>(`/api/v1/account-balance`, aBalance);
+  public postAccountBalance(aAccountBalance: CreateAccountBalanceDto) {
+    return this.http.post<AccountBalance>(
+      `/api/v1/account-balance`,
+      aAccountBalance
+    );
   }
 
   public postBenchmark(benchmark: UniqueAsset) {

--- a/libs/ui/src/lib/account-balances/account-balances.component.ts
+++ b/libs/ui/src/lib/account-balances/account-balances.component.ts
@@ -1,3 +1,5 @@
+import { CreateAccountBalanceDto } from '@ghostfolio/api/app/account-balance/create-account-balance.dto';
+import { validateObjectForForm } from '@ghostfolio/client/util/form.util';
 import { getLocale } from '@ghostfolio/common/helper';
 import { AccountBalancesResponse } from '@ghostfolio/common/interfaces';
 
@@ -60,10 +62,7 @@ export class GfAccountBalancesComponent
   @Input() locale = getLocale();
   @Input() showActions = true;
 
-  @Output() accountBalanceCreated = new EventEmitter<{
-    balance: number;
-    date: Date;
-  }>();
+  @Output() accountBalanceCreated = new EventEmitter<CreateAccountBalanceDto>();
   @Output() accountBalanceDeleted = new EventEmitter<string>();
 
   @ViewChild(MatSort) sort: MatSort;
@@ -107,8 +106,25 @@ export class GfAccountBalancesComponent
     }
   }
 
-  public onSubmitAccountBalance() {
-    this.accountBalanceCreated.emit(this.accountBalanceForm.getRawValue());
+  public async onSubmitAccountBalance() {
+    const balance: CreateAccountBalanceDto = {
+      accountId: this.accountId,
+      balance: this.accountBalanceForm.get('balance').value,
+      date: this.accountBalanceForm.get('date').value.toISOString()
+    };
+
+    try {
+      await validateObjectForForm({
+        classDto: CreateAccountBalanceDto,
+        form: this.accountBalanceForm,
+        object: balance
+      });
+    } catch (error) {
+      console.error(error);
+      return;
+    }
+
+    this.accountBalanceCreated.emit(balance);
   }
 
   public ngOnDestroy() {

--- a/libs/ui/src/lib/account-balances/account-balances.component.ts
+++ b/libs/ui/src/lib/account-balances/account-balances.component.ts
@@ -107,7 +107,7 @@ export class GfAccountBalancesComponent
   }
 
   public async onSubmitAccountBalance() {
-    const balance: CreateAccountBalanceDto = {
+    const accountBalance: CreateAccountBalanceDto = {
       accountId: this.accountId,
       balance: this.accountBalanceForm.get('balance').value,
       date: this.accountBalanceForm.get('date').value.toISOString()
@@ -117,14 +117,14 @@ export class GfAccountBalancesComponent
       await validateObjectForForm({
         classDto: CreateAccountBalanceDto,
         form: this.accountBalanceForm,
-        object: balance
+        object: accountBalance
       });
     } catch (error) {
       console.error(error);
       return;
     }
 
-    this.accountBalanceCreated.emit(balance);
+    this.accountBalanceCreated.emit(accountBalance);
   }
 
   public ngOnDestroy() {


### PR DESCRIPTION
Closes #3341

Update data service to use the `CreateAccountBalanceDto`.

Refactor account balance component to validate the form using the DTO. The validated DTO is then emitted.

Change account detail dialog to use`CreateAccountBalanceDto`.