### PR TITLE
add/color-red-green-euqal-to-grey-always

### DIFF
--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -91,7 +91,7 @@ export class GfTreemapChartComponent
       datasets: [
         {
           backgroundColor(ctx) {
-            const annualizedNetPerformancePercentWithCurrencyEffect =
+            let annualizedNetPerformancePercentWithCurrencyEffect =
               getAnnualizedPerformancePercent({
                 daysInMarket: differenceInDays(
                   endDate,
@@ -105,7 +105,15 @@ export class GfTreemapChartComponent
                 )
               }).toNumber();
 
-            if (
+              if (annualizedNetPerformancePercentWithCurrencyEffect === -0) {
+                annualizedNetPerformancePercentWithCurrencyEffect = 0;
+              }
+              
+              if (annualizedNetPerformancePercentWithCurrencyEffect === 0) {
+                return gray[3];
+              }
+
+            else if(
               annualizedNetPerformancePercentWithCurrencyEffect >
               0.03 * GfTreemapChartComponent.HEAT_MULTIPLIER
             ) {


### PR DESCRIPTION
fixes #3906 

*This pr improved the background assignment in the*  [treemap chart component](https://github.com/ghostfolio/ghostfolio/blob/main/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts#L94):


*This change  ensures that both 0.00% and -0.00% are treated consistently with a gray background.*

fixes #3906 