### PR TITLE
cicd: add lint step to build-code.yml workflow

### DIFF
--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check code style
+        run: npm run lint
+
       - name: Check formatting
         run: npm run format:check
 


### PR DESCRIPTION
This PR adds a lint step to the existing build-code.yml.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>