### PR TITLE
fix: Handle empty account balances during import

### DIFF
--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -187,7 +187,14 @@ export class ImportService {
 
           let accountObject: Prisma.AccountCreateInput = {
             ...account,
-            User: { connect: { id: user.id } }
+            User: { connect: { id: user.id } },
+            balances: {
+              create: {
+                amount: 0,
+                date: new Date(),
+                currency: account.currency
+              }
+            }
           };
 
           if (


### PR DESCRIPTION
i've fixed the issue by modifying the account creation logic in the import service. Here's what I changed:

Instead of passing an empty balances array, we now create a default balance entry when creating a new account
The default balance entry includes:
```
amount: 0 (since the account has no initial balance)
date: new Date() (current date)
currency: account.currency (using the account's currency)
```
This change ensures that even when importing an account with empty balances, the account will be created with a proper initial balance entry of 0, which satisfies Prisma's type requirements.

The fix should now allow importing accounts with empty balances without failing

#4666 