### PR TITLE
Bugfix/fix format options needed in `getNumberFormatGroup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue with the detection of the thousand separator by locale
 - Fixed an issue with the MIME type detection in the scraper configuration
 
 ## 2.135.0 - 2025-01-19

--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -41,12 +41,71 @@ describe('Helper', () => {
   });
 
   describe('Get Number Format Group', () => {
+    let languageGetter;
+    beforeEach(() => {
+      languageGetter = jest.spyOn(window.navigator, 'language', 'get');
+    });
     it('Get en-US number format group', () => {
       expect(getNumberFormatGroup('en-US')).toEqual(',');
     });
 
+    it('Get en-US number format group when it is default', () => {
+      languageGetter.mockReturnValue('en-US');
+      expect(getNumberFormatGroup()).toEqual(',');
+    });
+
+    it('Get en-GB number format group', () => {
+      expect(getNumberFormatGroup('en-GB')).toEqual(',');
+    });
+
+    it('Get en-GB number format group when it is default', () => {
+      languageGetter.mockReturnValue('en-GB');
+      expect(getNumberFormatGroup()).toEqual(',');
+    });
+
     it('Get es-ES number format group', () => {
       expect(getNumberFormatGroup('es-ES')).toEqual('.');
+    });
+
+    it('Get es-ES number format group when it is default', () => {
+      languageGetter.mockReturnValue('es-ES');
+      expect(getNumberFormatGroup()).toEqual('.');
+    });
+
+    it('Get de-DE number format group', () => {
+      expect(getNumberFormatGroup('de-DE')).toEqual('.');
+    });
+
+    it('Get de-DE number format group when it is default', () => {
+      languageGetter.mockReturnValue('de-DE');
+      expect(getNumberFormatGroup()).toEqual('.');
+    });
+
+    it('Get de-CH number format group', () => {
+      expect(getNumberFormatGroup('de-CH')).toEqual('’');
+    });
+
+    it('Get de-CH number format group when it is default', () => {
+      languageGetter.mockReturnValue('de-CH');
+      expect(getNumberFormatGroup()).toEqual('’');
+    });
+
+    it('Get zh-CN number format group', () => {
+      expect(getNumberFormatGroup('zh-CN')).toEqual(',');
+    });
+
+    it('Get zh-CN number format group when it is default', () => {
+      languageGetter.mockReturnValue('zh-CN');
+      expect(getNumberFormatGroup()).toEqual(',');
+    });
+
+    it('Get ru-RU number format group', () => {
+      expect(getNumberFormatGroup('ru-RU')).toEqual(' ');
+    });
+
+    it('Get ru-RU number format group when it is default', () => {
+      languageGetter.mockReturnValue('ru-RU');
+      expect(getNumberFormatGroup()).toEqual(' ');
     });
   });
 });

--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -17,12 +17,6 @@ describe('Helper', () => {
       expect(extractNumberFromString({ value: '999.99 CHF' })).toEqual(999.99);
     });
 
-    it('Get decimal number (comma notation) for locale where currency is not grouped by default', () => {
-      expect(
-        extractNumberFromString({ locale: 'es-ES', value: '999,99' })
-      ).toEqual(999.99);
-    });
-
     it('Get decimal number (comma notation)', () => {
       expect(
         extractNumberFromString({ locale: 'de-DE', value: '999,99' })
@@ -41,23 +35,40 @@ describe('Helper', () => {
       ).toEqual(99999.99);
     });
 
+    it('Get decimal number (comma notation) for locale where currency is not grouped by default', () => {
+      expect(
+        extractNumberFromString({ locale: 'es-ES', value: '999,99' })
+      ).toEqual(999.99);
+    });
+
     it('Not a number', () => {
       expect(extractNumberFromString({ value: 'X' })).toEqual(NaN);
     });
   });
 
-  describe('Get Number Format Group', () => {
-    let languageGetter;
+  describe('Get number format group', () => {
+    let languageGetter: jest.SpyInstance<string, [], any>;
+
     beforeEach(() => {
       languageGetter = jest.spyOn(window.navigator, 'language', 'get');
     });
-    it('Get en-US number format group', () => {
-      expect(getNumberFormatGroup('en-US')).toEqual(',');
+
+    it('Get de-CH number format group', () => {
+      expect(getNumberFormatGroup('de-CH')).toEqual('’');
     });
 
-    it('Get en-US number format group when it is default', () => {
-      languageGetter.mockReturnValue('en-US');
-      expect(getNumberFormatGroup()).toEqual(',');
+    it('Get de-CH number format group when it is default', () => {
+      languageGetter.mockReturnValue('de-CH');
+      expect(getNumberFormatGroup()).toEqual('’');
+    });
+
+    it('Get de-DE number format group', () => {
+      expect(getNumberFormatGroup('de-DE')).toEqual('.');
+    });
+
+    it('Get de-DE number format group when it is default', () => {
+      languageGetter.mockReturnValue('de-DE');
+      expect(getNumberFormatGroup()).toEqual('.');
     });
 
     it('Get en-GB number format group', () => {
@@ -66,6 +77,15 @@ describe('Helper', () => {
 
     it('Get en-GB number format group when it is default', () => {
       languageGetter.mockReturnValue('en-GB');
+      expect(getNumberFormatGroup()).toEqual(',');
+    });
+
+    it('Get en-US number format group', () => {
+      expect(getNumberFormatGroup('en-US')).toEqual(',');
+    });
+
+    it('Get en-US number format group when it is default', () => {
+      languageGetter.mockReturnValue('en-US');
       expect(getNumberFormatGroup()).toEqual(',');
     });
 
@@ -78,22 +98,13 @@ describe('Helper', () => {
       expect(getNumberFormatGroup()).toEqual('.');
     });
 
-    it('Get de-DE number format group', () => {
-      expect(getNumberFormatGroup('de-DE')).toEqual('.');
+    it('Get ru-RU number format group', () => {
+      expect(getNumberFormatGroup('ru-RU')).toEqual(' ');
     });
 
-    it('Get de-DE number format group when it is default', () => {
-      languageGetter.mockReturnValue('de-DE');
-      expect(getNumberFormatGroup()).toEqual('.');
-    });
-
-    it('Get de-CH number format group', () => {
-      expect(getNumberFormatGroup('de-CH')).toEqual('’');
-    });
-
-    it('Get de-CH number format group when it is default', () => {
-      languageGetter.mockReturnValue('de-CH');
-      expect(getNumberFormatGroup()).toEqual('’');
+    it('Get ru-RU number format group when it is default', () => {
+      languageGetter.mockReturnValue('ru-RU');
+      expect(getNumberFormatGroup()).toEqual(' ');
     });
 
     it('Get zh-CN number format group', () => {
@@ -103,15 +114,6 @@ describe('Helper', () => {
     it('Get zh-CN number format group when it is default', () => {
       languageGetter.mockReturnValue('zh-CN');
       expect(getNumberFormatGroup()).toEqual(',');
-    });
-
-    it('Get ru-RU number format group', () => {
-      expect(getNumberFormatGroup('ru-RU')).toEqual(' ');
-    });
-
-    it('Get ru-RU number format group when it is default', () => {
-      languageGetter.mockReturnValue('ru-RU');
-      expect(getNumberFormatGroup()).toEqual(' ');
     });
   });
 });

--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -1,4 +1,7 @@
-import { extractNumberFromString } from '@ghostfolio/common/helper';
+import {
+  extractNumberFromString,
+  getNumberFormatGroup
+} from '@ghostfolio/common/helper';
 
 describe('Helper', () => {
   describe('Extract number from string', () => {
@@ -34,6 +37,16 @@ describe('Helper', () => {
 
     it('Not a number', () => {
       expect(extractNumberFromString({ value: 'X' })).toEqual(NaN);
+    });
+  });
+
+  describe('Get Number Format Group', () => {
+    it('Get en-US number format group', () => {
+      expect(getNumberFormatGroup('en-US')).toEqual(',');
+    });
+
+    it('Get es-ES number format group', () => {
+      expect(getNumberFormatGroup('es-ES')).toEqual('.');
     });
   });
 });

--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -17,6 +17,12 @@ describe('Helper', () => {
       expect(extractNumberFromString({ value: '999.99 CHF' })).toEqual(999.99);
     });
 
+    it('Get decimal number (comma notation) for locale where currency is not grouped by default', () => {
+      expect(
+        extractNumberFromString({ locale: 'es-ES', value: '999,99' })
+      ).toEqual(999.99);
+    });
+
     it('Get decimal number (comma notation)', () => {
       expect(
         extractNumberFromString({ locale: 'de-DE', value: '999,99' })

--- a/libs/common/src/lib/helper.ts
+++ b/libs/common/src/lib/helper.ts
@@ -251,7 +251,7 @@ export function getNumberFormatDecimal(aLocale?: string) {
 }
 
 export function getNumberFormatGroup(aLocale = getLocale()) {
-  const formatOptions = {'useGrouping': true}
+  const formatOptions = {'useGrouping': true};
   const formatObject = new Intl.NumberFormat(aLocale, formatOptions).formatToParts(9999.99);
 
   return formatObject.find((object) => {

--- a/libs/common/src/lib/helper.ts
+++ b/libs/common/src/lib/helper.ts
@@ -251,11 +251,9 @@ export function getNumberFormatDecimal(aLocale?: string) {
 }
 
 export function getNumberFormatGroup(aLocale = getLocale()) {
-  const formatOptions = { useGrouping: true };
-  const formatObject = new Intl.NumberFormat(
-    aLocale,
-    formatOptions
-  ).formatToParts(9999.99);
+  const formatObject = new Intl.NumberFormat(aLocale, {
+    useGrouping: true
+  }).formatToParts(9999.99);
 
   return formatObject.find((object) => {
     return object.type === 'group';

--- a/libs/common/src/lib/helper.ts
+++ b/libs/common/src/lib/helper.ts
@@ -251,7 +251,8 @@ export function getNumberFormatDecimal(aLocale?: string) {
 }
 
 export function getNumberFormatGroup(aLocale = getLocale()) {
-  const formatObject = new Intl.NumberFormat(aLocale).formatToParts(9999.99);
+  const formatOptions = {'useGrouping': true}
+  const formatObject = new Intl.NumberFormat(aLocale, formatOptions).formatToParts(9999.99);
 
   return formatObject.find((object) => {
     return object.type === 'group';

--- a/libs/common/src/lib/helper.ts
+++ b/libs/common/src/lib/helper.ts
@@ -251,8 +251,11 @@ export function getNumberFormatDecimal(aLocale?: string) {
 }
 
 export function getNumberFormatGroup(aLocale = getLocale()) {
-  const formatOptions = {'useGrouping': true};
-  const formatObject = new Intl.NumberFormat(aLocale, formatOptions).formatToParts(9999.99);
+  const formatOptions = { useGrouping: true };
+  const formatObject = new Intl.NumberFormat(
+    aLocale,
+    formatOptions
+  ).formatToParts(9999.99);
 
   return formatObject.find((object) => {
     return object.type === 'group';


### PR DESCRIPTION
Fixes #3652 

I was able to reproduce and diagnose the bug on development. It is found in the function `getNumberFormatGroup()`.

https://github.com/ghostfolio/ghostfolio/blob/553c10ac91ebdfa27ddfbd945d62f225f1c1d388/libs/common/src/lib/helper.ts#L245-L251

More precisely, the line 

https://github.com/ghostfolio/ghostfolio/blob/553c10ac91ebdfa27ddfbd945d62f225f1c1d388/libs/common/src/lib/helper.ts#L246

Assumes that the locale uses [grouping separators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#usegrouping), but when the locale is `es-ES` it does not and the function returns `undefined`.

The solution would be adding the option to always using grouping separators:

```typescript
 export function getNumberFormatDecimal(aLocale?: string) { 
   const formatOptions = {'useGrouping': true}
   const formatObject = new Intl.NumberFormat(aLocale, formatOptions).formatToParts(9999.99); 
  
   return formatObject.find((object) => { 
     return object.type === 'decimal'; 
   }).value; 
 } 
```