### PR TITLE
bugfix: update name of the item type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue with the renaming of activities with type `FEE`, `INTEREST`, `ITEM` or `LIABILITY`
+
 ## 2.133.0 - 2025-01-08
 
 ### Added

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -476,7 +476,9 @@ export class CreateOrUpdateActivityDialog implements OnDestroy {
       fee: this.activityForm.get('fee').value,
       quantity: this.activityForm.get('quantity').value,
       symbol:
-        (['ITEM', 'FEE'].includes(this.activityForm.get('type').value)
+        (['FEE', 'INTEREST', 'ITEM', 'LIABILITY'].includes(
+          this.activityForm.get('type').value
+        )
           ? undefined
           : this.activityForm.get('searchSymbol')?.value?.symbol) ??
         this.activityForm.get('name')?.value,

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -1,7 +1,5 @@
 import { CreateOrderDto } from '@ghostfolio/api/app/order/create-order.dto';
 import { UpdateOrderDto } from '@ghostfolio/api/app/order/update-order.dto';
-import { DataService } from '@ghostfolio/client/services/data.service';
-import { validateObjectForForm } from '@ghostfolio/client/util/form.util';
 import { getDateFormatString } from '@ghostfolio/common/helper';
 import { translate } from '@ghostfolio/ui/i18n';
 
@@ -24,6 +22,8 @@ import { isAfter, isToday } from 'date-fns';
 import { EMPTY, Observable, Subject, lastValueFrom, of } from 'rxjs';
 import { catchError, delay, map, startWith, takeUntil } from 'rxjs/operators';
 
+import { DataService } from '../../../../services/data.service';
+import { validateObjectForForm } from '../../../../util/form.util';
 import { CreateOrUpdateActivityDialogParams } from './interfaces/interfaces';
 
 @Component({
@@ -124,7 +124,7 @@ export class CreateOrUpdateActivityDialog implements OnDestroy {
       name: [this.data.activity?.SymbolProfile?.name, Validators.required],
       quantity: [this.data.activity?.quantity, Validators.required],
       searchSymbol: [
-        !!this.data.activity?.SymbolProfile
+        this.data.activity?.SymbolProfile
           ? {
               dataSource: this.data.activity?.SymbolProfile?.dataSource,
               symbol: this.data.activity?.SymbolProfile?.symbol
@@ -476,7 +476,9 @@ export class CreateOrUpdateActivityDialog implements OnDestroy {
       fee: this.activityForm.get('fee').value,
       quantity: this.activityForm.get('quantity').value,
       symbol:
-        this.activityForm.get('searchSymbol')?.value?.symbol ??
+        (this.activityForm.get('type').value === 'ITEM'
+          ? undefined
+          : this.activityForm.get('searchSymbol')?.value?.symbol) ??
         this.activityForm.get('name')?.value,
       tags: this.activityForm.get('tags').value,
       type: this.activityForm.get('type').value,
@@ -485,8 +487,9 @@ export class CreateOrUpdateActivityDialog implements OnDestroy {
 
     try {
       if (this.mode === 'create') {
-        (activity as CreateOrderDto).updateAccountBalance =
-          this.activityForm.get('updateAccountBalance').value;
+        activity.updateAccountBalance = this.activityForm.get(
+          'updateAccountBalance'
+        ).value;
 
         await validateObjectForForm({
           classDto: CreateOrderDto,
@@ -495,7 +498,7 @@ export class CreateOrUpdateActivityDialog implements OnDestroy {
           object: activity
         });
 
-        this.dialogRef.close(activity as CreateOrderDto);
+        this.dialogRef.close(activity);
       } else {
         (activity as UpdateOrderDto).id = this.data.activity.id;
 

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -476,7 +476,7 @@ export class CreateOrUpdateActivityDialog implements OnDestroy {
       fee: this.activityForm.get('fee').value,
       quantity: this.activityForm.get('quantity').value,
       symbol:
-        (this.activityForm.get('type').value === 'ITEM'
+        (['ITEM', 'FEE'].includes(this.activityForm.get('type').value)
           ? undefined
           : this.activityForm.get('searchSymbol')?.value?.symbol) ??
         this.activityForm.get('name')?.value,


### PR DESCRIPTION
Issue:
While editing orders of type ITEM, it was discovered that the name field was being replaced with the order ID instead of retaining the updated name. This caused the name field to display incorrect data after editing.

Fix:
Adjusted the logic to ensure that the name field is updated correctly during the editing process. Now, when editing an order of type ITEM, the name will reflect the new value provided instead of being overwritten by the order ID.