### PR TITLE
Feature/extend holding endpoint by performances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Extended the endpoint to get a holding by the date of the last all time high and the current change to the all time high
+
 ## 2.160.0 - 2025-05-04
 
 ### Added

--- a/apps/api/src/app/endpoints/ai/ai.module.ts
+++ b/apps/api/src/app/endpoints/ai/ai.module.ts
@@ -8,6 +8,7 @@ import { RulesService } from '@ghostfolio/api/app/portfolio/rules.service';
 import { RedisCacheModule } from '@ghostfolio/api/app/redis-cache/redis-cache.module';
 import { UserModule } from '@ghostfolio/api/app/user/user.module';
 import { ApiModule } from '@ghostfolio/api/services/api/api.module';
+import { BenchmarkModule } from '@ghostfolio/api/services/benchmark/benchmark.module';
 import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
 import { DataProviderModule } from '@ghostfolio/api/services/data-provider/data-provider.module';
 import { ExchangeRateDataModule } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.module';
@@ -27,6 +28,7 @@ import { AiService } from './ai.service';
   controllers: [AiController],
   imports: [
     ApiModule,
+    BenchmarkModule,
     ConfigurationModule,
     DataProviderModule,
     ExchangeRateDataModule,

--- a/apps/api/src/app/endpoints/public/public.module.ts
+++ b/apps/api/src/app/endpoints/public/public.module.ts
@@ -9,6 +9,7 @@ import { RulesService } from '@ghostfolio/api/app/portfolio/rules.service';
 import { RedisCacheModule } from '@ghostfolio/api/app/redis-cache/redis-cache.module';
 import { UserModule } from '@ghostfolio/api/app/user/user.module';
 import { TransformDataSourceInRequestModule } from '@ghostfolio/api/interceptors/transform-data-source-in-request/transform-data-source-in-request.module';
+import { BenchmarkModule } from '@ghostfolio/api/services/benchmark/benchmark.module';
 import { DataProviderModule } from '@ghostfolio/api/services/data-provider/data-provider.module';
 import { ExchangeRateDataModule } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.module';
 import { ImpersonationModule } from '@ghostfolio/api/services/impersonation/impersonation.module';
@@ -25,6 +26,7 @@ import { PublicController } from './public.controller';
   controllers: [PublicController],
   imports: [
     AccessModule,
+    BenchmarkModule,
     DataProviderModule,
     ExchangeRateDataModule,
     ImpersonationModule,

--- a/apps/api/src/app/portfolio/portfolio.module.ts
+++ b/apps/api/src/app/portfolio/portfolio.module.ts
@@ -9,6 +9,7 @@ import { RedactValuesInResponseModule } from '@ghostfolio/api/interceptors/redac
 import { TransformDataSourceInRequestModule } from '@ghostfolio/api/interceptors/transform-data-source-in-request/transform-data-source-in-request.module';
 import { TransformDataSourceInResponseModule } from '@ghostfolio/api/interceptors/transform-data-source-in-response/transform-data-source-in-response.module';
 import { ApiModule } from '@ghostfolio/api/services/api/api.module';
+import { BenchmarkModule } from '@ghostfolio/api/services/benchmark/benchmark.module';
 import { ConfigurationModule } from '@ghostfolio/api/services/configuration/configuration.module';
 import { DataProviderModule } from '@ghostfolio/api/services/data-provider/data-provider.module';
 import { ExchangeRateDataModule } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.module';
@@ -33,6 +34,7 @@ import { RulesService } from './rules.service';
   imports: [
     AccessModule,
     ApiModule,
+    BenchmarkModule,
     ConfigurationModule,
     DataGatheringModule,
     DataProviderModule,

--- a/libs/common/src/lib/interfaces/responses/portfolio-holding-response.interface.ts
+++ b/libs/common/src/lib/interfaces/responses/portfolio-holding-response.interface.ts
@@ -1,5 +1,6 @@
 import { Activity } from '@ghostfolio/api/app/order/interfaces/activities.interface';
 import {
+  Benchmark,
   DataProviderInfo,
   EnhancedSymbolProfile,
   HistoricalDataItem
@@ -29,6 +30,7 @@ export interface PortfolioHoldingResponse {
   netPerformancePercent: number;
   netPerformancePercentWithCurrencyEffect: number;
   netPerformanceWithCurrencyEffect: number;
+  performances: Benchmark['performances'];
   quantity: number;
   SymbolProfile: EnhancedSymbolProfile;
   tags: Tag[];


### PR DESCRIPTION
Hi @dtslvr, this PR is to resolve issue https://github.com/ghostfolio/ghostfolio/issues/4651. Please take a look :)

### Changes
* Added `performances` property to `PortfolioHoldingResponse`.
* Added performance data calculation in `PortfolioService.getHolding`.
* Imported `BenchmarkModule` in `AiModule`, `PublicModule` and `PortfolioModule`.

The `performances` field should now be included through endpoint call to
`GET api/v1/portfolio /holding/:dataSource/:symbol`/