### PR TITLE
Fix exchange rate gathering job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Handled an exception in the historical market data gathering of derived currencies
+
 ## 2.112.0 - 2024-10-03
 
 ### Added

--- a/apps/api/src/services/data-provider/data-provider.service.ts
+++ b/apps/api/src/services/data-provider/data-provider.service.ts
@@ -666,12 +666,13 @@ export class DataProviderService {
     } = {};
 
     for (const date in rootData) {
-      if (rootData[date].marketPrice === null) {
-        continue;
+      if (isNumber(rootData[date].marketPrice)) {
+        data[date] = {
+          marketPrice: new Big(factor)
+            .mul(rootData[date].marketPrice)
+            .toNumber()
+        };
       }
-      data[date] = {
-        marketPrice: rootData[date].marketPrice
-      };
     }
 
     return data;

--- a/apps/api/src/services/data-provider/data-provider.service.ts
+++ b/apps/api/src/services/data-provider/data-provider.service.ts
@@ -667,7 +667,9 @@ export class DataProviderService {
 
     for (const date in rootData) {
       data[date] = {
-        marketPrice: new Big(factor).mul(rootData[date].marketPrice).toNumber()
+        marketPrice: rootData[date].marketPrice
+          ? new Big(factor).mul(rootData[date].marketPrice).toNumber()
+          : null
       };
     }
 

--- a/apps/api/src/services/data-provider/data-provider.service.ts
+++ b/apps/api/src/services/data-provider/data-provider.service.ts
@@ -666,11 +666,11 @@ export class DataProviderService {
     } = {};
 
     for (const date in rootData) {
-      data[date] = {
-        marketPrice: rootData[date].marketPrice
-          ? new Big(factor).mul(rootData[date].marketPrice).toNumber()
-          : null
-      };
+      if (rootData[date].marketPrice >= 0) {
+        data[date] = {
+          marketPrice: rootData[date].marketPrice
+        };
+      }
     }
 
     return data;

--- a/apps/api/src/services/data-provider/data-provider.service.ts
+++ b/apps/api/src/services/data-provider/data-provider.service.ts
@@ -666,11 +666,12 @@ export class DataProviderService {
     } = {};
 
     for (const date in rootData) {
-      if (rootData[date].marketPrice >= 0) {
-        data[date] = {
-          marketPrice: rootData[date].marketPrice
-        };
+      if (rootData[date].marketPrice === null) {
+        continue;
       }
+      data[date] = {
+        marketPrice: rootData[date].marketPrice
+      };
     }
 
     return data;


### PR DESCRIPTION
Hi @dtslvr 

I had an issues with one datagathering job as a value was missing.

In the combination GBp <-> GBP and the root currency handling one value was missing ([08.10.2013 for GBP was missing](https://finance.yahoo.com/quote/GBPUSD%3DX/history/?period1=1381017600&period2=1381363200))
This lead to the whole update job to fail, now it checks if a value is present before trying to multiply it with the sub currency factor.

I