### PR TITLE
feat: replace mat-input with mat-slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the labels of the chart of the holdings tab on the home page (experimental)
+- Improved the usability to customize the rule thresholds in the _X-ray_ section by introducing sliders (experimental)
 - Refactored the rule thresholds in the _X-ray_ section (experimental)
 - Exposed the timeout of the portfolio snapshot computation as an environment variable (`PROCESSOR_PORTFOLIO_SNAPSHOT_COMPUTATION_TIMEOUT`)
 - Harmonized the processor concurrency environment variables

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.component.ts
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSliderModule } from '@angular/material/slider';
 
 import { IRuleSettingsDialogParams } from './interfaces/interfaces';
 
@@ -21,7 +22,8 @@ import { IRuleSettingsDialogParams } from './interfaces/interfaces';
     MatButtonModule,
     MatDialogModule,
     MatFormFieldModule,
-    MatInputModule
+    MatInputModule,
+    MatSliderModule
   ],
   selector: 'gf-rule-settings-dialog',
   standalone: true,

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.component.ts
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.component.ts
@@ -9,8 +9,6 @@ import {
   MatDialogModule,
   MatDialogRef
 } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatSliderModule } from '@angular/material/slider';
 
 import { IRuleSettingsDialogParams } from './interfaces/interfaces';
@@ -21,8 +19,6 @@ import { IRuleSettingsDialogParams } from './interfaces/interfaces';
     FormsModule,
     MatButtonModule,
     MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatSliderModule
   ],
   selector: 'gf-rule-settings-dialog',

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
@@ -2,11 +2,14 @@
 
 <div class="py-3" mat-dialog-content>
   <div
-    appearance="outline"
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMin }"
   >
-    <h5 i18n>Threshold Min ({{ data.settings.thresholdMin }})</h5>
+    <h6 class="mb-0">
+      <ng-container i18n>Threshold Min</ng-container> ({{
+        data.settings.thresholdMin?.toFixed(2)
+      }})
+    </h6>
     <label>{{ data.rule.configuration.threshold.min.toFixed(2) }}</label>
     <mat-slider
       name="thresholdMin"
@@ -19,19 +22,23 @@
     <label>{{ data.rule.configuration.threshold.max.toFixed(2) }}</label>
   </div>
   <div
-    appearance="outline"
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMax }"
   >
-    <h5 i18n>Threshold Max ({{ data.settings.thresholdMax }})</h5>
+    <h6 class="mb-0">
+      <ng-container i18n>Threshold Max</ng-container> ({{
+        data.settings.thresholdMax?.toFixed(2)
+      }})
+    </h6>
     <label>{{ data.rule.configuration.threshold.min.toFixed(2) }}</label>
     <mat-slider
       name="thresholdMax"
       [max]="data.rule.configuration.threshold.max"
       [min]="data.rule.configuration.threshold.min"
       [step]="data.rule.configuration.threshold.step"
-      ><input matSliderThumb [(ngModel)]="data.settings.thresholdMax"
-    /></mat-slider>
+    >
+      <input matSliderThumb [(ngModel)]="data.settings.thresholdMax" />
+    </mat-slider>
     <label>{{ data.rule.configuration.threshold.max.toFixed(2) }}</label>
   </div>
 </div>

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
@@ -6,7 +6,8 @@
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMin }"
   >
-    <label i18n>Threshold Min</label>
+    <h5 i18n>Threshold Min</h5>
+    <label>{{ data.settings.thresholdMin }}</label>
     <mat-slider
       name="thresholdMin"
       [max]="data.rule.configuration.threshold.max"
@@ -15,14 +16,14 @@
     >
       <input matSliderThumb [(ngModel)]="data.settings.thresholdMin" />
     </mat-slider>
-    <mat-label>{{ data.settings.thresholdMin }}</mat-label>
   </div>
   <div
     appearance="outline"
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMax }"
   >
-    <mat-label i18n>Threshold Max</mat-label>
+    <h5 i18n>Threshold Max</h5>
+    <label>{{ data.settings.thresholdMax }}</label>
     <mat-slider
       name="thresholdMax"
       [max]="data.rule.configuration.threshold.max"
