### PR TITLE
feat: split holdings in chart dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Improved the backgrounds of the chart of the holdings tab on the home page (experimental)
+
 ### Fixed
 
 - Fixed an issue in the carousel component for the testimonial section on the landing page

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -86,32 +86,38 @@ export class GfTreemapChartComponent
     this.isLoading = true;
 
     const { endDate, startDate } = getIntervalFromDateRange(this.dateRange);
-    const netPerformancePercentsWithCurrencyEffect = this.holdings.map((h) =>
-      getAnnualizedPerformancePercent({
-        daysInMarket: differenceInDays(
-          endDate,
-          max([h.dateOfFirstActivity ?? new Date(0), startDate])
-        ),
-        netPerformancePercentage: new Big(
-          h.netPerformancePercentWithCurrencyEffect
-        )
-      }).toNumber()
+    const netPerformancePercentsWithCurrencyEffect = this.holdings.map(
+      ({ dateOfFirstActivity, netPerformancePercentWithCurrencyEffect }) => {
+        return getAnnualizedPerformancePercent({
+          daysInMarket: differenceInDays(
+            endDate,
+            max([dateOfFirstActivity ?? new Date(0), startDate])
+          ),
+          netPerformancePercentage: new Big(
+            netPerformancePercentWithCurrencyEffect
+          )
+        }).toNumber();
+      }
     );
 
-    const positiveNetPercents = netPerformancePercentsWithCurrencyEffect.filter(
-      (v) => v > 0
-    );
-    const positiveNetPercentsRange = {
-      max: Math.max(...positiveNetPercents),
-      min: Math.min(...positiveNetPercents)
+    const positiveNetPerformancePercents =
+      netPerformancePercentsWithCurrencyEffect.filter((v) => {
+        return v > 0;
+      });
+    const positiveNetPerformancePercentsRange = {
+      max: Math.max(...positiveNetPerformancePercents),
+      min: Math.min(...positiveNetPerformancePercents)
     };
-    const negativeNetPercents = netPerformancePercentsWithCurrencyEffect.filter(
-      (v) => v < 0
-    );
-    const negativeNetPercentsRange = {
-      max: Math.max(...negativeNetPercents),
-      min: Math.min(...negativeNetPercents)
+
+    const negativeNetPerformancePercents =
+      netPerformancePercentsWithCurrencyEffect.filter((v) => {
+        return v < 0;
+      });
+    const negativeNetPerformancePercentsRange = {
+      max: Math.max(...negativeNetPerformancePercents),
+      min: Math.min(...negativeNetPerformancePercents)
     };
+
     const data: ChartConfiguration['data'] = {
       datasets: [
         {
@@ -129,6 +135,7 @@ export class GfTreemapChartComponent
                   ctx.raw._data.netPerformancePercentWithCurrencyEffect
                 )
               }).toNumber();
+
             // Round to 2 decimal places
             annualizedNetPerformancePercentWithCurrencyEffect =
               Math.round(
@@ -146,49 +153,51 @@ export class GfTreemapChartComponent
 
             if (annualizedNetPerformancePercentWithCurrencyEffect > 0) {
               const range =
-                positiveNetPercentsRange.max - positiveNetPercentsRange.min;
+                positiveNetPerformancePercentsRange.max -
+                positiveNetPerformancePercentsRange.min;
+
               if (
                 annualizedNetPerformancePercentWithCurrencyEffect >=
-                positiveNetPercentsRange.max - range * 0.25
+                positiveNetPerformancePercentsRange.max - range * 0.25
               ) {
                 return green[9];
-              }
-              if (
+              } else if (
                 annualizedNetPerformancePercentWithCurrencyEffect >=
-                positiveNetPercentsRange.max - range * 0.5
+                positiveNetPerformancePercentsRange.max - range * 0.5
               ) {
                 return green[7];
-              }
-              if (
+              } else if (
                 annualizedNetPerformancePercentWithCurrencyEffect >=
-                positiveNetPercentsRange.max - range * 0.75
+                positiveNetPerformancePercentsRange.max - range * 0.75
               ) {
                 return green[5];
               }
+
               return green[3];
             }
 
             const range =
-              negativeNetPercentsRange.min - negativeNetPercentsRange.max;
+              negativeNetPerformancePercentsRange.min -
+              negativeNetPerformancePercentsRange.max;
+
             if (
               annualizedNetPerformancePercentWithCurrencyEffect <=
-              negativeNetPercentsRange.min + range * 0.25
+              negativeNetPerformancePercentsRange.min + range * 0.25
             ) {
               return red[9];
-            }
-            if (
+            } else if (
               annualizedNetPerformancePercentWithCurrencyEffect <=
-              negativeNetPercentsRange.min + range * 0.5
+              negativeNetPerformancePercentsRange.min + range * 0.5
             ) {
               return red[7];
-            }
-            if (
+            } else if (
               annualizedNetPerformancePercentWithCurrencyEffect <=
-              negativeNetPercentsRange.min + range * 0.75
+              negativeNetPerformancePercentsRange.min + range * 0.75
             ) {
-              return red[7];
+              return red[5];
             }
-            return red[9];
+
+            return red[3];
           },
           borderRadius: 4,
           key: 'allocationInPercentage',

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -149,9 +149,7 @@ export class GfTreemapChartComponent
                 annualizedNetPerformancePercentWithCurrencyEffect
               );
               return gray[3];
-            }
-
-            if (annualizedNetPerformancePercentWithCurrencyEffect > 0) {
+            } else if (annualizedNetPerformancePercentWithCurrencyEffect > 0) {
               const range =
                 positiveNetPerformancePercentsRange.max -
                 positiveNetPerformancePercentsRange.min;

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -57,8 +57,6 @@ export class GfTreemapChartComponent
 
   @ViewChild('chartCanvas') chartCanvas: ElementRef<HTMLCanvasElement>;
 
-  public static readonly HEAT_MULTIPLIER = 5;
-
   public chart: Chart<'treemap'>;
   public isLoading = true;
 
@@ -86,6 +84,7 @@ export class GfTreemapChartComponent
     this.isLoading = true;
 
     const { endDate, startDate } = getIntervalFromDateRange(this.dateRange);
+
     const netPerformancePercentsWithCurrencyEffect = this.holdings.map(
       ({ dateOfFirstActivity, netPerformancePercentWithCurrencyEffect }) => {
         return getAnnualizedPerformancePercent({
@@ -101,18 +100,24 @@ export class GfTreemapChartComponent
     );
 
     const positiveNetPerformancePercents =
-      netPerformancePercentsWithCurrencyEffect.filter((v) => {
-        return v > 0;
-      });
+      netPerformancePercentsWithCurrencyEffect.filter(
+        (annualizedNetPerformancePercent) => {
+          return annualizedNetPerformancePercent > 0;
+        }
+      );
+
     const positiveNetPerformancePercentsRange = {
       max: Math.max(...positiveNetPerformancePercents),
       min: Math.min(...positiveNetPerformancePercents)
     };
 
     const negativeNetPerformancePercents =
-      netPerformancePercentsWithCurrencyEffect.filter((v) => {
-        return v < 0;
-      });
+      netPerformancePercentsWithCurrencyEffect.filter(
+        (annualizedNetPerformancePercent) => {
+          return annualizedNetPerformancePercent < 0;
+        }
+      );
+
     const negativeNetPerformancePercentsRange = {
       max: Math.max(...negativeNetPerformancePercents),
       min: Math.min(...negativeNetPerformancePercents)
@@ -172,30 +177,30 @@ export class GfTreemapChartComponent
               }
 
               return green[3];
+            } else {
+              const range =
+                negativeNetPerformancePercentsRange.min -
+                negativeNetPerformancePercentsRange.max;
+
+              if (
+                annualizedNetPerformancePercentWithCurrencyEffect <=
+                negativeNetPerformancePercentsRange.min + range * 0.25
+              ) {
+                return red[9];
+              } else if (
+                annualizedNetPerformancePercentWithCurrencyEffect <=
+                negativeNetPerformancePercentsRange.min + range * 0.5
+              ) {
+                return red[7];
+              } else if (
+                annualizedNetPerformancePercentWithCurrencyEffect <=
+                negativeNetPerformancePercentsRange.min + range * 0.75
+              ) {
+                return red[5];
+              }
+
+              return red[3];
             }
-
-            const range =
-              negativeNetPerformancePercentsRange.min -
-              negativeNetPerformancePercentsRange.max;
-
-            if (
-              annualizedNetPerformancePercentWithCurrencyEffect <=
-              negativeNetPerformancePercentsRange.min + range * 0.25
-            ) {
-              return red[9];
-            } else if (
-              annualizedNetPerformancePercentWithCurrencyEffect <=
-              negativeNetPerformancePercentsRange.min + range * 0.5
-            ) {
-              return red[7];
-            } else if (
-              annualizedNetPerformancePercentWithCurrencyEffect <=
-              negativeNetPerformancePercentsRange.min + range * 0.75
-            ) {
-              return red[5];
-            }
-
-            return red[3];
           },
           borderRadius: 4,
           key: 'allocationInPercentage',


### PR DESCRIPTION
Address [the issue](https://github.com/ghostfolio/ghostfolio/issues/3931) and split the datapoints on treemap in 9 groups from red[9] to green[9] colors based on _netPerformancePercentWithCurrencyEffect_