### PR TITLE
Change entrypoint.sh permission from 0700 to 0755 to fix #3946 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install -y --no-install-suggests \
 
 COPY --chown=node:node --from=builder /ghostfolio/dist/apps /ghostfolio/apps
 COPY --chown=node:node ./docker/entrypoint.sh /ghostfolio/entrypoint.sh
-RUN chmod 0700 /ghostfolio/entrypoint.sh
+RUN chmod 0755 /ghostfolio/entrypoint.sh
 WORKDIR /ghostfolio/apps/api
 EXPOSE ${PORT:-3333}
 USER node


### PR DESCRIPTION
Change entrypoint.sh permission from 0700 to 0755 to fix #3946 

When users run ghostfolio with a specified user in the compose file ghostfolio will not start because /ghostfolio/entrypoint.sh has permission 0700. This change gives other users other than the owner of entrypoint.sh permissions to read and execute.

Testing:

If you build from the current main with a different user (see following example), ghostfolio will not start with the error shown in #3946 .

```
docker compose --env-file ./.env -f docker/docker-compose.build.yml build
docker compose --env-file ./.env -f docker/docker-compose.build.yml up -d
```

```
services:
  ghostfolio:
    build: ../
    user: '999:1000'
    init: true
    env_file:
      - ../.env
... (all else the same, truncated to save space) ...
```

Note that the only change is `user: '999:1000'`

If you apply this change, you should see ghostfolio build and start  properly. Furthermore, after applying this change, ghostfolio will start with or without `user: '999:1000'`

Future work:

I've elected to only change `Dockerfile` and not any of the docker-compose yaml files as I don't understand the implication of changing everybody's dev ghostfolio user or everybody's production ghostfolio user. However, I strongly suggest that we add the following to at least the `docker-compose.build.yml` and potentially to `docker-compose.yml`

```
services:
  ghostfolio:
    build: ../
    user: '${PUID}:${GUID}'
    init: true
    env_file:
      - ../.env
... (all else the same, truncated to save space) ...
```

Also the following to `.env.example` and `.env.dev` with the UID and GID to be discussed.

```
COMPOSE_PROJECT_NAME=ghostfolio
PUID=999
PGID=1000

# CACHE
REDIS_HOST=localhost
... (all else the same, truncated to save space) ...
```

Finally, once merged and tested by the community, I would suggest that we spin up a new build to unbreak all current users running ghostfolio with a custom user.