### PR TITLE
Feature/add created at to snapshot and response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Extended the export functionality by the platforms
+- Extended the portfolio snapshot in the portfolio calculator by the `createdAt` timestamp
 - Extended the _Trackinsight_ data enhancer for asset profile data by `cusip`
 - Added _Storybook_ to the build process
 
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extended the export functionality by the tags
 - Extended the portfolio snapshot in the portfolio calculator by the activities count
-- Extended the portfolio snapshot in the portfolio calculator by the `createdAt` timestamp
 - Extended the user endpoint `GET api/v1/user` by the activities count
 - Added `cusip` to the asset profile model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extended the export functionality by the tags
 - Extended the portfolio snapshot in the portfolio calculator by the activities count
+- Extended the portfolio snapshot in the portfolio calculator by the `createdAt` timestamp
 - Extended the user endpoint `GET api/v1/user` by the activities count
 - Added `cusip` to the asset profile model
 

--- a/apps/api/src/app/endpoints/public/public.controller.ts
+++ b/apps/api/src/app/endpoints/public/public.controller.ts
@@ -84,6 +84,7 @@ export class PublicController {
       hasDetails,
       markets,
       alias: access.alias,
+      createdAt: performance1d.createdAt,
       holdings: {},
       performance: {
         '1d': {

--- a/apps/api/src/app/endpoints/public/public.controller.ts
+++ b/apps/api/src/app/endpoints/public/public.controller.ts
@@ -57,7 +57,7 @@ export class PublicController {
     }
 
     const [
-      { holdings, markets },
+      { createdAt, holdings, markets },
       { performance: performance1d },
       { performance: performanceMax },
       { performance: performanceYtd }
@@ -81,10 +81,10 @@ export class PublicController {
     });
 
     const publicPortfolioResponse: PublicPortfolioResponse = {
+      createdAt,
       hasDetails,
       markets,
       alias: access.alias,
-      createdAt: performance1d.createdAt,
       holdings: {},
       performance: {
         '1d': {

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -175,12 +175,9 @@ export abstract class PortfolioCalculator {
 
     if (!transactionPoints.length) {
       return {
-<<<<<<< HEAD
         activitiesCount: 0,
-=======
->>>>>>> 6e5db62f (Code review fixes)
-        currentValueInBaseCurrency: new Big(0),
         createdAt: new Date(),
+        currentValueInBaseCurrency: new Big(0),
         errors: [],
         hasErrors: false,
         historicalData: [],

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -177,6 +177,7 @@ export abstract class PortfolioCalculator {
       return {
         activitiesCount: 0,
         currentValueInBaseCurrency: new Big(0),
+        createdAt: new Date(),
         errors: [],
         hasErrors: false,
         historicalData: [],

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -175,7 +175,10 @@ export abstract class PortfolioCalculator {
 
     if (!transactionPoints.length) {
       return {
+<<<<<<< HEAD
         activitiesCount: 0,
+=======
+>>>>>>> 6e5db62f (Code review fixes)
         currentValueInBaseCurrency: new Big(0),
         createdAt: new Date(),
         errors: [],

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -104,8 +104,8 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
       activitiesCount: this.activities.filter(({ type }) => {
         return ['BUY', 'SELL'].includes(type);
       }).length,
-      errors: [],
       createdAt: new Date(),
+      errors: [],
       historicalData: [],
       totalLiabilitiesWithCurrencyEffect: new Big(0),
       totalValuablesWithCurrencyEffect: new Big(0)

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -94,7 +94,6 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
     }
 
     return {
-      createdAt: new Date(),
       currentValueInBaseCurrency,
       hasErrors,
       positions,
@@ -106,6 +105,7 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
         return ['BUY', 'SELL'].includes(type);
       }).length,
       errors: [],
+      createdAt: new Date(),
       historicalData: [],
       totalLiabilitiesWithCurrencyEffect: new Big(0),
       totalValuablesWithCurrencyEffect: new Big(0)

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -94,6 +94,7 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
     }
 
     return {
+      createdAt: new Date(),
       currentValueInBaseCurrency,
       hasErrors,
       positions,

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -105,6 +105,7 @@ export class PortfolioController {
 
     const {
       accounts,
+      createdAt,
       hasErrors,
       holdings,
       markets,
@@ -233,6 +234,7 @@ export class PortfolioController {
 
     return {
       accounts,
+      createdAt,
       hasError,
       holdings,
       platforms,

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -376,7 +376,7 @@ export class PortfolioService {
       currency: userCurrency
     });
 
-    const { currentValueInBaseCurrency, hasErrors, positions } =
+    const { createdAt, currentValueInBaseCurrency, hasErrors, positions } =
       await portfolioCalculator.getSnapshot();
 
     const cashDetails = await this.accountService.getCashDetails({
@@ -617,6 +617,7 @@ export class PortfolioService {
 
     return {
       accounts,
+      createdAt,
       hasErrors,
       holdings,
       markets,
@@ -1100,7 +1101,6 @@ export class PortfolioService {
         firstOrderDate: undefined,
         hasErrors: false,
         performance: {
-          createdAt: new Date(),
           currentNetWorth: 0,
           currentValueInBaseCurrency: 0,
           netPerformance: 0,
@@ -1121,7 +1121,7 @@ export class PortfolioService {
       currency: userCurrency
     });
 
-    const { createdAt, errors, hasErrors, historicalData } =
+    const { errors, hasErrors, historicalData } =
       await portfolioCalculator.getSnapshot();
 
     const { endDate, startDate } = getIntervalFromDateRange(dateRange);
@@ -1155,7 +1155,6 @@ export class PortfolioService {
       hasErrors,
       firstOrderDate: parseDate(historicalData[0]?.date),
       performance: {
-        createdAt,
         netPerformance,
         netPerformanceWithCurrencyEffect,
         totalInvestment,
@@ -1811,7 +1810,7 @@ export class PortfolioService {
       }
     }
 
-    const { createdAt, currentValueInBaseCurrency, totalInvestment } =
+    const { currentValueInBaseCurrency, totalInvestment } =
       await portfolioCalculator.getSnapshot();
 
     const { performance } = await this.getPerformance({
@@ -1916,7 +1915,6 @@ export class PortfolioService {
       })?.toNumber();
 
     return {
-      createdAt,
       annualizedPerformancePercent,
       annualizedPerformancePercentWithCurrencyEffect,
       cash,

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1100,7 +1100,7 @@ export class PortfolioService {
         firstOrderDate: undefined,
         hasErrors: false,
         performance: {
-          createdAt: undefined,
+          createdAt: new Date(),
           currentNetWorth: 0,
           currentValueInBaseCurrency: 0,
           netPerformance: 0,
@@ -1155,10 +1155,10 @@ export class PortfolioService {
       hasErrors,
       firstOrderDate: parseDate(historicalData[0]?.date),
       performance: {
+        createdAt,
         netPerformance,
         netPerformanceWithCurrencyEffect,
         totalInvestment,
-        createdAt: createdAt,
         currentNetWorth: netWorth,
         currentValueInBaseCurrency: valueWithCurrencyEffect,
         netPerformancePercentage: netPerformanceInPercentage,
@@ -1916,6 +1916,7 @@ export class PortfolioService {
       })?.toNumber();
 
     return {
+      createdAt,
       annualizedPerformancePercent,
       annualizedPerformancePercentWithCurrencyEffect,
       cash,
@@ -1929,7 +1930,6 @@ export class PortfolioService {
       totalSell,
       committedFunds: committedFunds.toNumber(),
       currentValueInBaseCurrency: currentValueInBaseCurrency.toNumber(),
-      createdAt: createdAt,
       dividendInBaseCurrency: dividendInBaseCurrency.toNumber(),
       emergencyFund: {
         assets: emergencyFundPositionsValueInBaseCurrency,

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1100,6 +1100,7 @@ export class PortfolioService {
         firstOrderDate: undefined,
         hasErrors: false,
         performance: {
+          createdAt: undefined,
           currentNetWorth: 0,
           currentValueInBaseCurrency: 0,
           netPerformance: 0,
@@ -1120,7 +1121,7 @@ export class PortfolioService {
       currency: userCurrency
     });
 
-    const { errors, hasErrors, historicalData } =
+    const { createdAt, errors, hasErrors, historicalData } =
       await portfolioCalculator.getSnapshot();
 
     const { endDate, startDate } = getIntervalFromDateRange(dateRange);
@@ -1157,6 +1158,7 @@ export class PortfolioService {
         netPerformance,
         netPerformanceWithCurrencyEffect,
         totalInvestment,
+        createdAt: createdAt,
         currentNetWorth: netWorth,
         currentValueInBaseCurrency: valueWithCurrencyEffect,
         netPerformancePercentage: netPerformanceInPercentage,
@@ -1809,7 +1811,7 @@ export class PortfolioService {
       }
     }
 
-    const { currentValueInBaseCurrency, totalInvestment } =
+    const { createdAt, currentValueInBaseCurrency, totalInvestment } =
       await portfolioCalculator.getSnapshot();
 
     const { performance } = await this.getPerformance({
@@ -1927,6 +1929,7 @@ export class PortfolioService {
       totalSell,
       committedFunds: committedFunds.toNumber(),
       currentValueInBaseCurrency: currentValueInBaseCurrency.toNumber(),
+      createdAt: createdAt,
       dividendInBaseCurrency: dividendInBaseCurrency.toNumber(),
       emergencyFund: {
         assets: emergencyFundPositionsValueInBaseCurrency,

--- a/apps/client/src/app/pages/portfolio/allocations/allocations-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/allocations/allocations-page.component.ts
@@ -260,6 +260,7 @@ export class AllocationsPageComponent implements OnDestroy, OnInit {
     this.platforms = {};
     this.portfolioDetails = {
       accounts: {},
+      createdAt: undefined,
       holdings: {},
       platforms: {},
       summary: undefined

--- a/libs/common/src/lib/interfaces/portfolio-details.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-details.interface.ts
@@ -14,6 +14,7 @@ export interface PortfolioDetails {
       valueInPercentage?: number;
     };
   };
+  createdAt: Date;
   holdings: { [symbol: string]: PortfolioPosition };
   markets?: {
     [key in Market]: {

--- a/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
@@ -1,6 +1,5 @@
 export interface PortfolioPerformance {
   annualizedPerformancePercent?: number;
-  createdAt: Date;
   currentNetWorth?: number;
   currentValueInBaseCurrency: number;
   netPerformance: number;

--- a/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-performance.interface.ts
@@ -1,5 +1,6 @@
 export interface PortfolioPerformance {
   annualizedPerformancePercent?: number;
+  createdAt: Date;
   currentNetWorth?: number;
   currentValueInBaseCurrency: number;
   netPerformance: number;

--- a/libs/common/src/lib/interfaces/responses/public-portfolio-response.interface.ts
+++ b/libs/common/src/lib/interfaces/responses/public-portfolio-response.interface.ts
@@ -3,7 +3,6 @@ import { Market } from '../../types';
 
 export interface PublicPortfolioResponse extends PublicPortfolioResponseV1 {
   alias?: string;
-  createdAt: Date;
   hasDetails: boolean;
   holdings: {
     [symbol: string]: Pick<
@@ -33,6 +32,7 @@ export interface PublicPortfolioResponse extends PublicPortfolioResponseV1 {
 }
 
 interface PublicPortfolioResponseV1 {
+  createdAt: Date;
   performance: {
     '1d': {
       relativeChange: number;

--- a/libs/common/src/lib/interfaces/responses/public-portfolio-response.interface.ts
+++ b/libs/common/src/lib/interfaces/responses/public-portfolio-response.interface.ts
@@ -3,6 +3,7 @@ import { Market } from '../../types';
 
 export interface PublicPortfolioResponse extends PublicPortfolioResponseV1 {
   alias?: string;
+  createdAt: Date;
   hasDetails: boolean;
   holdings: {
     [symbol: string]: Pick<

--- a/libs/common/src/lib/models/portfolio-snapshot.ts
+++ b/libs/common/src/lib/models/portfolio-snapshot.ts
@@ -11,6 +11,8 @@ import { Transform, Type } from 'class-transformer';
 export class PortfolioSnapshot {
   activitiesCount: number;
 
+  createdAt: Date;
+
   @Transform(transformToBig, { toClassOnly: true })
   @Type(() => Big)
   currentValueInBaseCurrency: Big;


### PR DESCRIPTION
### Issue
https://github.com/ghostfolio/ghostfolio/issues/3865

### What
Add createdAt field to PortfolioSnapshot and PublicPortfolioResponse to provide additional information for the client about the freshness of the calculations.

### How
Added the field to multiple iterfaces
Set the field whenever a snapshot is created and pass it through multiple methods to provide it in PublicPortfolioResponse