### PR TITLE
feat: Add French translation for "Log out" in header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for Catalan (`ca`)
 - Improved the language localization for Chinese (`zh`)
 - Improved the language localization for Dutch (`nl`)
+- Improved the language localization for French (`fr`)
 - Improved the language localization for German (`de`)
 - Improved the language localization for Italian (`it`)
 - Upgraded `countup.js` from version `2.8.0` to `2.8.2`

--- a/apps/client/src/locales/messages.fr.xlf
+++ b/apps/client/src/locales/messages.fr.xlf
@@ -7995,7 +7995,7 @@
       </trans-unit>
       <trans-unit id="3fdc751b264ca9998e1542fcf5794e274cd56344" datatype="html">
         <source>Log out</source>
-        <target state="new">Log out</target>
+        <target state="translated">Se déconnecter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/header/header.component.html</context>
           <context context-type="linenumber">315</context>

--- a/apps/client/src/locales/messages.fr.xlf
+++ b/apps/client/src/locales/messages.fr.xlf
@@ -471,7 +471,7 @@
       </trans-unit>
       <trans-unit id="8ea23a2cc3e9549fa71e7724870038a17216b210" datatype="html">
         <source>Historical Market Data</source>
-        <target state="translated">Données de Marché Historiques</target>
+        <target state="translated">Données historiques du marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-jobs/admin-jobs.html</context>
           <context context-type="linenumber">37</context>
@@ -535,7 +535,7 @@
       </trans-unit>
       <trans-unit id="78a0f1c3cb3e3af864d2c21e621ba3b40b4e0afc" datatype="html">
         <source>Market Price</source>
-        <target state="translated">Prix du Marché</target>
+        <target state="translated">Prix du marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/admin-market-data.html</context>
           <context context-type="linenumber">133</context>
@@ -1127,7 +1127,7 @@
       </trans-unit>
       <trans-unit id="68ca4a6d3699c0b1141421f8ca995cb1ed736128" datatype="html">
         <source>Current Market Mood</source>
-        <target state="translated">Sentiment Actuel du Marché</target>
+        <target state="translated">Sentiment actuel du marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/fear-and-greed-index/fear-and-greed-index.component.html</context>
           <context context-type="linenumber">12</context>
@@ -1479,7 +1479,7 @@
       </trans-unit>
       <trans-unit id="41c1e1f19aabc4a4bf198e4a189436a1f69257bb" datatype="html">
         <source>Time in Market</source>
-        <target state="translated">Temps sur le Marché</target>
+        <target state="translated">Temps sur le marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html</context>
           <context context-type="linenumber">3</context>
@@ -2203,7 +2203,7 @@
       </trans-unit>
       <trans-unit id="4798457301875181136" datatype="html">
         <source>Market Data</source>
-        <target state="translated">Données de Marché</target>
+        <target state="translated">Données du marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/admin/admin-page-routing.module.ts</context>
           <context context-type="linenumber">30</context>
@@ -2663,7 +2663,7 @@
       </trans-unit>
       <trans-unit id="034c2b473d0b76acbc938453375b13cb2491dc17" datatype="html">
         <source>Developed Markets</source>
-        <target state="translated">Marchés Développés</target>
+        <target state="translated">Marchés développés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">222</context>
@@ -2675,7 +2675,7 @@
       </trans-unit>
       <trans-unit id="81eb53c18dfd116d6e54877444847b3091d92ab0" datatype="html">
         <source>Emerging Markets</source>
-        <target state="translated">Marchés Émergents</target>
+        <target state="translated">Marchés émergents</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">231</context>
@@ -4171,7 +4171,7 @@
       </trans-unit>
       <trans-unit id="7136888919962092730" datatype="html">
         <source>Changelog</source>
-        <target state="translated">Historique des Modifications</target>
+        <target state="translated">Historique des modifications</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/about/about-page.component.ts</context>
           <context context-type="linenumber">50</context>
@@ -4267,7 +4267,7 @@
       </trans-unit>
       <trans-unit id="dbf8136366f55644df4ce493c233c74c12d79257" datatype="html">
         <source>Market Mood</source>
-        <target state="translated">Sentiment du Marché</target>
+        <target state="translated">Sentiment du marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/features/features-page.html</context>
           <context context-type="linenumber">215</context>
@@ -4583,7 +4583,7 @@
       </trans-unit>
       <trans-unit id="834807cba8928b6f8b27ea62c886f7f3715079b0" datatype="html">
         <source>By Market</source>
-        <target state="translated">par Marchés</target>
+        <target state="translated">par marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">175</context>
@@ -7670,7 +7670,7 @@
       </trans-unit>
       <trans-unit id="cdcd7c871f3bc0326ee77e5aea82af1ef26f46f2" datatype="html">
         <source>Market Data</source>
-        <target state="translated">Données de Marché</target>
+        <target state="translated">Données du marché</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html</context>
           <context context-type="linenumber">374</context>


### PR DESCRIPTION
This pull request updates the French translations in the `apps/client/src/locales/messages.fr.xlf` file to ensure consistency in capitalization and phrasing, and to address a previously untranslated string. The most important changes are grouped below by theme.

### Consistency in capitalization:
* Standardized capitalization for phrases like "Données du marché," "Sentiment actuel du marché," and "Historique des modifications" by using lowercase for non-proper nouns. [[1]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL474-R474) [[2]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL1130-R1130) [[3]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL4174-R4174)
* Adjusted translations for "Marchés développés" and "Marchés émergents" to use lowercase for adjectives. [[1]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL2666-R2666) [[2]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL2678-R2678)

### Addressing untranslated string:
* Translated the previously untranslated "Log out" string to "Se déconnecter."

### Other phrasing updates:
* Updated phrases such as "Prix du marché" and "Temps sur le marché" for consistency with the updated style. [[1]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL538-R538) [[2]](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL1482-R1482)

Related to #3589 