### PR TITLE
Manual scraper: Fix json mimetype detection (closes #4233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `date-fns` from version `3.6.0` to `4.1.0`
 - Upgraded `rxjs` from version `7.5.6` to `7.8.1`
 
+### Fixed
+
+- Fixed an issue with the MIME type detection in the scraper configuration
+
 ## 2.135.0 - 2025-01-19
 
 ### Changed

--- a/apps/api/src/services/data-provider/manual/manual.service.ts
+++ b/apps/api/src/services/data-provider/manual/manual.service.ts
@@ -282,7 +282,7 @@ export class ManualService implements DataProviderInterface {
       )
     });
 
-    if (response.headers['content-type']?.includes('application/json')) {
+    if (response.headers.get('content-type')?.includes('application/json')) {
       const data = await response.json();
 
       const value = String(


### PR DESCRIPTION
This fixes https://github.com/ghostfolio/ghostfolio/issues/4233 as I was also interested in the same feature.
response.headers is a Headers interface (https://developer.mozilla.org/en-US/docs/Web/API/Headers) so accessing it like `response.headers['content-type']` will always return undefined