### PR TITLE
refactor: run lint only on affected projects in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 # Run linting and stop the commit process if any errors are found
 # --quiet suppresses warnings (temporary until all warnings are fixed)
-npm run affected:lint --parallel=2 --base=main --head=HEAD --quiet || exit 1
+npm run affected:lint --base=main --head=HEAD --parallel=2 --quiet || exit 1
 
 # Check formatting on modified and uncommitted files, stop the commit if issues are found
 npm run format:check --uncommitted || exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 # Run linting and stop the commit process if any errors are found
 # --quiet suppresses warnings (temporary until all warnings are fixed)
-npm run lint --quiet || exit 1
+npm run affected:lint --parallel=2 --base=main --head=HEAD --quiet || exit 1
 
 # Check formatting on modified and uncommitted files, stop the commit if issues are found
 npm run format:check --uncommitted || exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Optimized the dialog sizes for mobile (full screen)
+- Optimized the git-hook via `husky` to lint only affected projects before a commit
 - Upgraded `angular` from version `18.1.1` to `18.2.8`
 - Upgraded `Nx` from version `19.5.6` to `20.0.3`
 


### PR DESCRIPTION
@dtslvr As discussed by mail, here a reworked pre-commit hook that only runs linting on affected projects.
Reference: https://nx.dev/nx-api/nx/documents/affected

An decrease in committing time due to faster linting was observed. E.g. changes in project `client` may affect projects `client-e2e` and `ui`. Therefor those 3 projects get linted.
![image](https://github.com/user-attachments/assets/7ff8dfd1-e263-4869-9eac-e028ffc3b14d)
