### PR TITLE
fixed import button being disabled on import

### DIFF
--- a/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.component.ts
@@ -289,6 +289,10 @@ export class ImportActivitiesDialog implements OnDestroy {
             this.activities = activities;
             this.dataSource = new MatTableDataSource(activities.reverse());
             this.totalItems = activities.length;
+
+            this.selectedActivities = [...activities];
+            this.changeDetectorRef.markForCheck();
+            stepper.next();
           } catch (error) {
             console.error(error);
             this.handleImportError({ error, activities: content.activities });
@@ -307,6 +311,10 @@ export class ImportActivitiesDialog implements OnDestroy {
             this.activities = data.activities;
             this.dataSource = new MatTableDataSource(data.activities.reverse());
             this.totalItems = data.activities.length;
+
+            this.selectedActivities = [...data.activities];
+            this.changeDetectorRef.markForCheck();
+            stepper.next();
           } catch (error) {
             console.error(error);
             this.handleImportError({


### PR DESCRIPTION
There was a bug #4745 that stated when the import button stayed disabled for too long. 

From my recreation of the bug, it seems the import button was disabled, but then gets enabled whenever an item on the table is selected/deselected. 

With these changes, the button "import" should be enabled right away. 

My approach: 

**1. auto-select all loaded activities**
this.selectedActivities = [...activities];
this.selectedActivities = [...data.activities]; 

- Right after populating the table (dataSource) and set totalItems, we copy the full list of validated activities into selectedActivities

**2. trigger OnPush change detection**
 this.changeDetectorRef.markForCheck();

- this allows the view to see the new selections and re-evaluates the import button state

**3. ensure stepper advances after selection**

stepper.next();

stepper.next is kept in the "finally" block but I moved the new lines to run before it. This allows for when users land on the "Select Activities" step, the import button will already be enabled! 



All in all, no other logic is touched such as error-handling, table setup, etc. This change should only boost the default selection for a butter user interface.  