### PR TITLE
Yahoo Finance: Allow searching cryptocurrencies in all configured fiat currencies

### DIFF
--- a/apps/api/src/app/admin/admin.module.ts
+++ b/apps/api/src/app/admin/admin.module.ts
@@ -4,6 +4,7 @@ import { SubscriptionModule } from '@ghostfolio/api/app/subscription/subscriptio
 import { TransformDataSourceInRequestModule } from '@ghostfolio/api/interceptors/transform-data-source-in-request/transform-data-source-in-request.module';
 import { ApiModule } from '@ghostfolio/api/services/api/api.module';
 import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
+import { CurrencyModule } from '@ghostfolio/api/services/currency/currency.module';
 import { DataProviderModule } from '@ghostfolio/api/services/data-provider/data-provider.module';
 import { ExchangeRateDataModule } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.module';
 import { MarketDataModule } from '@ghostfolio/api/services/market-data/market-data.module';
@@ -23,6 +24,7 @@ import { QueueModule } from './queue/queue.module';
     ApiModule,
     BenchmarkModule,
     ConfigurationModule,
+    CurrencyModule,
     DataGatheringModule,
     DataProviderModule,
     ExchangeRateDataModule,

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -3,6 +3,7 @@ import { OrderService } from '@ghostfolio/api/app/order/order.service';
 import { SubscriptionService } from '@ghostfolio/api/app/subscription/subscription.service';
 import { environment } from '@ghostfolio/api/environments/environment';
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
+import { CurrencyService } from '@ghostfolio/api/services/currency/currency.service';
 import { DataProviderService } from '@ghostfolio/api/services/data-provider/data-provider.service';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { MarketDataService } from '@ghostfolio/api/services/market-data/market-data.service';
