### PR TITLE
Feature/activitiesCount added to PortfolioSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added the activities count to the portfolio snapshot in the portfolio calculator
+
 ## 2.140.0 - 2025-02-20
 
 ### Changed

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -185,7 +185,8 @@ export abstract class PortfolioCalculator {
         totalInvestment: new Big(0),
         totalInvestmentWithCurrencyEffect: new Big(0),
         totalLiabilitiesWithCurrencyEffect: new Big(0),
-        totalValuablesWithCurrencyEffect: new Big(0)
+        totalValuablesWithCurrencyEffect: new Big(0),
+        activitiesCount: 0
       };
     }
 

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -175,6 +175,7 @@ export abstract class PortfolioCalculator {
 
     if (!transactionPoints.length) {
       return {
+        activitiesCount: 0,
         currentValueInBaseCurrency: new Big(0),
         errors: [],
         hasErrors: false,
@@ -185,8 +186,7 @@ export abstract class PortfolioCalculator {
         totalInvestment: new Big(0),
         totalInvestmentWithCurrencyEffect: new Big(0),
         totalLiabilitiesWithCurrencyEffect: new Big(0),
-        totalValuablesWithCurrencyEffect: new Big(0),
-        activitiesCount: 0
+        totalValuablesWithCurrencyEffect: new Big(0)
       };
     }
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -101,11 +101,11 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
       totalInterestWithCurrencyEffect,
       totalInvestment,
       totalInvestmentWithCurrencyEffect,
+      activitiesCount: this.activities.length,
       errors: [],
       historicalData: [],
       totalLiabilitiesWithCurrencyEffect: new Big(0),
-      totalValuablesWithCurrencyEffect: new Big(0),
-      activitiesCount: this.activities.length
+      totalValuablesWithCurrencyEffect: new Big(0)
     };
   }
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -104,7 +104,8 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
       errors: [],
       historicalData: [],
       totalLiabilitiesWithCurrencyEffect: new Big(0),
-      totalValuablesWithCurrencyEffect: new Big(0)
+      totalValuablesWithCurrencyEffect: new Big(0),
+      activitiesCount: this.activities.length
     };
   }
 

--- a/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/twr/portfolio-calculator.ts
@@ -101,7 +101,9 @@ export class TWRPortfolioCalculator extends PortfolioCalculator {
       totalInterestWithCurrencyEffect,
       totalInvestment,
       totalInvestmentWithCurrencyEffect,
-      activitiesCount: this.activities.length,
+      activitiesCount: this.activities.filter(({ type }) => {
+        return ['BUY', 'SELL'].includes(type);
+      }).length,
       errors: [],
       historicalData: [],
       totalLiabilitiesWithCurrencyEffect: new Big(0),

--- a/libs/common/src/lib/models/portfolio-snapshot.ts
+++ b/libs/common/src/lib/models/portfolio-snapshot.ts
@@ -9,6 +9,8 @@ import { Big } from 'big.js';
 import { Transform, Type } from 'class-transformer';
 
 export class PortfolioSnapshot {
+  activitiesCount: number;
+
   @Transform(transformToBig, { toClassOnly: true })
   @Type(() => Big)
   currentValueInBaseCurrency: Big;
@@ -45,6 +47,4 @@ export class PortfolioSnapshot {
   @Transform(transformToBig, { toClassOnly: true })
   @Type(() => Big)
   totalValuablesWithCurrencyEffect: Big;
-
-  activitiesCount: number;
 }

--- a/libs/common/src/lib/models/portfolio-snapshot.ts
+++ b/libs/common/src/lib/models/portfolio-snapshot.ts
@@ -45,4 +45,6 @@ export class PortfolioSnapshot {
   @Transform(transformToBig, { toClassOnly: true })
   @Type(() => Big)
   totalValuablesWithCurrencyEffect: Big;
+
+  activitiesCount: number;
 }


### PR DESCRIPTION
### Issue
https://github.com/ghostfolio/ghostfolio/issues/4343

### What
Store activitiesCount: number; (this.activities.length) in the [PortfolioSnapshot](https://github.com/ghostfolio/ghostfolio/blob/main/libs/common/src/lib/models/portfolio-snapshot.ts) (see [computeSnapshot()](https://github.com/ghostfolio/ghostfolio/blob/main/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts#L169)).

### How
`activitiesCount` added to `PortfolioSnapshot`