### PR TITLE
Feature/upgrade chart.js dependencies to the latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extended the search by `isin` in the _Financial Modeling Prep_ service
 - Switched to _ESLint_’s flat config format
+- Upgraded `chart.js` from version `4.2.0` to `4.4.7`
+- Upgraded `chartjs-chart-treemap` from version `2.3.1` to `3.1.0`
+- Upgraded `chartjs-plugin-annotation` from version `2.1.2` to `3.1.0`
 - Upgraded `eslint` dependencies
 
 ## 2.134.0 - 2025-01-15

--- a/libs/ui/src/lib/portfolio-proportion-chart/portfolio-proportion-chart.component.ts
+++ b/libs/ui/src/lib/portfolio-proportion-chart/portfolio-proportion-chart.component.ts
@@ -77,7 +77,7 @@ export class GfPortfolioProportionChartComponent
 
   @ViewChild('chartCanvas') chartCanvas: ElementRef<HTMLCanvasElement>;
 
-  public chart: Chart<'pie'>;
+  public chart: Chart<'doughnut'>;
   public isLoading = true;
 
   private readonly OTHER_KEY = 'OTHER';
@@ -257,7 +257,7 @@ export class GfPortfolioProportionChartComponent
       });
     });
 
-    const datasets: ChartConfiguration['data']['datasets'] = [
+    const datasets: ChartConfiguration<'doughnut'>['data']['datasets'] = [
       {
         backgroundColor: chartDataSorted.map(([, item]) => {
           return item.color;
@@ -295,7 +295,7 @@ export class GfPortfolioProportionChartComponent
       datasets[1].data[1] = Number.MAX_SAFE_INTEGER;
     }
 
-    const data: ChartConfiguration['data'] = {
+    const data: ChartConfiguration<'doughnut'>['data'] = {
       datasets,
       labels
     };
@@ -308,7 +308,7 @@ export class GfPortfolioProportionChartComponent
         ) as unknown;
         this.chart.update();
       } else {
-        this.chart = new Chart(this.chartCanvas.nativeElement, {
+        this.chart = new Chart<'doughnut'>(this.chartCanvas.nativeElement, {
           data,
           options: {
             animation: false,

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.ts
@@ -196,7 +196,7 @@ export class GfTreemapChartComponent
       min: Math.min(...negativeNetPerformancePercents)
     };
 
-    const data: ChartConfiguration['data'] = {
+    const data: ChartConfiguration<'treemap'>['data'] = {
       datasets: [
         {
           backgroundColor: (ctx) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "chart.js": "4.2.0",
         "chartjs-adapter-date-fns": "3.0.0",
         "chartjs-chart-treemap": "3.1.0",
-        "chartjs-plugin-annotation": "2.1.2",
+        "chartjs-plugin-annotation": "3.1.0",
         "chartjs-plugin-datalabels": "2.2.0",
         "cheerio": "1.0.0",
         "class-transformer": "0.5.1",
@@ -14339,12 +14339,12 @@
       }
     },
     "node_modules/chartjs-plugin-annotation": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-2.1.2.tgz",
-      "integrity": "sha512-kmEp2WtpogwnKKnDPO3iO3mVwvVGtmG5BkZVtAEZm5YzJ9CYxojjYEgk7OTrFbJ5vU098b84UeJRe8kRfNcq5g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
+      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
       "license": "MIT",
       "peerDependencies": {
-        "chart.js": ">=3.7.0"
+        "chart.js": ">=4.0.0"
       }
     },
     "node_modules/chartjs-plugin-datalabels": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "bull": "4.16.2",
         "cache-manager": "5.7.6",
         "cache-manager-redis-yet": "5.1.4",
-        "chart.js": "4.2.0",
+        "chart.js": "4.4.7",
         "chartjs-adapter-date-fns": "3.0.0",
         "chartjs-chart-treemap": "3.1.0",
         "chartjs-plugin-annotation": "3.1.0",
@@ -14308,15 +14308,15 @@
       "license": "MIT"
     },
     "node_modules/chart.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.0.tgz",
-      "integrity": "sha512-wbtcV+QKeH0F7gQZaCJEIpsNriFheacouJQTVIjITi3eQA8bTlIBoknz0+dgV79aeKLNMAX+nDslIVE/nJ3rzA==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
+      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
       "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
-        "pnpm": "^7.0.0"
+        "pnpm": ">=8"
       }
     },
     "node_modules/chartjs-adapter-date-fns": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "cache-manager-redis-yet": "5.1.4",
         "chart.js": "4.2.0",
         "chartjs-adapter-date-fns": "3.0.0",
-        "chartjs-chart-treemap": "2.3.1",
+        "chartjs-chart-treemap": "3.1.0",
         "chartjs-plugin-annotation": "2.1.2",
         "chartjs-plugin-datalabels": "2.2.0",
         "cheerio": "1.0.0",
@@ -14330,9 +14330,9 @@
       }
     },
     "node_modules/chartjs-chart-treemap": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/chartjs-chart-treemap/-/chartjs-chart-treemap-2.3.1.tgz",
-      "integrity": "sha512-GW+iODLICIJhNZtHbTtaOjCwRIxmXcquXRKDFMsrkXyqyDeSN1aiVfzNNj6Xjy55soopqRA+YfHqjT2S2zF7lQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartjs-chart-treemap/-/chartjs-chart-treemap-3.1.0.tgz",
+      "integrity": "sha512-0LJxj4J9sCTHmrXCFlqtoBKMJDcS7VzFeRgNBRZRwU1QSpCXJKTNk5TysPEs5/YW0XYvZoN8u44RqqLf0pAzQw==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "chart.js": "4.2.0",
     "chartjs-adapter-date-fns": "3.0.0",
     "chartjs-chart-treemap": "3.1.0",
-    "chartjs-plugin-annotation": "2.1.2",
+    "chartjs-plugin-annotation": "3.1.0",
     "chartjs-plugin-datalabels": "2.2.0",
     "cheerio": "1.0.0",
     "class-transformer": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "bull": "4.16.2",
     "cache-manager": "5.7.6",
     "cache-manager-redis-yet": "5.1.4",
-    "chart.js": "4.2.0",
+    "chart.js": "4.4.7",
     "chartjs-adapter-date-fns": "3.0.0",
     "chartjs-chart-treemap": "3.1.0",
     "chartjs-plugin-annotation": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "cache-manager-redis-yet": "5.1.4",
     "chart.js": "4.2.0",
     "chartjs-adapter-date-fns": "3.0.0",
-    "chartjs-chart-treemap": "2.3.1",
+    "chartjs-chart-treemap": "3.1.0",
     "chartjs-plugin-annotation": "2.1.2",
     "chartjs-plugin-datalabels": "2.2.0",
     "cheerio": "1.0.0",


### PR DESCRIPTION
Hi @dtslvr, this PR is to resolve issue https://github.com/ghostfolio/ghostfolio/issues/4163. Take a look :)

### Changes
* Bumped `chart.js`, `chartjs-chart-treemap`, and `chartjs-plugin-annotation` to their latest versions.
* Fixed type annotations in portfolio proportion chart and treemap chart.