### PR TITLE
feat: set up stylisticTypeChecked rule in eslint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,33 @@
           }
         ],
         "@typescript-eslint/member-ordering": "warn",
-        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/naming-convention": [
+          "warn",
+          {
+            "selector": "default",
+            "format": ["camelCase"],
+            "leadingUnderscore": "allow",
+            "trailingUnderscore": "allow"
+          },
+          {
+            "selector": ["variable", "classProperty", "typeProperty"],
+            "format": ["camelCase", "UPPER_CASE"],
+            "leadingUnderscore": "allow",
+            "trailingUnderscore": "allow"
+          },
+          {
+            "selector": "objectLiteralProperty",
+            "format": null
+          },
+          {
+            "selector": "enumMember",
+            "format": ["camelCase", "UPPER_CASE", "PascalCase"]
+          },
+          {
+            "selector": "typeLike",
+            "format": ["PascalCase"]
+          }
+        ],
         "@typescript-eslint/no-empty-interface": "warn",
         "@typescript-eslint/no-inferrable-types": [
           "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,7 @@
         ],
         "@typescript-eslint/member-ordering": "warn",
         "@typescript-eslint/naming-convention": [
-          "warn",
+          "off",
           {
             "selector": "default",
             "format": ["camelCase"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,9 +34,11 @@
     {
       "files": ["*.ts"],
       "plugins": ["eslint-plugin-import", "@typescript-eslint"],
-      "extends": ["plugin:@typescript-eslint/recommended-type-checked"],
+      "extends": [
+        "plugin:@typescript-eslint/recommended-type-checked",
+        "plugin:@typescript-eslint/stylistic-type-checked"
+      ],
       "rules": {
-        "@typescript-eslint/consistent-type-definitions": "warn",
         "@typescript-eslint/dot-notation": "off",
         "@typescript-eslint/explicit-member-accessibility": [
           "off",
@@ -46,7 +48,6 @@
         ],
         "@typescript-eslint/member-ordering": "warn",
         "@typescript-eslint/naming-convention": "off",
-        "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-empty-interface": "warn",
         "@typescript-eslint/no-inferrable-types": [
           "warn",
@@ -61,7 +62,6 @@
             "hoist": "all"
           }
         ],
-        "@typescript-eslint/prefer-function-type": "warn",
         "@typescript-eslint/unified-signatures": "error",
         "@typescript-eslint/no-loss-of-precision": "warn",
         "@typescript-eslint/no-var-requires": "warn",
@@ -114,7 +114,18 @@
         "@typescript-eslint/require-await": "warn",
         "@typescript-eslint/restrict-template-expressions": "warn",
         "@typescript-eslint/unbound-method": "warn",
-        "prefer-const": "warn"
+        "prefer-const": "warn",
+
+        // The following rules are part of @typescript-eslint/stylistic-type-checked
+        // and can be remove once solved
+        "@typescript-eslint/consistent-type-definitions": "warn",
+        "@typescript-eslint/prefer-function-type": "warn",
+        "@typescript-eslint/no-empty-function": "warn",
+        "@typescript-eslint/prefer-nullish-coalescing": "warn", // requires strictNullChecks: true
+        "@typescript-eslint/consistent-type-assertions": "warn",
+        "@typescript-eslint/prefer-optional-chain": "warn",
+        "@typescript-eslint/consistent-indexed-object-style": "warn",
+        "@typescript-eslint/consistent-generic-constructors": "warn"
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,7 +147,7 @@
         "@typescript-eslint/consistent-type-definitions": "warn",
         "@typescript-eslint/prefer-function-type": "warn",
         "@typescript-eslint/no-empty-function": "warn",
-        "@typescript-eslint/prefer-nullish-coalescing": "warn", // requires strictNullChecks: true
+        "@typescript-eslint/prefer-nullish-coalescing": "warn", // TODO: Requires strictNullChecks: true
         "@typescript-eslint/consistent-type-assertions": "warn",
         "@typescript-eslint/prefer-optional-chain": "warn",
         "@typescript-eslint/consistent-indexed-object-style": "warn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set up a git-hook via `husky` to lint and format the changes before a commit
 - Added the `typescript-eslint/recommended-type-checked` rule to the `eslint` configuration
+- Added the `typescript-eslint/stylistic-type-checked` rule to the `eslint` configuration
 
 ### Fixed
 

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -15,7 +15,8 @@
   ],
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictTemplates": false
+    "strictInputAccessModifiers": false, // todo: enable strict input access modifiers
+    "strictTemplates": false // todo: enable strict templates
   },
   "compilerOptions": {
     "target": "es2020"

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -15,8 +15,9 @@
   ],
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": false, // todo: enable strict input access modifiers
-    "strictTemplates": false // todo: enable strict templates
+    // TODO: Enable stricter rules for this project
+    "strictInputAccessModifiers": false,
+    "strictTemplates": false
   },
   "compilerOptions": {
     "target": "es2020"

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -14,10 +14,9 @@
     }
   ],
   "compilerOptions": {
-    "forceConsistentCasingInFileNames": true,
-    "strict": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
+    "strict": false, // remove once solved in tsconfig.base.json
+    "noImplicitReturns": true, // remove once solved in tsconfig.base.json
+    "noFallthroughCasesInSwitch": true, // remove once solved in tsconfig.base.json
     "target": "es2020"
   },
   "angularCompilerOptions": {

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -14,10 +14,11 @@
     }
   ],
   "compilerOptions": {
-    "strict": false, // remove once solved in tsconfig.base.json
-    "noImplicitReturns": true, // remove once solved in tsconfig.base.json
-    "noFallthroughCasesInSwitch": true, // remove once solved in tsconfig.base.json
-    "target": "es2020"
+    "target": "es2020",
+    // TODO: Remove once solved in tsconfig.base.json
+    "strict": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,6 @@
     },
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-    // set to true to enable stricter type checking for this project
     "strict": false,
     "strictNullChecks": false,
     "strictPropertyInitialization": false,
