### PR TITLE
import: fix import of FEE record with unitPrice=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue with the import of activities with type `FEE` (where unit price is `0`)
 - Fixed an issue with the renaming of activities with type `FEE`, `INTEREST`, `ITEM` or `LIABILITY`
 
 ## 2.133.1 - 2025-01-09

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -30,7 +30,7 @@ import { Injectable } from '@nestjs/common';
 import { DataSource, Prisma, SymbolProfile } from '@prisma/client';
 import { Big } from 'big.js';
 import { endOfToday, format, isAfter, isSameSecond, parseISO } from 'date-fns';
-import { uniqBy } from 'lodash';
+import { isNumber, uniqBy } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
@@ -328,8 +328,7 @@ export class ImportService {
           date
         );
 
-        // unitPrice can be 0 if it's a fee record
-        if (unitPrice === undefined) {
+        if (!isNumber(unitPrice)) {
           throw new Error(
             `activities.${index} historical exchange rate at ${format(
               date,

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -328,7 +328,8 @@ export class ImportService {
           date
         );
 
-        if (!unitPrice) {
+        // unitPrice can be 0 if it's a fee record
+        if (unitPrice === undefined) {
           throw new Error(
             `activities.${index} historical exchange rate at ${format(
               date,


### PR DESCRIPTION
The current code gives a misleading error: `activities.0 historical exchange rate at 2025-01-10 is not available from "EUR" to "USD"` when importing a record with unitPrice=0.

The reason is that the code treats `unitPrice=0` as an undefined value, giving the error.

This PR fixes it.