### PR TITLE
feat: Add Italian translation for "Log out" in header component

### DIFF
--- a/apps/client/src/locales/messages.it.xlf
+++ b/apps/client/src/locales/messages.it.xlf
@@ -7992,7 +7992,7 @@
       </trans-unit>
       <trans-unit id="3fdc751b264ca9998e1542fcf5794e274cd56344" datatype="html">
         <source>Log out</source>
-        <target state="new">Log out</target>
+        <target state="translated">Esci</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/header/header.component.html</context>
           <context context-type="linenumber">315</context>


### PR DESCRIPTION
This PR adds the Italian translation for the "Log out" text in the header component.

Changes:
- Updated the Italian translation file (messages.it.xlf) to translate "Log out" to "Esci"

Closes #3587
