### PR TITLE
Bugfix/handle exception in benchmark service related to unnamed asset profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Handled an exception in the benchmark service related to unnamed asset profiles
+
 ## 2.142.0 - 2025-02-28
 
 ### Added
@@ -50,7 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the error handling in the `HttpResponseInterceptor`
 - Fixed an issue while using symbol profile overrides in the historical market data table of the admin control panel
 - Added missing assets in _Storybook_ setup
-- Fixed an issue when using an unnamed manual symbol as a benchmark
 
 ## 2.139.1 - 2025-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the error handling in the `HttpResponseInterceptor`
 - Fixed an issue while using symbol profile overrides in the historical market data table of the admin control panel
 - Added missing assets in _Storybook_ setup
+- Fixed an issue when using an unnamed manual symbol as a benchmark
 
 ## 2.139.1 - 2025-02-15
 

--- a/apps/api/src/services/benchmark/benchmark.service.ts
+++ b/apps/api/src/services/benchmark/benchmark.service.ts
@@ -133,7 +133,7 @@ export class BenchmarkService {
           symbol
         };
       })
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .sort((a, b) => a.name?.localeCompare(b?.name) ?? 0);
   }
 
   public async addBenchmark({

--- a/apps/api/src/services/benchmark/benchmark.service.ts
+++ b/apps/api/src/services/benchmark/benchmark.service.ts
@@ -133,7 +133,9 @@ export class BenchmarkService {
           symbol
         };
       })
-      .sort((a, b) => a.name?.localeCompare(b?.name) ?? 0);
+      .sort((a, b) => {
+        return a.name?.localeCompare(b?.name) ?? 0;
+      });
   }
 
   public async addBenchmark({


### PR DESCRIPTION
When using an unnamed symbol as a benchmark, several pages fail to load and the below message is printed in the server logs.

```
[Nest] 1252  - ERROR [ExceptionsHandler] Cannot read properties of null (reading 'localeCompare')
  TypeError: Cannot read properties of null (reading 'localeCompare')
  at ghostfolio/dist/apps/api/main.js:1:120131
  at Array.sort (<anonymous>)
  at BenchmarkService.getBenchmarkAssetProfiles (ghostfolio/dist/apps/api/main.js:1:120111)
  at async Promise.all (index 0)
  at async InfoService.get (ghostfolio/dist/apps/api/main.js:1:789591)
```

As a sidenote, I couldn't work out how to add a "name" for an manual symbol, it doesn't seem to have autopopulated or anything and the Market Data page is showing as below
<img width="638" alt="image" src="https://github.com/user-attachments/assets/f93465b3-6cc3-45b5-82cd-71e6df0a833b" />
