### PR TITLE
Feature/improve performance of portfolio snapshot computation - 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set up a git-hook via `husky` to lint and format the changes before a commit
 - Added the `typescript-eslint/recommended-type-checked` rule to the `eslint` configuration
 
+### Changed
+
+- Optimized the portfolio calculations by reusing date intervals
+
 ### Fixed
 
 - Handled an exception in the historical market data gathering of derived currencies


### PR DESCRIPTION
This is similar to the previous diff. Here we can speed things up by using the dates in `chatDatesMap` instead of computing the whole interval every time.

For reference, before this diff, the `while (isBefore(...))` loop was taking on average ~88ms per symbol for me (Raspberry Pi 4, 481 symbols in the DB). After this diff, it takes ~12ms per symbol, shaving off almost 40s of total computation time.

Test Plan:
Check that result of portfolio snapshot computation is the same before and after this diff:
1. Flush portfolio snapshot cache:
```
$ docker exec -it ghostfolio-redis-1 redis-cli --pass $REDIS_PASSWORD del "portfolio-snapshot-f9e4c63e-4b8e-46fc-b6ed-75ca0205f12b"
```
2. Open Accounts to trigger snapshot calculation
3. Dump portfolio snapshot to a file:
```
$ docker exec -it ghostfolio-redis-1 redis-cli --pass $REDIS_PASSWORD --no-auth-warning get "portfolio-snapshot-f9e4c63e-4b8e-46fc-b6ed-75ca0205f12b" | python -c "import json, sys; json.dump(json.loads(json.loads(json.load(sys.stdin))), sys.stdout, indent=2, sort_keys=True)" > snapshot-before.json
```
4. Apply this patch
5. Repeat steps 1-3
6. Compare results, check everything matches except for expiration time:
```
$ diff snapshot-before.json snapshot-after.json
2c2
<   "expiration": 1727834561292,
---
>   "expiration": 1727836180162,
```