### PR TITLE
Feature/improve check for duplicates in preview step of activities import (comments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the check for duplicates in the preview step of the activities import (allow different comments)
 - Improved the language localization for German (`fr`)
 - Upgraded `ng-extract-i18n-merge` from version `2.14.1` to `2.14.3`
 

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -526,7 +526,8 @@ export class ImportService {
             activity.quantity === quantity &&
             activity.SymbolProfile.symbol === symbol &&
             activity.type === type &&
-            activity.unitPrice === unitPrice
+            activity.unitPrice === unitPrice &&
+            activity.comment === comment
           );
         });
 

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -519,6 +519,7 @@ export class ImportService {
         const isDuplicate = existingActivities.some((activity) => {
           return (
             activity.accountId === accountId &&
+            activity.comment === comment &&
             activity.SymbolProfile.currency === currency &&
             activity.SymbolProfile.dataSource === dataSource &&
             isSameSecond(activity.date, date) &&
@@ -526,8 +527,7 @@ export class ImportService {
             activity.quantity === quantity &&
             activity.SymbolProfile.symbol === symbol &&
             activity.type === type &&
-            activity.unitPrice === unitPrice &&
-            activity.comment === comment
+            activity.unitPrice === unitPrice
           );
         });
 


### PR DESCRIPTION
In a situation when stocks are bought or sold in lots of say 100, it is not unusual that multiple lots are sold within the same second in separate transactions. In such cases, the comment field can be used to distinguish between the transactions, for example by putting external trade id. 