@@ -30,7 +31,6 @@
       [step]="data.rule.configuration.threshold.step"
       ><input matSliderThumb [(ngModel)]="data.settings.thresholdMax"
     /></mat-slider>
-    <mat-label>{{ data.settings.thresholdMax }}</mat-label>
   </div>
 </div>
 

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
@@ -1,32 +1,37 @@
 <div mat-dialog-title>{{ data.rule.name }}</div>
 
 <div class="py-3" mat-dialog-content>
-  <mat-form-field
+  <div
     appearance="outline"
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMin }"
   >
-    <mat-label i18n>Threshold Min</mat-label>
-    <input
-      matInput
+    <label i18n>Threshold Min</label>
+    <mat-slider
       name="thresholdMin"
-      type="number"
-      [(ngModel)]="data.settings.thresholdMin"
-    />
-  </mat-form-field>
-  <mat-form-field
+      [max]="data.rule.configuration.threshold.max"
+      [min]="data.rule.configuration.threshold.min"
+      [step]="data.rule.configuration.threshold.step"
+    >
+      <input matSliderThumb [(ngModel)]="data.settings.thresholdMin" />
+    </mat-slider>
+    <mat-label>{{ data.settings.thresholdMin }}</mat-label>
+  </div>
+  <div
     appearance="outline"
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMax }"
   >
     <mat-label i18n>Threshold Max</mat-label>
-    <input
-      matInput
+    <mat-slider
       name="thresholdMax"
-      type="number"
-      [(ngModel)]="data.settings.thresholdMax"
-    />
-  </mat-form-field>
+      [max]="data.rule.configuration.threshold.max"
+      [min]="data.rule.configuration.threshold.min"
+      [step]="data.rule.configuration.threshold.step"
+      ><input matSliderThumb [(ngModel)]="data.settings.thresholdMax"
+    /></mat-slider>
+    <mat-label>{{ data.settings.thresholdMax }}</mat-label>
+  </div>
 </div>
 
 <div align="end" mat-dialog-actions>

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
@@ -6,8 +6,8 @@
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMin }"
   >
-    <h5 i18n>Threshold Min</h5>
-    <label>{{ data.settings.thresholdMin }}</label>
+    <h5 i18n>Threshold Min ({{ data.settings.thresholdMin }})</h5>
+    <label>{{ data.rule.configuration.threshold.min.toFixed(2) }}</label>
     <mat-slider
       name="thresholdMin"
       [max]="data.rule.configuration.threshold.max"
@@ -16,14 +16,15 @@
     >
       <input matSliderThumb [(ngModel)]="data.settings.thresholdMin" />
     </mat-slider>
+    <label>{{ data.rule.configuration.threshold.max.toFixed(2) }}</label>
   </div>
   <div
     appearance="outline"
     class="w-100"
     [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMax }"
   >
-    <h5 i18n>Threshold Max</h5>
-    <label>{{ data.settings.thresholdMax }}</label>
+    <h5 i18n>Threshold Max ({{ data.settings.thresholdMax }})</h5>
+    <label>{{ data.rule.configuration.threshold.min.toFixed(2) }}</label>
     <mat-slider
       name="thresholdMax"
       [max]="data.rule.configuration.threshold.max"
@@ -31,6 +32,7 @@
       [step]="data.rule.configuration.threshold.step"
       ><input matSliderThumb [(ngModel)]="data.settings.thresholdMax"
     /></mat-slider>
+    <label>{{ data.rule.configuration.threshold.max.toFixed(2) }}</label>
   </div>
 </div>
 


### PR DESCRIPTION
Replace the mat-input components for Threshold Min and Threshold Max to <mat-slider> (see [Slider](https://material.angular.io/components/slider/overview)) in the [rule settings dialog component](https://github.com/ghostfolio/ghostfolio/tree/main/apps/client/src/app/components/rule/rule-settings-dialog).

<img width="934" alt="image" src="https://github.com/user-attachments/assets/e82ac2f1-12fc-4592-861e-b9e1a2318542">

### Related Issue
- [[FEATURE] Change input to slider in rule settings dialog](https://github.com/ghostfolio/ghostfolio/issues/3917)