### PR TITLE
#3865 Add 'createdAt' field to PortfolioSnapshot and PublicPortfolioResponse

### DIFF
--- a/apps/api/src/app/endpoints/public/public.controller.ts
+++ b/apps/api/src/app/endpoints/public/public.controller.ts
@@ -84,6 +84,7 @@ export class PublicController {
       hasDetails,
       markets,
       alias: access.alias,
+      createdAt: performance1d.createdAt,
       holdings: {},
       performance: {
         '1d': {

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -176,6 +176,7 @@ export abstract class PortfolioCalculator {
     if (!transactionPoints.length) {
       return {
         currentValueInBaseCurrency: new Big(0),
+        createdAt: new Date(),
         hasErrors: false,
         historicalData: [],
         positions: [],

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -94,6 +94,7 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
     }
 
     return {
+      createdAt: new Date(),
       currentValueInBaseCurrency,
       hasErrors,
       positions,

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1085,6 +1085,7 @@ export class PortfolioService {
         firstOrderDate: undefined,
         hasErrors: false,
         performance: {
+          createdAt: undefined,
           currentNetWorth: 0,
           currentValueInBaseCurrency: 0,
           netPerformance: 0,
@@ -1105,7 +1106,7 @@ export class PortfolioService {
       currency: userCurrency
     });
 
-    const { errors, hasErrors, historicalData } =
+    const { createdAt, errors, hasErrors, historicalData } =
       await portfolioCalculator.getSnapshot();
 
     const { endDate, startDate } = getIntervalFromDateRange(dateRange);
@@ -1145,6 +1146,7 @@ export class PortfolioService {
         netPerformance,
         netPerformanceWithCurrencyEffect,
         totalInvestment,
+        createdAt: createdAt,
         currentNetWorth: netWorth,
         currentValueInBaseCurrency: valueWithCurrencyEffect,
         netPerformancePercentage: netPerformanceInPercentage,
@@ -1699,7 +1701,7 @@ export class PortfolioService {
       }
     }
 
-    const { currentValueInBaseCurrency, totalInvestment } =
+    const { createdAt, currentValueInBaseCurrency, totalInvestment } =
       await portfolioCalculator.getSnapshot();
 
     const { performance } = await this.getPerformance({
@@ -1817,6 +1819,7 @@ export class PortfolioService {
       totalSell,
       committedFunds: committedFunds.toNumber(),
       currentValueInBaseCurrency: currentValueInBaseCurrency.toNumber(),
+      createdAt: createdAt,
       dividendInBaseCurrency: dividendInBaseCurrency.toNumber(),
       emergencyFund: {
         assets: emergencyFundPositionsValueInBaseCurrency,

--- a/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
@@ -1,5 +1,6 @@
 export interface PortfolioPerformance {
   annualizedPerformancePercent?: number;
+  createdAt: Date;
   currentNetWorth?: number;
   currentValueInBaseCurrency: number;
   netPerformance: number;

--- a/libs/common/src/lib/interfaces/responses/public-portfolio-response.interface.ts
+++ b/libs/common/src/lib/interfaces/responses/public-portfolio-response.interface.ts
@@ -3,6 +3,7 @@ import { Market } from '../../types';
 
 export interface PublicPortfolioResponse extends PublicPortfolioResponseV1 {
   alias?: string;
+  createdAt: Date;
   hasDetails: boolean;
   holdings: {
     [symbol: string]: Pick<

--- a/libs/common/src/lib/models/portfolio-snapshot.ts
+++ b/libs/common/src/lib/models/portfolio-snapshot.ts
@@ -9,6 +9,8 @@ import { Big } from 'big.js';
 import { Transform, Type } from 'class-transformer';
 
 export class PortfolioSnapshot {
+  createdAt: Date;
+
   @Transform(transformToBig, { toClassOnly: true })
   @Type(() => Big)
   currentValueInBaseCurrency: Big;


### PR DESCRIPTION
### Issue
https://github.com/ghostfolio/ghostfolio/issues/3865

### What
Add `createdAt` field to PortfolioSnapshot and PublicPortfolioResponse to provide additional information for the client about the freshness of the calculations.

### How
- Added the field to multiple iterfaces
- Set the field whenever a snapshot is created and pass it through multiple methods to provide it in PublicPortfolioResponse