### PR TITLE
Feature/import global styles in Storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added global styles to the _Storybook_ setup
+
 ## 2.138.0 - 2025-02-08
 
 ### Added

--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -1,1 +1,0 @@
-// import '!style-loader!css-loader!sass-loader!../../../apps/client/src/styles.scss';

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -29,12 +29,7 @@
         "port": 4400,
         "configDir": "libs/ui/.storybook",
         "browserTarget": "ui:build-storybook",
-        "compodoc": false,
-        "styles": [
-          "apps/client/src/assets/fonts/inter.css",
-          "apps/client/src/styles/theme.scss",
-          "apps/client/src/styles.scss"
-        ]
+        "compodoc": false
       },
       "configurations": {
         "ci": {

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -29,7 +29,12 @@
         "port": 4400,
         "configDir": "libs/ui/.storybook",
         "browserTarget": "ui:build-storybook",
-        "compodoc": false
+        "compodoc": false,
+        "styles": [
+          "apps/client/src/assets/fonts/inter.css",
+          "apps/client/src/styles/theme.scss",
+          "apps/client/src/styles.scss"
+        ]
       },
       "configurations": {
         "ci": {
@@ -44,7 +49,12 @@
         "outputDir": "dist/storybook/ui",
         "configDir": "libs/ui/.storybook",
         "browserTarget": "ui:build-storybook",
-        "compodoc": false
+        "compodoc": false,
+        "styles": [
+          "apps/client/src/assets/fonts/inter.css",
+          "apps/client/src/styles/theme.scss",
+          "apps/client/src/styles.scss"
+        ]
       },
       "configurations": {
         "ci": {


### PR DESCRIPTION
Hi @dtslvr, this PR is to resolve issue https://github.com/ghostfolio/ghostfolio/issues/1977. Please take a look :)

### Changes
* Include global styles in Storybook build.
* Cleanup unused line of code in `preview.js`.

### Notes
* Only `ui:build-storybook` target needs the `styles` attribute, as explained [here](https://nx.dev/recipes/storybook/angular-configuring-styles#using-buildstorybook-for-styles).