@@ -49,6 +50,7 @@ import { groupBy } from 'lodash';
 export class AdminService {
   public constructor(
     private readonly benchmarkService: BenchmarkService,
+    private readonly currencyService: CurrencyService,
     private readonly configurationService: ConfigurationService,
     private readonly dataProviderService: DataProviderService,
     private readonly exchangeRateDataService: ExchangeRateDataService,
@@ -112,7 +114,7 @@ export class AdminService {
   }
 
   public async get(): Promise<AdminData> {
-    const exchangeRates = this.exchangeRateDataService
+    const exchangeRates = this.currencyService
       .getCurrencies()
       .filter((currency) => {
         return currency !== DEFAULT_CURRENCY;
@@ -513,6 +515,7 @@ export class AdminService {
     if (key === PROPERTY_IS_READ_ONLY_MODE && value === 'true') {
       await this.putSetting(PROPERTY_IS_USER_SIGNUP_ENABLED, 'false');
     } else if (key === PROPERTY_CURRENCIES) {
+      await this.currencyService.initialize();
       await this.exchangeRateDataService.initialize();
     }
 

--- a/apps/api/src/app/app.controller.ts
+++ b/apps/api/src/app/app.controller.ts
@@ -1,3 +1,4 @@
+import { CurrencyService } from '@ghostfolio/api/services/currency/currency.service';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 
 import { Controller } from '@nestjs/common';
@@ -5,6 +6,7 @@ import { Controller } from '@nestjs/common';
 @Controller()
 export class AppController {
   public constructor(
+    private readonly currencyService: CurrencyService,
     private readonly exchangeRateDataService: ExchangeRateDataService
   ) {
     this.initialize();
@@ -12,6 +14,7 @@ export class AppController {
 
   private async initialize() {
     try {
+      await this.currencyService.initialize();
       await this.exchangeRateDataService.initialize();
     } catch {}
   }

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { StatusCodes } from 'http-status-codes';
 import { join } from 'path';
 
+import { CurrencyModule } from '../services/currency/currency.module';
 import { AccessModule } from './access/access.module';
 import { AccountModule } from './account/account.module';
 import { AdminModule } from './admin/admin.module';
@@ -75,6 +76,7 @@ import { UserModule } from './user/user.module';
     CacheModule,
     ConfigModule.forRoot(),
     ConfigurationModule,
+    CurrencyModule,
     DataGatheringModule,
     DataProviderModule,
     EventEmitterModule.forRoot(),

--- a/apps/api/src/app/endpoints/data-providers/ghostfolio/ghostfolio.module.ts
+++ b/apps/api/src/app/endpoints/data-providers/ghostfolio/ghostfolio.module.ts
@@ -1,6 +1,7 @@
 import { RedisCacheModule } from '@ghostfolio/api/app/redis-cache/redis-cache.module';
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
 import { CryptocurrencyModule } from '@ghostfolio/api/services/cryptocurrency/cryptocurrency.module';
+import { CurrencyModule } from '@ghostfolio/api/services/currency/currency.module';
 import { AlphaVantageService } from '@ghostfolio/api/services/data-provider/alpha-vantage/alpha-vantage.service';
 import { CoinGeckoService } from '@ghostfolio/api/services/data-provider/coingecko/coingecko.service';
 import { YahooFinanceDataEnhancerService } from '@ghostfolio/api/services/data-provider/data-enhancer/yahoo-finance/yahoo-finance.service';

--- a/apps/api/src/app/endpoints/data-providers/ghostfolio/ghostfolio.module.ts
+++ b/apps/api/src/app/endpoints/data-providers/ghostfolio/ghostfolio.module.ts
@@ -26,6 +26,7 @@ import { GhostfolioService } from './ghostfolio.service';
 @Module({
   controllers: [GhostfolioController],
   imports: [
+    CurrencyModule,
     CryptocurrencyModule,
     DataProviderModule,
     MarketDataModule,

--- a/apps/api/src/app/info/info.module.ts
+++ b/apps/api/src/app/info/info.module.ts
@@ -4,8 +4,8 @@ import { RedisCacheModule } from '@ghostfolio/api/app/redis-cache/redis-cache.mo
 import { UserModule } from '@ghostfolio/api/app/user/user.module';
 import { TransformDataSourceInResponseModule } from '@ghostfolio/api/interceptors/transform-data-source-in-response/transform-data-source-in-response.module';
 import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
+import { CurrencyModule } from '@ghostfolio/api/services/currency/currency.module';
 import { DataProviderModule } from '@ghostfolio/api/services/data-provider/data-provider.module';
-import { ExchangeRateDataModule } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.module';
 import { PropertyModule } from '@ghostfolio/api/services/property/property.module';
 import { DataGatheringModule } from '@ghostfolio/api/services/queues/data-gathering/data-gathering.module';
 import { SymbolProfileModule } from '@ghostfolio/api/services/symbol-profile/symbol-profile.module';
@@ -21,9 +21,9 @@ import { InfoService } from './info.service';
   imports: [
     BenchmarkModule,
     ConfigurationModule,
+    CurrencyModule,
     DataGatheringModule,
     DataProviderModule,
-    ExchangeRateDataModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET_KEY,
       signOptions: { expiresIn: '30 days' }

--- a/apps/api/src/app/info/info.service.ts
+++ b/apps/api/src/app/info/info.service.ts
@@ -3,7 +3,7 @@ import { PlatformService } from '@ghostfolio/api/app/platform/platform.service';
 import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.service';
 import { UserService } from '@ghostfolio/api/app/user/user.service';
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
-import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { CurrencyService } from '@ghostfolio/api/services/currency/currency.service';
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
 import {
   DEFAULT_CURRENCY,
@@ -41,7 +41,7 @@ export class InfoService {
   public constructor(
     private readonly benchmarkService: BenchmarkService,
     private readonly configurationService: ConfigurationService,
-    private readonly exchangeRateDataService: ExchangeRateDataService,
+    private readonly currencyService: CurrencyService,
     private readonly jwtService: JwtService,
     private readonly platformService: PlatformService,
     private readonly propertyService: PropertyService,
@@ -127,7 +127,7 @@ export class InfoService {
       statistics,
       subscriptionOffers,
       baseCurrency: DEFAULT_CURRENCY,
-      currencies: this.exchangeRateDataService.getCurrencies()
+      currencies: this.currencyService.getCurrencies()
     };
   }
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell-in-two-activities.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell-in-two-activities.spec.ts
@@ -63,12 +63,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy-and-sell.spec.ts
@@ -63,12 +63,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-baln-buy.spec.ts
@@ -63,12 +63,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-btcusd-buy-and-sell-partially.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-btcusd-buy-and-sell-partially.spec.ts
@@ -76,12 +76,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-fee.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-fee.spec.ts
@@ -63,12 +63,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-googl-buy.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-googl-buy.spec.ts
@@ -76,12 +76,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-item.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-item.spec.ts
@@ -63,12 +63,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-liability.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-liability.spec.ts
@@ -63,12 +63,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-msft-buy-with-dividend.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-msft-buy-with-dividend.spec.ts
@@ -76,12 +76,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-no-orders.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-no-orders.spec.ts
@@ -58,12 +58,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-novn-buy-and-sell-partially.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-novn-buy-and-sell-partially.spec.ts
@@ -77,12 +77,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-novn-buy-and-sell.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator-novn-buy-and-sell.spec.ts
@@ -77,12 +77,7 @@ describe('PortfolioCalculator', () => {
 
     currentRateService = new CurrentRateService(null, null, null, null);
 
-    exchangeRateDataService = new ExchangeRateDataService(
-      null,
-      null,
-      null,
-      null
-    );
+    exchangeRateDataService = new ExchangeRateDataService(null, null, null);
 
     portfolioSnapshotService = new PortfolioSnapshotService(null);
 

--- a/apps/api/src/services/cryptocurrency/cryptocurrency.service.ts
+++ b/apps/api/src/services/cryptocurrency/cryptocurrency.service.ts
@@ -1,5 +1,3 @@
-import { DEFAULT_CURRENCY } from '@ghostfolio/common/config';
-
 import { Injectable } from '@nestjs/common';
 
 const cryptocurrencies = require('../../assets/cryptocurrencies/cryptocurrencies.json');
@@ -10,12 +8,10 @@ export class CryptocurrencyService {
   private combinedCryptocurrencies: string[];
 
   public isCryptocurrency(aSymbol = '') {
-    const cryptocurrencySymbol = aSymbol.substring(0, aSymbol.length - 3);
-
-    return (
-      aSymbol.endsWith(DEFAULT_CURRENCY) &&
-      this.getCryptocurrencies().includes(cryptocurrencySymbol)
-    );
+    const cryptocurrencySymbol = aSymbol.includes('-')
+      ? aSymbol.split('-')[0]
+      : aSymbol;
+    return this.getCryptocurrencies().includes(cryptocurrencySymbol);
   }
 
   private getCryptocurrencies() {

--- a/apps/api/src/services/currency/currency.module.ts
+++ b/apps/api/src/services/currency/currency.module.ts
@@ -1,0 +1,13 @@
+import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
+import { CurrencyService } from '@ghostfolio/api/services/currency/currency.service';
+import { PrismaModule } from '@ghostfolio/api/services/prisma/prisma.module';
+import { PropertyModule } from '@ghostfolio/api/services/property/property.module';
+
+import { Module } from '@nestjs/common';
+
+@Module({
+  exports: [CurrencyService],
+  imports: [ConfigurationModule, PrismaModule, PropertyModule],
+  providers: [CurrencyService]
+})
+export class CurrencyModule {}

--- a/apps/api/src/services/currency/currency.service.ts
+++ b/apps/api/src/services/currency/currency.service.ts
@@ -1,0 +1,77 @@
+import { PrismaService } from '@ghostfolio/api/services/prisma/prisma.service';
+import { PropertyService } from '@ghostfolio/api/services/property/property.service';
+import {
+  DEFAULT_CURRENCY,
+  DERIVED_CURRENCIES,
+  PROPERTY_CURRENCIES
+} from '@ghostfolio/common/config';
+
+import { Injectable } from '@nestjs/common';
+import { uniq } from 'lodash';
+
+@Injectable()
+export class CurrencyService {
+  private currencies: string[] = [];
+
+  public constructor(
+    private readonly prismaService: PrismaService,
+    private readonly propertyService: PropertyService
+  ) {}
+
+  public getCurrencies() {
+    return this.currencies?.length > 0 ? this.currencies : [DEFAULT_CURRENCY];
+  }
+
+  public async initialize() {
+    this.currencies = await this.prepareCurrencies();
+  }
+
+  private async prepareCurrencies(): Promise<string[]> {
+    let currencies: string[] = [DEFAULT_CURRENCY];
+
+    (
+      await this.prismaService.account.findMany({
+        distinct: ['currency'],
+        orderBy: [{ currency: 'asc' }],
+        select: { currency: true },
+        where: {
+          currency: {
+            not: null
+          }
+        }
+      })
+    ).forEach(({ currency }) => {
+      currencies.push(currency);
+    });
+
+    (
+      await this.prismaService.symbolProfile.findMany({
+        distinct: ['currency'],
+        orderBy: [{ currency: 'asc' }],
+        select: { currency: true }
+      })
+    ).forEach(({ currency }) => {
+      currencies.push(currency);
+    });
+
+    const customCurrencies = (await this.propertyService.getByKey(
+      PROPERTY_CURRENCIES
+    )) as string[];
+
+    if (customCurrencies?.length > 0) {
+      currencies = currencies.concat(customCurrencies);
+    }
+
+    // Add derived currencies
+    currencies.push('USX');
+
+    for (const { currency, rootCurrency } of DERIVED_CURRENCIES) {
+      if (currencies.includes(currency) || currencies.includes(rootCurrency)) {
+        currencies.push(currency);
+        currencies.push(rootCurrency);
+      }
+    }
+
+    return uniq(currencies).filter(Boolean).sort();
+  }
+}

--- a/apps/api/src/services/data-provider/data-provider.module.ts
+++ b/apps/api/src/services/data-provider/data-provider.module.ts
@@ -1,6 +1,7 @@
 import { RedisCacheModule } from '@ghostfolio/api/app/redis-cache/redis-cache.module';
 import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
 import { CryptocurrencyModule } from '@ghostfolio/api/services/cryptocurrency/cryptocurrency.module';
+import { CurrencyModule } from '@ghostfolio/api/services/currency/currency.module';
 import { AlphaVantageService } from '@ghostfolio/api/services/data-provider/alpha-vantage/alpha-vantage.service';
 import { CoinGeckoService } from '@ghostfolio/api/services/data-provider/coingecko/coingecko.service';
 import { EodHistoricalDataService } from '@ghostfolio/api/services/data-provider/eod-historical-data/eod-historical-data.service';
@@ -24,6 +25,7 @@ import { DataProviderService } from './data-provider.service';
 @Module({
   imports: [
     ConfigurationModule,
+    CurrencyModule,
     CryptocurrencyModule,
     DataEnhancerModule,
     MarketDataModule,

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.module.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.module.ts
@@ -1,4 +1,5 @@
 import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
+import { CurrencyModule } from '@ghostfolio/api/services/currency/currency.module';
 import { DataProviderModule } from '@ghostfolio/api/services/data-provider/data-provider.module';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { MarketDataModule } from '@ghostfolio/api/services/market-data/market-data.module';
@@ -11,6 +12,7 @@ import { Module } from '@nestjs/common';
   exports: [ExchangeRateDataService],
   imports: [
     ConfigurationModule,
+    CurrencyModule,
     DataProviderModule,
     MarketDataModule,
     PrismaModule,


### PR DESCRIPTION
Hey there,

This pull request allows the yahoo finance data provider to also look for cryptocurrencies in other user configured currencies (apart from the default USD): e.g. BTC-EUR, BTC-CAD, etc. It seems counter intuitive that users have to create manual scrapers (pointing to yahoo finance) to simply have access to these symbols (ref: https://github.com/ghostfolio/ghostfolio/pull/4237, https://github.com/ghostfolio/ghostfolio/issues/3320#issuecomment-2585202408).

The change was quite straight forward apart from the fact that currencies are completely tied to `ExchangeRateDataModule` in the codebase. Importing this into the yahoo finance data provider results into circular dependencies. Hence, I've introduced a new module (`CurrencyModule` / `CurrencyService`) that at the moment only moves the user currency list getter previously in the `ExchangeRateDataService` there. Sounded like a possible clean way to go considering that in the future more logic could probably be added to this service. This is handled in https://github.com/ghostfolio/ghostfolio/commit/912f5ad9322e737ab3deb69d05f7afb143d3ac4d.

**Screenshots:**
User with only USD configured as currency:
![image](https://github.com/user-attachments/assets/4e8ca656-9dca-451a-b353-bc0ead72afa9)

- Can find BTC-USD:
![image](https://github.com/user-attachments/assets/b71e15ec-24f5-47b7-94ae-28df403efebd)

- Can't find BTC-EUR:
![image](https://github.com/user-attachments/assets/c3b52bd4-f3a8-4a50-92d5-d602673d2196)

User adds EUR as currency:
![image](https://github.com/user-attachments/assets/7013ae1b-d14f-4c7d-817b-30477bc0f7db)

- User finds both BTC-USD and BTC-EUR:
![image](https://github.com/user-attachments/assets/4da40aa4-8fa6-46f0-aece-f14411bc5921)
![image](https://github.com/user-attachments/assets/749119bc-969b-4ba8-8a81-286a72eccefd)

