### PR TITLE
Feature/Extend tooltip in treemap chart component by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added the name to the tooltip of the chart of the holdings tab on the home page (experimental)
+
 ### Fixed
 
 - Considered the language of the user settings on login with _Security Token_

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -227,16 +227,22 @@ export class GfTreemapChartComponent
       }),
       callbacks: {
         label: (context) => {
+          const name = context.raw._data.name;
+          const symbol = context.raw._data.symbol;
+
           if (context.raw._data.valueInBaseCurrency !== null) {
             const value = <number>context.raw._data.valueInBaseCurrency;
-            return `${value.toLocaleString(this.locale, {
-              maximumFractionDigits: 2,
-              minimumFractionDigits: 2
-            })} ${this.baseCurrency}`;
+            return [
+              `${name ?? symbol}`,
+              `${value.toLocaleString(this.locale, {
+                maximumFractionDigits: 2,
+                minimumFractionDigits: 2
+              })} ${this.baseCurrency}`
+            ];
           } else {
             const percentage =
               <number>context.raw._data.allocationInPercentage * 100;
-            return `${percentage.toFixed(2)}%`;
+            return [`${name ?? symbol}`, `${percentage.toFixed(2)}%`];
           }
         },
         title: () => {

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -232,6 +232,7 @@ export class GfTreemapChartComponent
 
           if (context.raw._data.valueInBaseCurrency !== null) {
             const value = <number>context.raw._data.valueInBaseCurrency;
+
             return [
               `${name ?? symbol}`,
               `${value.toLocaleString(this.locale, {
@@ -242,6 +243,7 @@ export class GfTreemapChartComponent
           } else {
             const percentage =
               <number>context.raw._data.allocationInPercentage * 100;
+
             return [`${name ?? symbol}`, `${percentage.toFixed(2)}%`];
           }
         },


### PR DESCRIPTION
Fixes #3904.

This PR adds the `name` (and `symbol` as a fallback) to the label for the tooltip in [GfTreemapChartComponent](https://github.com/ghostfolio/ghostfolio/tree/main/libs/ui/src/lib/treemap-chart).

It should also be possible to display the name/symbol as the tooltip **title** instead if preferred, but [GfPortfolioProportionChartComponent](https://github.com/ghostfolio/ghostfolio/blob/main/libs/ui/src/lib/portfolio-proportion-chart/portfolio-proportion-chart.component.ts#L423) puts them in the label so I decided to keep it consistent.

![image](https://github.com/user-attachments/assets/cc183729-3348-43ea-9b71-732a6f46ba0e)
