### PR TITLE
Fixed docker-compose redis healthcheck when password has special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the warning `export was not found` in connection with `GetValuesParams`
+- Quoted the password for the _Redis_ service `healthcheck` in the `docker-compose` files (`docker-compose.yml` and `docker-compose.build.yml`)
 
 ## 2.117.0 - 2024-10-19
 

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -39,7 +39,7 @@ services:
       - ../.env
     command: ['redis-server', '--requirepass', $REDIS_PASSWORD]
     healthcheck:
-      test: ['CMD-SHELL', 'redis-cli --pass $REDIS_PASSWORD ping | grep PONG']
+      test: ['CMD-SHELL', 'redis-cli --pass "$REDIS_PASSWORD" ping | grep PONG']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ../.env
     command: ['redis-server', '--requirepass', $REDIS_PASSWORD]
     healthcheck:
-      test: ['CMD-SHELL', 'redis-cli --pass $REDIS_PASSWORD ping | grep PONG']
+      test: ['CMD-SHELL', 'redis-cli --pass "$REDIS_PASSWORD" ping | grep PONG']
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Quoted $REDIS_PASSWORD var of the redis heathcheck command both docker-compose.build.yml and docker-compose.yml . This will fix the issue where starting ghostfolio with a $REDIS_PASSWORD

This will fix #3967

Testing:
Tested with both commands and ensure that the all containers start, pass healthchecks, and going to http://<IP>:3333 loads landing page.

`docker compose --env-file ./.env -f docker/docker-compose.yml up -d`

`docker compose --env-file ./.env -f docker/docker-compose.build.yml build && docker compose --env-file ./.env -f docker/docker-compose.build.yml up -d`

with the following .env

```
COMPOSE_PROJECT_NAME=ghostfolio

# CACHE
REDIS_HOST=localhost
REDIS_PORT=6379
REDIS_PASSWORD=FOO;BAR

# POSTGRES
POSTGRES_DB=ghostfolio-db
POSTGRES_USER=user
POSTGRES_PASSWORD=wJHw2oDV6zyByIH9Qa0eiZBadoyvunka

# VARIOUS
ACCESS_TOKEN_SALT=3r3rdbjzpnylECMYPe06s2Wnej5GmQKU
DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?connect_timeout=300&sslmode=prefer
JWT_SECRET_KEY=3NgliY9luSe1gjGtd5jr8Qn8UkV67Z7u
```