### PR TITLE
Fix JSON scraper content-type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Improved the detection of REST APIs (`JSON`) used via the scraper configuration
+
 ## 2.92.0 - 2024-06-30
 
 ### Added

--- a/apps/api/src/services/data-provider/manual/manual.service.ts
+++ b/apps/api/src/services/data-provider/manual/manual.service.ts
@@ -257,7 +257,7 @@ export class ManualService implements DataProviderInterface {
         signal: abortController.signal
       });
 
-      if (headers['content-type'] === 'application/json') {
+      if (headers['content-type'].includes('application/json')) {
         const data = JSON.parse(body);
         const value = String(
           jsonpath.query(data, scraperConfiguration.selector)[0]


### PR DESCRIPTION
Header like `content-type: application/json; charset=utf-8` is a valid content-type header but will fall into the non-json codepath currently. Update the checking logic to accommodate headers like this