### PR TITLE
Feature/add allocations percentage to accounts table component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added the allocation column to the accounts table component of the holding detail dialog
+
 ### Changed
 
 - Restructured the response of the portfolio report endpoint (_X-ray_)

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -72,7 +72,6 @@ import {
   Order,
   Platform,
   Prisma,
-  SymbolProfile,
   Tag
 } from '@prisma/client';
 import { Big } from 'big.js';
@@ -161,11 +160,7 @@ export class PortfolioService {
       this.accountService.accounts({
         where,
         include: {
-          activities: {
-            include: {
-              SymbolProfile: true
-            }
-          },
+          activities: true,
           platform: true
         },
         orderBy: { name: 'asc' }
@@ -180,71 +175,39 @@ export class PortfolioService {
 
     const userCurrency = this.request.user.settings.settings.baseCurrency;
 
-    const accountsWithValue = accounts.map((account) => {
+    return accounts.map((account) => {
       let transactionCount = 0;
-      let valueInBaseCurrency =
-        details.accounts[account.id]?.valueInBaseCurrency ?? 0;
 
-      if (filterByDataSource && filterBySymbol) {
-        const holding = details.holdings[filterBySymbol];
-
-        const activities = (
-          account.activities as (Order & {
-            SymbolProfile: SymbolProfile;
-          })[]
-        ).filter((activity) => {
-          return (
-            activity.SymbolProfile.dataSource === filterByDataSource &&
-            activity.SymbolProfile.symbol === filterBySymbol
-          );
-        });
-
-        let quantity = new Big(0);
-        for (const activity of activities) {
-          quantity = quantity.plus(
-            new Big(getFactor(activity.type)).mul(activity.quantity)
-          );
-        }
-
-        valueInBaseCurrency = quantity.mul(holding.marketPrice ?? 0).toNumber();
-        transactionCount = activities.length;
-      } else {
-        for (const { isDraft } of account.activities) {
-          if (!isDraft) {
-            transactionCount += 1;
-          }
+      for (const { isDraft } of account.activities) {
+        if (!isDraft) {
+          transactionCount += 1;
         }
       }
 
+      const valueInBaseCurrency =
+        details.accounts[account.id]?.valueInBaseCurrency ?? 0;
+
       const result = {
         ...account,
-        allocationInPercentage: 0,
+        transactionCount,
+        valueInBaseCurrency,
+        allocationInPercentage: undefined, // TODO
         balanceInBaseCurrency: this.exchangeRateDataService.toCurrency(
           account.balance,
           account.currency,
           userCurrency
         ),
-        transactionCount,
         value: this.exchangeRateDataService.toCurrency(
           valueInBaseCurrency,
           userCurrency,
           account.currency
-        ),
-        valueInBaseCurrency
+        )
       };
 
       delete result.activities;
 
       return result;
     });
-
-    if (filterByDataSource && filterBySymbol) {
-      return accountsWithValue.filter((account) => {
-        return account.transactionCount > 0;
-      });
-    }
-
-    return accountsWithValue;
   }
 
   public async getAccountsWithAggregations({
@@ -273,14 +236,6 @@ export class PortfolioService {
         account.valueInBaseCurrency
       );
       transactionCount += account.transactionCount;
-    }
-
-    for (const account of accounts) {
-      account.allocationInPercentage = totalValueInBaseCurrency.gt(0)
-        ? new Big(account.valueInBaseCurrency)
-            .div(totalValueInBaseCurrency)
-            .toNumber()
-        : 0;
     }
 
     return {

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -191,7 +191,7 @@ export class PortfolioService {
         ...account,
         transactionCount,
         valueInBaseCurrency,
-        allocationInPercentage: undefined, // TODO
+        allocationInPercentage: null, // TODO
         balanceInBaseCurrency: this.exchangeRateDataService.toCurrency(
           account.balance,
           account.currency,

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.html
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.html
@@ -255,17 +255,9 @@
       </td>
       <td
         *matFooterCellDef
-        class="d-none d-lg-table-cell px-1 text-right"
+        class="d-none d-lg-table-cell px-1"
         mat-footer-cell
-      >
-        <gf-value
-          class="d-inline-block justify-content-end"
-          [isPercent]="true"
-          [locale]="locale"
-          [precision]="2"
-          [value]="1"
-        />
-      </td>
+      ></td>
     </ng-container>
 
     <ng-container matColumnDef="comment">
@@ -328,7 +320,11 @@
           </button>
         </mat-menu>
       </td>
-      <td *matFooterCellDef class="px-1" mat-footer-cell></td>
+      <td
+        *matFooterCellDef
+        class="d-none d-lg-table-cell px-1"
+        mat-footer-cell
+      ></td>
     </ng-container>
 
     <tr *matHeaderRowDef="displayedColumns" mat-header-row></tr>

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.html
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.html
@@ -231,6 +231,43 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="allocation">
+      <th
+        *matHeaderCellDef
+        class="d-none d-lg-table-cell justify-content-end px-1"
+        mat-header-cell
+        mat-sort-header
+      >
+        <ng-container i18n>Allocation</ng-container>
+      </th>
+      <td
+        *matCellDef="let element"
+        class="d-none d-lg-table-cell px-1 text-right"
+        mat-cell
+      >
+        <gf-value
+          class="d-inline-block justify-content-end"
+          [isPercent]="true"
+          [locale]="locale"
+          [precision]="2"
+          [value]="element.allocationInPercentage"
+        />
+      </td>
+      <td
+        *matFooterCellDef
+        class="d-none d-lg-table-cell px-1 text-right"
+        mat-footer-cell
+      >
+        <gf-value
+          class="d-inline-block justify-content-end"
+          [isPercent]="true"
+          [locale]="locale"
+          [precision]="2"
+          [value]="1"
+        />
+      </td>
+    </ng-container>
+
     <ng-container matColumnDef="comment">
       <th
         *matHeaderCellDef

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.ts
@@ -60,7 +60,7 @@ export class GfAccountsTableComponent implements OnChanges, OnDestroy {
   @Input() hasPermissionToOpenDetails = true;
   @Input() locale = getLocale();
   @Input() showActions: boolean;
-  @Input() showAllocationInPercentage = false;
+  @Input() showAllocationInPercentage: boolean;
   @Input() showBalance = true;
   @Input() showFooter = true;
   @Input() showTransactions = true;

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.ts
@@ -60,6 +60,7 @@ export class GfAccountsTableComponent implements OnChanges, OnDestroy {
   @Input() hasPermissionToOpenDetails = true;
   @Input() locale = getLocale();
   @Input() showActions: boolean;
+  @Input() showAllocationInPercentage = false;
   @Input() showBalance = true;
   @Input() showFooter = true;
   @Input() showTransactions = true;
@@ -117,7 +118,10 @@ export class GfAccountsTableComponent implements OnChanges, OnDestroy {
       this.displayedColumns.push('valueInBaseCurrency');
     }
 
-    this.displayedColumns.push('allocation');
+    if (this.showAllocationInPercentage) {
+      this.displayedColumns.push('allocation');
+    }
+
     this.displayedColumns.push('comment');
 
     if (this.showActions) {

--- a/apps/client/src/app/components/accounts-table/accounts-table.component.ts
+++ b/apps/client/src/app/components/accounts-table/accounts-table.component.ts
@@ -117,6 +117,7 @@ export class GfAccountsTableComponent implements OnChanges, OnDestroy {
       this.displayedColumns.push('valueInBaseCurrency');
     }
 
+    this.displayedColumns.push('allocation');
     this.displayedColumns.push('comment');
 
     if (this.showActions) {

--- a/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html
+++ b/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html
@@ -375,6 +375,7 @@
           [deviceType]="data.deviceType"
           [hasPermissionToOpenDetails]="false"
           [locale]="user?.settings?.locale"
+          [showAllocationInPercentage]="user?.settings?.isExperimentalFeatures"
           [showBalance]="false"
           [showFooter]="false"
           [showTransactions]="false"

--- a/libs/common/src/lib/types/account-with-value.type.ts
+++ b/libs/common/src/lib/types/account-with-value.type.ts
@@ -1,6 +1,7 @@
 import { Account as AccountModel, Platform } from '@prisma/client';
 
 export type AccountWithValue = AccountModel & {
+  allocationInPercentage: number;
   balanceInBaseCurrency: number;
   platform?: Platform;
   transactionCount: number;


### PR DESCRIPTION
Fixes #4646 

-Extended AccountWithValue type with allocationInPercentage property
-Enhanced PortfolioService.getAccounts() to calculate each account's allocation percentage based on its value relative to the total portfolio value
-Added an "Allocations" column to the accounts table component just before the comment column
-Displayed allocation values using the existing value component with percentage formatting
This feature helps users better understand how their portfolio is distributed across different accounts.