### PR TITLE
Feature/improve performance of portfolio snapshot computation - 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Optimized the portfolio calculations with smarter date interval selection
+
 ## 2.111.0 - 2024-09-28
 
 ### Added

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -821,8 +821,8 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
         startDate = start;
       }
 
-      const startDateString = format(startDate, DATE_FORMAT);
       const endDateString = format(endDate, DATE_FORMAT);
+      const startDateString = format(startDate, DATE_FORMAT);
 
       const currentValuesAtDateRangeStartWithCurrencyEffect =
         currentValuesWithCurrencyEffect[startDateString] ?? new Big(0);


### PR DESCRIPTION
Continuing my perf analysis of the portfolio snapshot computation, this was another big time sink on my machine, specially when generating each day for the `'5y'` and `'max'` date ranges.

For reference, before this diff, the `dateRange` loop was taking on average ~100ms per symbol for me (Raspberry Pi 4, 478 symbols in the DB). After this diff, it takes ~10ms per symbol, shaving off 40s of computation time.

Again, I'm not too familiar with TypeScript so please feel free to be very pedantic in the review.

Test Plan:
Check that result of portfolio snapshot computation is the same before and after this diff:
1. Flush portfolio snapshot cache:
```
$ docker exec -it ghostfolio-redis-1 redis-cli --pass $REDIS_PASSWORD del "portfolio-snapshot-f9e4c63e-4b8e-46fc-b6ed-75ca0205f12b"
```
2. Open Accounts to trigger snapshot calculation
3. Dump portfolio snapshot to a file:
```
$ docker exec -it ghostfolio-redis-1 redis-cli --pass $REDIS_PASSWORD --no-auth-warning get "portfolio-snapshot-f9e4c63e-4b8e-46fc-b6ed-75ca0205f12b" | python -c "import json, sys; json.dump(json.loads(json.loads(json.load(sys.stdin))), sys.stdout, indent=2, sort_keys=True)" > snapshot-before.json
```
4. Apply this patch
5. Repeat steps 1-3
6. Compare results, check everything matches except for expiration time:
```
$ diff snapshot-before.json snapshot-after.json
2c2
<   "expiration": 1727449402720,
---
>   "expiration": 1727449639794,
```