### PR TITLE
feat: set up recommendedTypeChecked rule in eslint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -93,26 +93,28 @@
         "no-prototype-builtins": "warn",
         "no-async-promise-executor": "warn",
         "no-constant-condition": "warn",
-        // the following rules are part of @typescript-eslint/recommended-type-checked, remove once solved
-        "@typescript-eslint/no-unused-expressions": "warn",
-        "@typescript-eslint/ban-ts-comment": "warn",
-        "@typescript-eslint/no-unsafe-assignment": "warn",
-        "@typescript-eslint/no-unsafe-member-access": "warn",
-        "@typescript-eslint/no-unsafe-return": "warn",
-        "@typescript-eslint/no-unsafe-argument": "warn",
-        "@typescript-eslint/no-explicit-any": "warn",
-        "@typescript-eslint/no-unused-vars": "warn",
-        "@typescript-eslint/no-unnecessary-type-assertion": "warn",
-        "@typescript-eslint/no-unsafe-call": "warn",
-        "@typescript-eslint/require-await": "warn",
+
+        // The following rules are part of @typescript-eslint/recommended-type-checked
+        // and can be remove once solved
         "@typescript-eslint/await-thenable": "warn",
-        "@typescript-eslint/unbound-method": "warn",
-        "@typescript-eslint/no-redundant-type-constituents": "warn",
+        "@typescript-eslint/ban-ts-comment": "warn",
+        "@typescript-eslint/no-base-to-string": "warn",
+        "@typescript-eslint/no-explicit-any": "warn",
         "@typescript-eslint/no-floating-promises": "warn",
         "@typescript-eslint/no-misused-promises": "warn",
+        "@typescript-eslint/no-redundant-type-constituents": "warn",
+        "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+        "@typescript-eslint/no-unsafe-argument": "warn",
+        "@typescript-eslint/no-unsafe-assignment": "warn",
         "@typescript-eslint/no-unsafe-enum-comparison": "warn",
+        "@typescript-eslint/no-unused-expressions": "warn",
+        "@typescript-eslint/no-unsafe-member-access": "warn",
+        "@typescript-eslint/no-unsafe-return": "warn",
+        "@typescript-eslint/no-unused-vars": "warn",
+        "@typescript-eslint/no-unsafe-call": "warn",
+        "@typescript-eslint/require-await": "warn",
         "@typescript-eslint/restrict-template-expressions": "warn",
-        "@typescript-eslint/no-base-to-string": "warn",
+        "@typescript-eslint/unbound-method": "warn",
         "prefer-const": "warn"
       }
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
     {
       "files": ["*.ts"],
       "plugins": ["eslint-plugin-import", "@typescript-eslint"],
+      "extends": ["plugin:@typescript-eslint/recommended-type-checked"],
       "rules": {
         "@typescript-eslint/consistent-type-definitions": "warn",
         "@typescript-eslint/dot-notation": "off",
@@ -53,7 +54,6 @@
             "ignoreParameters": true
           }
         ],
-        "@typescript-eslint/no-misused-new": "error",
         "@typescript-eslint/no-non-null-assertion": "warn",
         "@typescript-eslint/no-shadow": [
           "warn",
@@ -61,12 +61,10 @@
             "hoist": "all"
           }
         ],
-        "@typescript-eslint/no-unused-expressions": "warn",
         "@typescript-eslint/prefer-function-type": "warn",
         "@typescript-eslint/unified-signatures": "error",
         "@typescript-eslint/no-loss-of-precision": "warn",
         "@typescript-eslint/no-var-requires": "warn",
-        "@typescript-eslint/ban-ts-comment": "warn",
         "@typescript-eslint/ban-types": "warn",
         "arrow-body-style": "off",
         "constructor-super": "error",
@@ -83,11 +81,9 @@
         "no-fallthrough": "error",
         "no-new-wrappers": "error",
         "no-restricted-imports": ["error", "rxjs/Rx"],
-        "no-throw-literal": "warn",
         "no-undef-init": "error",
         "no-underscore-dangle": "off",
         "no-var": "error",
-        "prefer-const": "warn",
         "radix": "error",
         "no-unsafe-optional-chaining": "warn",
         "no-extra-boolean-cast": "warn",
@@ -96,7 +92,28 @@
         "no-unsafe-finally": "warn",
         "no-prototype-builtins": "warn",
         "no-async-promise-executor": "warn",
-        "no-constant-condition": "warn"
+        "no-constant-condition": "warn",
+        // the following rules are part of @typescript-eslint/recommended-type-checked, remove once solved
+        "@typescript-eslint/no-unused-expressions": "warn",
+        "@typescript-eslint/ban-ts-comment": "warn",
+        "@typescript-eslint/no-unsafe-assignment": "warn",
+        "@typescript-eslint/no-unsafe-member-access": "warn",
+        "@typescript-eslint/no-unsafe-return": "warn",
+        "@typescript-eslint/no-unsafe-argument": "warn",
+        "@typescript-eslint/no-explicit-any": "warn",
+        "@typescript-eslint/no-unused-vars": "warn",
+        "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+        "@typescript-eslint/no-unsafe-call": "warn",
+        "@typescript-eslint/require-await": "warn",
+        "@typescript-eslint/await-thenable": "warn",
+        "@typescript-eslint/unbound-method": "warn",
+        "@typescript-eslint/no-redundant-type-constituents": "warn",
+        "@typescript-eslint/no-floating-promises": "warn",
+        "@typescript-eslint/no-misused-promises": "warn",
+        "@typescript-eslint/no-unsafe-enum-comparison": "warn",
+        "@typescript-eslint/restrict-template-expressions": "warn",
+        "@typescript-eslint/no-base-to-string": "warn",
+        "prefer-const": "warn"
       }
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Set up a git-hook via `husky` to lint and format the changes before a commit
+- Added the `typescript-eslint/recommended-type-checked` rule to the `eslint` configuration
 
 ### Fixed
 

--- a/apps/client-e2e/.eslintrc.json
+++ b/apps/client-e2e/.eslintrc.json
@@ -5,7 +5,7 @@
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "parserOptions": {
-        "project": ["apps/ui-e2e/tsconfig.json"]
+        "project": ["apps/client-e2e/tsconfig.*?.json"]
       },
       "rules": {}
     },

--- a/libs/ui/.eslintrc.json
+++ b/libs/ui/.eslintrc.json
@@ -1,9 +1,12 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "**/*.stories.ts"],
   "overrides": [
     {
-      "files": ["*.ts"],
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "parserOptions": {
+        "project": ["libs/ui/tsconfig.*?.json"]
+      },
       "extends": [
         "plugin:@nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates"


### PR DESCRIPTION
Fixes #3874 

`"@typescript-eslint/no-misused-new": "error"` was removed, because it is already part of `@typescript-eslint/recommended-type-checked`
Other rules which are part of `@typescript-eslint/recommended-type-checked` were moved further down the file, separated by a comment, so they are easier to distinguish from the rest of the rules.
New rules which got introduced with `@typescript-eslint/recommended-type-checked` and would throw errors were set to "warn" so they can be solved later.

Next step could be, to also add `@typescript-eslint/stylistic-type-checked` to the rules (https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/stylistic-type-checked.ts) via the same process: add rules -> lint -> overwrite broken rules from "error" to "warn".
Alternative: consider adding https://github.com/eslint-stylistic/eslint-stylistic to the project


Signed-off-by: Dominik Willner <th33xitus@gmail.com>