### PR TITLE
Faster autocomplete

### DIFF
--- a/apps/api/src/app/order/order.service.ts
+++ b/apps/api/src/app/order/order.service.ts
@@ -276,7 +276,7 @@ export class OrderService {
     where.SymbolProfile = {
       AND: symbolProfileConditions
     };
-    const searchQuery = filters.find(({ type }) => {
+    const searchQuery = filters?.find(({ type }) => {
       return type === 'SEARCH_QUERY';
     })?.id;
     if (searchQuery) {

--- a/apps/api/src/app/order/order.service.ts
+++ b/apps/api/src/app/order/order.service.ts
@@ -272,6 +272,21 @@ export class OrderService {
     ];
     const where: Prisma.OrderWhereInput = { userId };
 
+    const searchQuery = filters.find(({ type }) => {
+      return type === 'SEARCH_QUERY';
+    })?.id;
+    if (searchQuery) {
+      // TODO: Manage merge with other mutation of .SymbolProfile below
+      where.SymbolProfile = {
+        OR: [
+          { id: { mode: 'insensitive', contains: searchQuery } },
+          { isin: { mode: 'insensitive', contains: searchQuery } },
+          { name: { mode: 'insensitive', contains: searchQuery } },
+          { symbol: { mode: 'insensitive', contains: searchQuery } }
+        ]
+      };
+    }
+
     if (endDate || startDate) {
       where.AND = [];
 

--- a/apps/api/src/app/order/order.service.ts
+++ b/apps/api/src/app/order/order.service.ts
@@ -272,19 +272,22 @@ export class OrderService {
     ];
     const where: Prisma.OrderWhereInput = { userId };
 
+    let symbolProfileConditions: Prisma.SymbolProfileWhereInput[] = [];
+    where.SymbolProfile = {
+      AND: symbolProfileConditions
+    };
     const searchQuery = filters.find(({ type }) => {
       return type === 'SEARCH_QUERY';
     })?.id;
     if (searchQuery) {
-      // TODO: Manage merge with other mutation of .SymbolProfile below
-      where.SymbolProfile = {
+      symbolProfileConditions.push({
         OR: [
           { id: { mode: 'insensitive', contains: searchQuery } },
           { isin: { mode: 'insensitive', contains: searchQuery } },
           { name: { mode: 'insensitive', contains: searchQuery } },
           { symbol: { mode: 'insensitive', contains: searchQuery } }
         ]
-      };
+      });
     }
 
     if (endDate || startDate) {
@@ -320,7 +323,7 @@ export class OrderService {
     }
 
     if (filtersByAssetClass?.length > 0) {
-      where.SymbolProfile = {
+      symbolProfileConditions.push({
         OR: [
           {
             AND: [
@@ -345,7 +348,7 @@ export class OrderService {
             }
           }
         ]
-      };
+      });
     }
 
     if (filtersByTag?.length > 0) {

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -1,5 +1,6 @@
 import { AccessService } from '@ghostfolio/api/app/access/access.service';
 import { OrderService } from '@ghostfolio/api/app/order/order.service';
+import { LookupItem } from '@ghostfolio/api/app/symbol/interfaces/lookup-item.interface';
 import { UserService } from '@ghostfolio/api/app/user/user.service';
 import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
 import {
@@ -317,6 +318,28 @@ export class PortfolioController {
     });
 
     return { holdings: Object.values(holdings) };
+  }
+
+  @Get('lookup')
+  @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
+  @UseInterceptors(TransformDataSourceInResponseInterceptor)
+  public async lookupSymbol(
+    @Headers(HEADER_KEY_IMPERSONATION.toLowerCase()) impersonationId: string,
+    @Query('accounts') filterByAccounts?: string,
+    @Query('query') filterBySearchQuery?: string
+  ): Promise<{ items: LookupItem[] }> {
+    const filters = this.apiService.buildFiltersFromQueryParams({
+      filterByAccounts,
+      filterBySearchQuery
+    });
+
+    return {
+      items: await this.portfolioService.getLookup({
+        filters,
+        impersonationId,
+        userId: this.request.user.id
+      })
+    };
   }
 
   @Get('investments')

--- a/apps/client/src/app/services/data.service.ts
+++ b/apps/client/src/app/services/data.service.ts
@@ -484,6 +484,20 @@ export class DataService {
       );
   }
 
+  public fetchPortfolioLookup({ query }: { query: string }) {
+    let params = new HttpParams().set('query', query);
+
+    return this.http
+      .get<{ items: LookupItem[] }>('/api/v1/portfolio/lookup', {
+        params
+      })
+      .pipe(
+        map((response) => {
+          return response.items;
+        })
+      );
+  }
+
   public fetchPortfolioHoldings({
     filters,
     range

--- a/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.html
+++ b/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.html
@@ -11,7 +11,7 @@
   [displayWith]="displayFn"
   (optionSelected)="onUpdateSymbol($event)"
 >
-  @if (!isLoading) {
+  @if (!isLoadingRemote || !isLoadingLocal) {
     @for (lookupItem of filteredLookupItems; track lookupItem) {
       <mat-option
         class="line-height-1"
@@ -32,9 +32,20 @@
         </small>
       </mat-option>
     }
+    @if (isLoadingRemote || isLoadingLocal) {
+      <mat-option class="line-height-1" [disabled]="true">
+        <span class="align-items-center d-flex line-height-1">
+          <mat-spinner
+            class="mat-more-symbols-progress-spinner"
+            [diameter]="20"
+          />
+          Loading more symbols ...
+        </span>
+      </mat-option>
+    }
   }
 </mat-autocomplete>
 
-@if (isLoading) {
+@if (isLoadingRemote || isLoadingLocal) {
   <mat-spinner class="position-absolute" [diameter]="20" />
 }

--- a/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.html
+++ b/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.html
@@ -11,7 +11,9 @@
   [displayWith]="displayFn"
   (optionSelected)="onUpdateSymbol($event)"
 >
-  @if (!isLoadingRemote || !isLoadingLocal) {
+  @if (
+    (!isLoadingRemote || !isLoadingLocal) && filteredLookupItems.length > 0
+  ) {
     @for (lookupItem of filteredLookupItems; track lookupItem) {
       <mat-option
         class="line-height-1"

--- a/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.scss
+++ b/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.scss
@@ -6,3 +6,7 @@
     top: calc(50% - 10px);
   }
 }
+
+.mat-more-symbols-progress-spinner {
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
See: https://github.com/ghostfolio/ghostfolio/discussions/3421

This implements a variant of the linked discussed idea. 

Initially, I tried making this work with the existing `/api/v1/portfolio/holdings` endpoint, but the latency was still too high for a smooth user experience. With the separate endpoint the feature is more like I imagined it to be. This is especially true when Ghostfolio is hosted locally and the difference between a strictly local request vs waiting for a 3rd party is more pronounced.

![Screen Capture on 2024-06-22 at 11-48-25](https://github.com/ghostfolio/ghostfolio/assets/1842905/06f35d34-f808-4c80-88ab-0b2a3c36cb75)

The separate endpoint still hooks into the `OrderService` which requires a minor change to implement a `SEARCH_QUERY` filter in `getOrders(...)`.

There's still behavior I might want to optimize: If an item is highlighted and focused (keypress arrow down) and the remaining suggestions come in after that, the focus is lost. 