### PR TITLE
cicd: add stackname/container names to docker compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Set the stack and container names in the `docker-compose` files (`docker-compose.yml`, `docker-compose.build.yml` and `docker-compose.dev.yml`)
+
 ## 2.120.0 - 2024-10-30
 
 ### Added

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -1,6 +1,8 @@
+name: ghostfolio_build
 services:
   ghostfolio:
     build: ../
+    container_name: gf-application-build
     init: true
     env_file:
       - ../.env
@@ -23,6 +25,7 @@ services:
 
   postgres:
     image: docker.io/library/postgres:15
+    container_name: gf-postgres-build
     env_file:
       - ../.env
     healthcheck:
@@ -35,6 +38,7 @@ services:
 
   redis:
     image: docker.io/library/redis:alpine
+    container_name: gf-redis-build
     env_file:
       - ../.env
     command: ['redis-server', '--requirepass', $REDIS_PASSWORD]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,7 +1,8 @@
+name: ghostfolio_dev
 services:
   postgres:
     image: docker.io/library/postgres:15
-    container_name: postgres
+    container_name: gf-postgres-dev
     restart: unless-stopped
     env_file:
       - ../.env
@@ -12,7 +13,7 @@ services:
 
   redis:
     image: docker.io/library/redis:alpine
-    container_name: redis
+    container_name: gf-redis-dev
     restart: unless-stopped
     env_file:
       - ../.env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,8 @@
+name: ghostfolio
 services:
   ghostfolio:
     image: docker.io/ghostfolio/ghostfolio:latest
+    container_name: gf-application
     init: true
     cap_drop:
       - ALL
@@ -27,6 +29,7 @@ services:
 
   postgres:
     image: docker.io/library/postgres:15
+    container_name: gf-postgres
     cap_drop:
       - ALL
     cap_add:
@@ -49,6 +52,7 @@ services:
 
   redis:
     image: docker.io/library/redis:alpine
+    container_name: gf-redis
     user: '999:1000'
     cap_drop:
       - ALL


### PR DESCRIPTION
By adding (more or less unique) names to each stack and container, you allow to have multiple stacks at the same time and you can prevent container naming issues that e.g. a container with the name "redis" or "postgres" already exists:
![image](https://github.com/user-attachments/assets/64ab813e-17f8-49d4-8580-11adf8753661)

