### PR TITLE
feat: enable to push to docker repo set in settings

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghostfolio/ghostfolio
+          images: ${{ vars.DOCKER_REPOSITORY || 'ghostfolio/ghostfolio' }}
           tags: |
             type=semver,pattern={{major}}
             type=semver,pattern={{version}}


### PR DESCRIPTION
If nothing is set in settings, we'd push to `ghostfolio/ghostfolio` as before. This commit will enable easier maintenance of forks by people outside of `ghostfolio` org.

It's working: 
- https://github.com/aensidhe/ghostfolio/actions/runs/14981245612/attempts/1 - job fails, because I don't have access to `ghostfolio/ghostfolio` repo
- https://github.com/aensidhe/ghostfolio/actions/runs/14981245612 - latest job works, because I've provided proper settings in my repo