@@ -34,7 +33,7 @@
     "noPropertyAccessFromIndexSignature": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "allowUnreachableCode": true // set to false for stricter type checking
+    "allowUnreachableCode": true
   },
   "exclude": ["node_modules", "tmp"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,21 @@
       "@ghostfolio/client/*": ["apps/client/src/app/*"],
       "@ghostfolio/common/*": ["libs/common/src/lib/*"],
       "@ghostfolio/ui/*": ["libs/ui/src/lib/*"]
-    }
+    },
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    // set to true to enable stricter type checking for this project
+    "strict": false,
+    "strictNullChecks": false,
+    "strictPropertyInitialization": false,
+    "noImplicitReturns": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noImplicitOverride": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "allowUnreachableCode": true // set to false for stricter type checking
   },
   "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
Fixes #3877 

Draft, once this is clearified:
>I have a question to this rule: https://typescript-eslint.io/rules/naming-convention/
>It is currently completely disabled. Is this intended? Should it stay disabled?

_Originally posted by @dw-0 in https://github.com/ghostfolio/ghostfolio/issues/3877#issuecomment-2395105096_

Within the scope of this PR, i also added some more type and style checks to the tsconfig files. I think those make sense as well, i hope that was okay and does not require another PR. But since i made it its own commit, it wouldn't be a big issue to extract it into a new PR.

What i noticed when i worked on this PR is, that for some reason the linting can indeed take quite a long time even though the cache was already built. Especially when squashing commits, it seems like the cache is ignored. Maybe we really want to look into linting only staged files, this should speed up the overall linting quite a lot. The build action could then run the full lint check on new PRs (would require a new ticket for this).

Signed-off-by: Dominik Willner <th33xitus@gmail.com>