### PR TITLE
Feature/add expansion panel for historical market data editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended the benchmark detail dialog by the current market price
 - Added `watchlist` to the `User` database schema as a preparation for watching assets
 
+### Changed
+
+- Made the historical market data editor expandable in the admin control panel
+
 ### Fixed
 
 - Fixed the word wrap in the menu of the historical market data table in the admin control panel

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -80,8 +80,10 @@
     <div class="mb-3">
       <mat-accordion class="my-3">
         <mat-expansion-panel class="shadow-none">
-          <mat-expansion-panel-header class="mr-3 p-0">
-            <mat-panel-title i18n>Historical Market Data</mat-panel-title>
+          <mat-expansion-panel-header class="p-0 pr-3">
+            <mat-panel-title class="font-weight-bold" i18n
+              >Historical Market Data</mat-panel-title
+            >
           </mat-expansion-panel-header>
 
           <gf-historical-market-data-editor
@@ -370,8 +372,10 @@
               (closed)="scraperConfiguationIsExpanded.set(false)"
               (opened)="scraperConfiguationIsExpanded.set(true)"
             >
-              <mat-expansion-panel-header class="mr-3 p-0">
-                <mat-panel-title i18n>Scraper Configuration</mat-panel-title>
+              <mat-expansion-panel-header class="p-0 pr-3">
+                <mat-panel-title class="font-weight-bold" i18n
+                  >Scraper Configuration</mat-panel-title
+                >
               </mat-expansion-panel-header>
               <div formGroupName="scraperConfiguration">
                 <div class="mt-3">

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -77,17 +77,27 @@
       [showYAxis]="true"
       [symbol]="data.symbol"
     />
-    <gf-historical-market-data-editor
-      class="mb-3"
-      [currency]="assetProfile?.currency"
-      [dataSource]="data.dataSource"
-      [dateOfFirstActivity]="assetProfile?.dateOfFirstActivity"
-      [locale]="data.locale"
-      [marketData]="marketDataItems"
-      [symbol]="data.symbol"
-      [user]="user"
-      (marketDataChanged)="onMarketDataChanged($event)"
-    />
+    <div class="mb-3">
+      <mat-accordion class="my-3">
+        <mat-expansion-panel class="shadow-none">
+          <mat-expansion-panel-header class="p-0">
+            <mat-panel-title i18n>Historical Market Data</mat-panel-title>
+          </mat-expansion-panel-header>
+
+          <gf-historical-market-data-editor
+            class="mb-3"
+            [currency]="assetProfile?.currency"
+            [dataSource]="data.dataSource"
+            [dateOfFirstActivity]="assetProfile?.dateOfFirstActivity"
+            [locale]="data.locale"
+            [marketData]="marketDataItems"
+            [symbol]="data.symbol"
+            [user]="user"
+            (marketDataChanged)="onMarketDataChanged($event)"
+          />
+        </mat-expansion-panel>
+      </mat-accordion>
+    </div>
 
     <div class="row">
       @if (isEditAssetProfileIdentifierMode) {

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -80,7 +80,7 @@
     <div class="mb-3">
       <mat-accordion class="my-3">
         <mat-expansion-panel class="shadow-none">
-          <mat-expansion-panel-header class="p-0">
+          <mat-expansion-panel-header class="mr-3 p-0">
             <mat-panel-title i18n>Historical Market Data</mat-panel-title>
           </mat-expansion-panel-header>
 
@@ -370,7 +370,7 @@
               (closed)="scraperConfiguationIsExpanded.set(false)"
               (opened)="scraperConfiguationIsExpanded.set(true)"
             >
-              <mat-expansion-panel-header class="p-0">
+              <mat-expansion-panel-header class="mr-3 p-0">
                 <mat-panel-title i18n>Scraper Configuration</mat-panel-title>
               </mat-expansion-panel-header>
               <div formGroupName="scraperConfiguration">

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor.component.html
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor.component.html
@@ -1,7 +1,7 @@
 <div>
   @for (itemByMonth of marketDataByMonth | keyvalue; track itemByMonth) {
     <div class="d-flex">
-      <div class="date px-1 text-nowrap">{{ itemByMonth.key }}</div>
+      <div class="date mr-1 text-nowrap">{{ itemByMonth.key }}</div>
       <div class="align-items-center d-flex flex-grow-1 px-1">
         @for (dayItem of days; track dayItem; let i = $index) {
           <div


### PR DESCRIPTION
Hi @dtslvr,
This PR solves #4496.

Changes:
- Added expansion panel for the historical market data component.
- Added margin on the right of the expansion indicator such that a part of it is not cut off.
