### PR TITLE
ci: remove read_only attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved the language localization for German (`de`)
 
+### Fixed
+
+- Removed `read_only: true` from the `docker-compose.yml` file to allow prisma running migrations
+
 ## 2.103.0 - 2024-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removed `read_only: true` from the `docker-compose.yml` file to allow prisma running migrations
+- Removed `read_only: true` from the `docker-compose.yml` file to allow `prisma` to run migrations
 
 ## 2.103.0 - 2024-08-10
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   ghostfolio:
     image: docker.io/ghostfolio/ghostfolio:latest
     init: true
-    read_only: true
     cap_drop:
       - ALL
     security_opt:


### PR DESCRIPTION
Looks like the container needs write permissions in some edge cases so I'm removing the read_only attribute.
fixes #3650