### PR TITLE
Feature/improve symbol lookup in Trackinsight data enhancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the symbol lookup in the _Trackinsight_ data enhancer for asset profile data
 - Improved the caching of the portfolio snapshot in the portfolio calculator by expiring cache entries when a user changes tags in the holding detail dialog
 - Improved the error handling in the _CoinGecko_ service
 - Improved the language localization for German (`de`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the symbol lookup in the _Trackinsight_ data enhancer for asset profile data
 - Improved the language localization for German (`de`)
 
 ## 2.138.0 - 2025-02-08
@@ -32,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improved the symbol lookup in the _Trackinsight_ data enhancer for asset profile data
 - Improved the caching of the portfolio snapshot in the portfolio calculator by expiring cache entries when a user changes tags in the holding detail dialog
 - Improved the error handling in the _CoinGecko_ service
 - Improved the language localization for German (`de`)

--- a/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
+++ b/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
@@ -80,9 +80,7 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
     const holdings = await fetch(
       `${TrackinsightDataEnhancerService.baseUrl}/holdings/${trackinsightSymbol}.json`,
       {
-        signal: AbortSignal.timeout(
-          this.configurationService.get('REQUEST_TIMEOUT')
-        )
+        signal: AbortSignal.timeout(requestTimeout)
       }
     )
       .then((res) => res.json())

--- a/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
+++ b/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
@@ -178,7 +178,7 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
     requestTimeout: number;
     symbol: string;
   }) {
-    return await fetch(
+    return fetch(
       `https://www.trackinsight.com/search-api/search_v2/${symbol}/_/ticker/default/0/3`,
       {
         signal: AbortSignal.timeout(requestTimeout)
@@ -186,10 +186,13 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
     )
       .then((res) => res.json())
       .then((jsonRes) => {
-        if (jsonRes['results']['count'] === 1) {
-          // Return the only ticker that matches the one in the search
+        if (
+          jsonRes['results']?.['count'] === 1 ||
+          jsonRes['results']?.['docs']?.[0]?.['ticker'] === symbol
+        ) {
           return jsonRes['results']['docs'][0]['ticker'];
         }
+
         return undefined;
       })
       .catch(() => {

--- a/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
+++ b/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
@@ -44,10 +44,17 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
       return response;
     }
 
-    const trackinsightSymbol = await this.searchTrackinsightSymbol({
+    let trackinsightSymbol = await this.searchTrackinsightSymbol({
       requestTimeout,
       symbol
     });
+
+    if (!trackinsightSymbol) {
+      trackinsightSymbol = await this.searchTrackinsightSymbol({
+        requestTimeout,
+        symbol: symbol.split('.')?.[0]
+      });
+    }
 
     if (!trackinsightSymbol) {
       return response;
@@ -165,35 +172,14 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
   }
 
   private async searchTrackinsightSymbol({
-    requestTimeout = this.configurationService.get('REQUEST_TIMEOUT'),
+    requestTimeout,
     symbol
   }: {
-    symbol: string;
     requestTimeout: number;
+    symbol: string;
   }) {
-    const newSymbol = await fetch(
-      `https://www.trackinsight.com/search-api/search_v2/${symbol}/_/ticker/default/0/3`,
-      {
-        signal: AbortSignal.timeout(requestTimeout)
-      }
-    )
-      .then((res) => res.json())
-      .then((jsonRes) => {
-        if (jsonRes['results']['count'] === 1) {
-          // Return the only ticker that matches the one in the search
-          return jsonRes['results']['docs'][0]['ticker'];
-        }
-        return undefined;
-      })
-      .catch(() => {
-        return undefined;
-      });
-    if (newSymbol) {
-      return newSymbol;
-    }
-
     return await fetch(
-      `https://www.trackinsight.com/search-api/search_v2/${symbol.split('.')?.[0]}/_/ticker/default/0/3`,
+      `https://www.trackinsight.com/search-api/search_v2/${symbol}/_/ticker/default/0/3`,
       {
         signal: AbortSignal.timeout(requestTimeout)
       }


### PR DESCRIPTION
Fixes #4257 

This PR enhances Trackinsight Data Enhancer in order to search for the adequate symbol. This has two main benefits:

1. It streamlines symbols like `VUAA` and `VUAA.DE`, which before needed two search attempts in case it needed to remove the `.DE` part.
2. It looks for the symbol stored in Trackinsight with the same ISIN as the symbol searched. Tickers can differ between markets to refer to the same ISIN, but the underlying asset is the same. So we can use this to obtain sectors, holdings and countries, which are informations of the asset rather than the market. 