### PR TITLE
Check assetProfile.symbol instead of name during import

### DIFF
--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -610,7 +610,7 @@ export class ImportService {
         };
 
         if (type === 'BUY' || type === 'DIVIDEND' || type === 'SELL') {
-          if (!assetProfile?.name) {
+          if (!assetProfile?.symbol) {
             throw new Error(
               `activities.${index}.symbol ("${symbol}") is not valid for the specified data source ("${dataSource}")`
             );


### PR DESCRIPTION
I have GOOGLE_SHEETS data source enabled in my instance. But when I import activities with GOOGLE_SHEETS as data source, an error message will be thrown. This is because google sheets (and many other data sources) does not return name in `getAssetProfile`.
https://github.com/ghostfolio/ghostfolio/blob/4fb2aebf4fc0d6b99c8aba2d1aa4db32a84c871c/apps/api/src/services/data-provider/google-sheets/google-sheets.service.ts#L36-L45

I can also fix this by adding name to the return value like #2923, however, there will be a lot of data sources that need to be changed and I personally don't see a reason why we must have a name before importing, so my proposed change is to check `assetProfile.symbol` instead.