### PR TITLE
Feature/holding table add summary to footer row

### DIFF
--- a/libs/ui/src/lib/holdings-table/holdings-table.component.html
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.html
@@ -145,6 +145,7 @@
       <td *matFooterCellDef class="px-1" mat-footer-cell>
         <div class="d-flex justify-content-end">
           <gf-value
+            [colorizeSign]="true"
             [isCurrency]="true"
             [locale]="locale"
             [value]="totalChange"
@@ -180,6 +181,7 @@
       <td *matFooterCellDef class="px-1" mat-footer-cell>
         <div class="d-flex justify-content-end">
           <gf-value
+            [colorizeSign]="true"
             [isPercent]="true"
             [locale]="locale"
             [value]="totalChangePercentage"

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.html
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.html
@@ -64,7 +64,11 @@
           />
         </div>
       </td>
-      <td *matFooterCellDef class="px-1" mat-footer-cell></td>
+      <td
+        *matFooterCellDef
+        class="d-none d-lg-table-cell justify-content-end px-1"
+        mat-footer-cell
+      ></td>
     </ng-container>
 
     <ng-container matColumnDef="valueInBaseCurrency">
@@ -90,7 +94,7 @@
         </div>
       </td>
 
-      <td *matFooterCellDef class="px-1" mat-footer-cell>
+      <td *matFooterCellDef class="d-none d-lg-table-cell px-1" mat-footer-cell>
         <gf-value
           [isCurrency]="true"
           [locale]="locale"

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.html
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.html
@@ -16,6 +16,7 @@
           [tooltip]="element.name"
         />
       </td>
+      <td *matFooterCellDef class="px-1" mat-footer-cell></td>
     </ng-container>
 
     <ng-container matColumnDef="nameWithSymbol">
@@ -38,6 +39,7 @@
           <small class="text-muted">{{ element.symbol }}</small>
         </div>
       </td>
+      <td *matFooterCellDef class="px-1" mat-footer-cell>Total</td>
     </ng-container>
 
     <ng-container matColumnDef="dateOfFirstActivity">
@@ -62,6 +64,7 @@
           />
         </div>
       </td>
+      <td *matFooterCellDef class="px-1" mat-footer-cell></td>
     </ng-container>
 
     <ng-container matColumnDef="valueInBaseCurrency">
@@ -86,6 +89,14 @@
           />
         </div>
       </td>
+
+      <td *matFooterCellDef class="px-1" mat-footer-cell>
+        <gf-value
+          [isCurrency]="true"
+          [locale]="locale"
+          [value]="totalValue"
+        ></gf-value>
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="allocationInPercentage">
@@ -107,6 +118,7 @@
           />
         </div>
       </td>
+      <td *matFooterCellDef class="px-1" mat-footer-cell></td>
     </ng-container>
 
     <ng-container matColumnDef="performance">
@@ -128,6 +140,15 @@
               isLoading ? undefined : element.netPerformanceWithCurrencyEffect
             "
           />
+        </div>
+      </td>
+      <td *matFooterCellDef class="px-1" mat-footer-cell>
+        <div class="d-flex justify-content-end">
+          <gf-value
+            [isCurrency]="true"
+            [locale]="locale"
+            [value]="totalChange"
+          ></gf-value>
         </div>
       </td>
     </ng-container>
@@ -156,6 +177,15 @@
           />
         </div>
       </td>
+      <td *matFooterCellDef class="px-1" mat-footer-cell>
+        <div class="d-flex justify-content-end">
+          <gf-value
+            [isPercent]="true"
+            [locale]="locale"
+            [value]="totalChangePercentage"
+          ></gf-value>
+        </div>
+      </td>
     </ng-container>
 
     <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>
@@ -174,6 +204,11 @@
             symbol: row.symbol
           })
       "
+    ></tr>
+    <tr
+      *matFooterRowDef="displayedColumns"
+      mat-footer-row
+      [ngClass]="{ hidden: isLoading }"
     ></tr>
   </table>
 </div>

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.ts
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.ts
@@ -70,6 +70,10 @@ export class GfHoldingsTableComponent implements OnChanges, OnDestroy {
   public isLoading = true;
   public routeQueryParams: Subscription;
 
+  protected totalValue = 0;
+  protected totalChange = 0;
+  protected totalChangePercentage = 0;
+
   private unsubscribeSubject = new Subject<void>();
 
   public ngOnChanges() {
@@ -92,6 +96,15 @@ export class GfHoldingsTableComponent implements OnChanges, OnDestroy {
     this.dataSource = new MatTableDataSource(this.holdings);
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+    this.totalValue = this.dataSource.data.reduce(
+      (sum, current) => sum + current.valueInBaseCurrency,
+      0
+    );
+    this.totalChange = this.dataSource.data.reduce(
+      (sum, current) => sum + current.netPerformancePercentWithCurrencyEffect,
+      0
+    );
+    this.totalChangePercentage = (this.totalChange / this.totalValue) * 100;
 
     if (this.holdings) {
       this.isLoading = false;

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.ts
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.ts
@@ -97,11 +97,11 @@ export class GfHoldingsTableComponent implements OnChanges, OnDestroy {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
     this.totalValue = this.dataSource.data.reduce(
-      (sum, current) => sum + current.valueInBaseCurrency,
+      (sum, current) => (sum += current.valueInBaseCurrency),
       0
     );
     this.totalChange = this.dataSource.data.reduce(
-      (sum, current) => sum + current.netPerformancePercentWithCurrencyEffect,
+      (sum, current) => (sum += current.netPerformanceWithCurrencyEffect),
       0
     );
     this.totalChangePercentage = (this.totalChange / this.totalValue) * 100;

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.ts
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.ts
@@ -104,7 +104,8 @@ export class GfHoldingsTableComponent implements OnChanges, OnDestroy {
       (sum, current) => (sum += current.netPerformanceWithCurrencyEffect),
       0
     );
-    this.totalChangePercentage = (this.totalChange / this.totalValue) * 100;
+    this.totalChangePercentage =
+      this.totalChange / (this.totalValue - this.totalChange);
 
     if (this.holdings) {
       this.isLoading = false;


### PR DESCRIPTION
This adds a summary row for all filtered positions to the holdings table (/home/holdings).
It summarizes the Values and the NetPerformanceWithCurrency effect. Additionally using both of these values it calculates the performance in percent:

> (Sum of NetPerf)./(Total Value - Sum of NetPerf.)