### PR TITLE
Feature/upgrade to svgmap version 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the language localization for German (`de`)
+- Upgraded `svgmap` from version `2.6.0` to `2.12.2`
 
 ## 2.137.1 - 2025-02-01
 

--- a/apps/client/src/app/components/world-map-chart/world-map-chart.component.html
+++ b/apps/client/src/app/components/world-map-chart/world-map-chart.component.html
@@ -8,4 +8,4 @@
   />
 }
 
-<div class="align-items-center d-flex h-100 w-100" id="svgMap"></div>
+<div class="h-100 w-100" id="svgMap"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.1",
         "stripe": "17.3.0",
-        "svgmap": "2.6.0",
+        "svgmap": "2.12.2",
         "twitter-api-v2": "1.14.2",
         "uuid": "11.0.5",
         "yahoo-finance2": "2.11.3",
@@ -29788,12 +29788,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/svgmap": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/svgmap/-/svgmap-2.6.0.tgz",
-      "integrity": "sha512-MePkVjgYlHwEfCSuGt+wB6WX6Z2fTD6yDtqZO5syzKYH7gamt1Hp9f/Bw5R49OvBtbsF7WCaGR0/GhewZGGA+w==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/svgmap/-/svgmap-2.12.2.tgz",
+      "integrity": "sha512-SCX1Oys3v1dz3mTEbQha+6lrHGyu3LwXBhcgW0HlTh7waQDMFqNUKD8hADvDaPkPapRvNCLMnXaVD1Pbxbnhow==",
       "license": "MIT",
       "dependencies": {
-        "svg-pan-zoom": "^3.6.1"
+        "svg-pan-zoom": "^3.6.2"
       }
     },
     "node_modules/svgo": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.1",
     "stripe": "17.3.0",
-    "svgmap": "2.6.0",
+    "svgmap": "2.12.2",
     "twitter-api-v2": "1.14.2",
     "uuid": "11.0.5",
     "yahoo-finance2": "2.11.3",


### PR DESCRIPTION
Hi @dtslvr, this PR is to resolve issue https://github.com/ghostfolio/ghostfolio/issues/4279. Please take a look :)

### Changes
* Bumped `svgmap` from 2.6.0 to 2.12.2.
* Removed `d-flex` and `align-items-center` to prevent error:

  ```console
  InvalidStateError: Failed to execute 'inverse' on 'SVGMatrix': The matrix is not invertible.
  ```