### PR TITLE
Holdingstable added Market price, limit name and add Sticky end

### DIFF
--- a/libs/ui/src/lib/holdings-table/holdings-table.component.html
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.html
@@ -21,13 +21,17 @@
     <ng-container matColumnDef="nameWithSymbol">
       <th
         *matHeaderCellDef
-        class="px-1"
+        class="px-1 name-col"
         mat-header-cell
         mat-sort-header="symbol"
       >
         <ng-container i18n>Name</ng-container>
       </th>
-      <td *matCellDef="let element" class="line-height-1 px-1" mat-cell>
+      <td
+        *matCellDef="let element"
+        class="line-height-1 px-1 name-col"
+        mat-cell
+      >
         <div class="text-truncate">
           {{ element.name }}
           @if (element.name === element.symbol) {
@@ -63,8 +67,34 @@
         </div>
       </td>
     </ng-container>
+    <ng-container
+      matColumnDef="marketPrice"
+      [stickyEnd]="dataSource?.sort?.active === 'marketPrice'"
+    >
+      <th
+        *matHeaderCellDef
+        class="justify-content-end px-1"
+        mat-header-cell
+        mat-sort-header
+      >
+        <span class="d-none d-sm-block" i18n>Marketprice</span>
+        <span class="d-block d-sm-none" i18n>Price</span>
+      </th>
+      <td *matCellDef="let element" class="px-1" mat-cell>
+        <div class="d-flex justify-content-end">
+          <gf-value
+            [isCurrency]="true"
+            [locale]="locale"
+            [value]="isLoading ? undefined : element.marketPrice"
+          />
+        </div>
+      </td>
+    </ng-container>
 
-    <ng-container matColumnDef="valueInBaseCurrency">
+    <ng-container
+      matColumnDef="valueInBaseCurrency"
+      [stickyEnd]="dataSource?.sort?.active === 'valueInBaseCurrency'"
+    >
       <th
         *matHeaderCellDef
         class="d-none d-lg-table-cell justify-content-end px-1"
@@ -88,7 +118,10 @@
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="allocationInPercentage">
+    <ng-container
+      matColumnDef="allocationInPercentage"
+      [stickyEnd]="dataSource?.sort?.active === 'allocationInPercentage'"
+    >
       <th
         *matHeaderCellDef
         class="justify-content-end px-1"
@@ -109,7 +142,12 @@
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="performance">
+    <ng-container
+      matColumnDef="performance"
+      [stickyEnd]="
+        dataSource?.sort?.active === 'netPerformanceWithCurrencyEffect'
+      "
+    >
       <th
         *matHeaderCellDef
         class="justify-content-end px-1"

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.scss
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.scss
@@ -1,6 +1,22 @@
 :host {
   display: block;
 
+  .mat-column-nameWithSymbol {
+    word-wrap: break-word !important;
+    white-space: unset !important;
+    max-width: 250px;
+    width: 60%;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
+    word-break: break-word;
+
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto;
+  }
+
   .gf-table {
     th {
       ::ng-deep {
@@ -10,4 +26,8 @@
       }
     }
   }
+}
+
+.mat-sort-header-sorted {
+  position: sticky !important;
 }

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.ts
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.ts
@@ -80,6 +80,7 @@ export class GfHoldingsTableComponent implements OnChanges, OnDestroy {
     }
 
     this.displayedColumns.push('allocationInPercentage');
+    this.displayedColumns.push('marketPrice');
 
     if (this.hasPermissionToShowValues) {
       this.displayedColumns.push('performance');


### PR DESCRIPTION
Hi @dtslvr 

I have added a further column on the holding page (/home/holdings) with the current marketprice.
With this added column I had issues with long etf names and a scrollbar appeared even on my desktop computer. 
Hence, I added a width-limitation to the name column. Unfortunately it was only working on mobile phones, if I had a fixed max-width.

On the same page I changed the column behavior of sorted columns adding a stickyEnd-attribute if the column is sorted by. On mobile phones this allows to always see the sorted column, even if you horizontally scroll back to the begin (the name column).
