### PR TITLE
Feature/upgrade yahoo-finance2 to version 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for Italian (`it`)
 - Upgraded `countup.js` from version `2.8.0` to `2.8.2`
 - Upgraded `nestjs` from version `10.4.15` to `11.0.12`
-- Upgraded `yahoo-finance2` from version `2.11.3` to `3.3.1`
+- Upgraded `yahoo-finance2` from version `2.11.3` to `3.3.2`
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "svgmap": "2.12.2",
         "twitter-api-v2": "1.14.2",
         "uuid": "11.1.0",
-        "yahoo-finance2": "3.3.1",
+        "yahoo-finance2": "3.3.2",
         "zone.js": "0.15.0"
       },
       "devDependencies": {
@@ -36091,9 +36091,9 @@
       }
     },
     "node_modules/yahoo-finance2": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.3.1.tgz",
-      "integrity": "sha512-hBXdhieq897OoAu2HxA4/Ca+XrYtPFLTtGzPRW5qKCd+nX1ahHID3tmvxVBBlDTeOesdp0wjO5uGJS+o4cnEMw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.3.2.tgz",
+      "integrity": "sha512-KJLrcEwG+PFxe7L2iXe1R9icceFChENA+2EdFo/6GYIFVJR4YJD3MrjIsAYfGuzK531EjDLyT4KSlpIkaKhhgw==",
       "license": "MIT",
       "dependencies": {
         "@deno/shim-deno": "~0.18.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "svgmap": "2.12.2",
     "twitter-api-v2": "1.14.2",
     "uuid": "11.1.0",
-    "yahoo-finance2": "3.3.1",
+    "yahoo-finance2": "3.3.2",
     "zone.js": "0.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* chore(deps): bump yahoo-finance2 from 3.3.1 to 3.3.2

Some recent changes to yf2's validateAndCoerce system were incorrectly recognizing "DateInMs" types, resulting in dates like "+044971-07-27T00:00:00.000Z".  The new release fixes this.


Hey team, hope I got the commit message format right :)  Just noticed the fairly serious bug above so wanted to squeeze this in before your next release, which I think will include yf2 v3.  On that note (and I guess unrelated here), it will still be some time until v3 is "official", but all updates are happening there and it seems stable.  Certainly positive feedback from a big installation base like yours will help.  But honestly, the biggest delay on my side now is probably just updating all the docs.