### PR TITLE
Bugfix/cryptocurrency quantity precision is not changed

### DIFF
--- a/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.component.ts
+++ b/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.component.ts
@@ -296,7 +296,7 @@ export class GfHoldingDetailDialogComponent implements OnDestroy, OnInit {
 
           if (Number.isInteger(this.quantity)) {
             this.quantityPrecision = 0;
-          } else if (this.SymbolProfile?.assetSubClass === 'CRYPTOCURRENCY') {
+          } else if (SymbolProfile?.assetSubClass === 'CRYPTOCURRENCY') {
             if (this.quantity < 1) {
               this.quantityPrecision = 7;
             } else if (this.quantity < 1000) {


### PR DESCRIPTION
Hi @dtslvr, this PR is to resolve issue https://github.com/ghostfolio/ghostfolio/issues/4253. Please take a look :)

### Changes
* Changed conditional expression to use `SymbolProfile` variable as `this.SymbolProfile` is not initialized yet (line 311).