### PR TITLE
Feature/handle orders with null buy price

### DIFF
--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator.ts
@@ -938,9 +938,11 @@ export class RoaiPortfolioCalculator extends PortfolioCalculator {
         Net performance: ${totalNetPerformance.toFixed(
           2
         )} / ${netPerformancePercentage.mul(100).toFixed(2)}%
-        Net performance with currency effect: ${netPerformancePercentageWithCurrencyEffectMap[
-          'max'
-        ].toFixed(2)}%`
+        Net performance with currency effect: ${netPerformanceValuesWithCurrencyEffect[
+          endDateString
+        ].toFixed(2)} / ${netPerformancePercentageWithCurrencyEffectMap['max']
+          .mul(100)
+          .toFixed(2)}%`
       );
     }
 

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator.ts
@@ -554,6 +554,16 @@ export class RoaiPortfolioCalculator extends PortfolioCalculator {
 
           initialValueWithCurrencyEffect =
             transactionInvestmentWithCurrencyEffect;
+        } else if (
+          order.quantity.gt(0) &&
+          ['BUY', 'SELL'].includes(order.type) &&
+          !order.itemType
+        ) {
+          initialValue = order.quantity.mul(marketPriceInBaseCurrency);
+
+          initialValueWithCurrencyEffect = order.quantity.mul(
+            marketPriceInBaseCurrencyWithCurrencyEffect
+          );
         }
       }
 

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator.ts
@@ -783,7 +783,9 @@ export class RoaiPortfolioCalculator extends PortfolioCalculator {
         ? totalGrossPerformance.div(
             timeWeightedAverageInvestmentBetweenStartAndEndDate
           )
-        : new Big(0);
+        : totalGrossPerformance
+          ? new Big(1)
+          : new Big(0);
 
     const grossPerformancePercentageWithCurrencyEffect =
       timeWeightedAverageInvestmentBetweenStartAndEndDateWithCurrencyEffect.gt(
@@ -792,7 +794,9 @@ export class RoaiPortfolioCalculator extends PortfolioCalculator {
         ? totalGrossPerformanceWithCurrencyEffect.div(
             timeWeightedAverageInvestmentBetweenStartAndEndDateWithCurrencyEffect
           )
-        : new Big(0);
+        : totalGrossPerformanceWithCurrencyEffect
+          ? new Big(1)
+          : new Big(0);
 
     const feesPerUnit = totalUnits.gt(0)
       ? fees.minus(feesAtStartDate).div(totalUnits)
@@ -809,7 +813,9 @@ export class RoaiPortfolioCalculator extends PortfolioCalculator {
         ? totalNetPerformance.div(
             timeWeightedAverageInvestmentBetweenStartAndEndDate
           )
-        : new Big(0);
+        : totalNetPerformance
+          ? new Big(1)
+          : new Big(0);
 
     const netPerformancePercentageWithCurrencyEffectMap: {
       [key: DateRange]: Big;
@@ -902,7 +908,9 @@ export class RoaiPortfolioCalculator extends PortfolioCalculator {
 
       netPerformancePercentageWithCurrencyEffectMap[dateRange] = average.gt(0)
         ? netPerformanceWithCurrencyEffectMap[dateRange].div(average)
-        : new Big(0);
+        : netPerformanceWithCurrencyEffectMap[dateRange]
+          ? new Big(1)
+          : new Big(0);
     }
 
     if (PortfolioCalculator.ENABLE_LOGGING) {

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -793,10 +793,7 @@ export class PortfolioService {
           historicalDataArray.push({
             date,
             averagePrice: currentAveragePrice,
-            marketPrice:
-              historicalDataArray.length > 0
-                ? marketPrice
-                : currentAveragePrice,
+            marketPrice,
             quantity: currentQuantity
           });
 

--- a/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.component.ts
+++ b/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.component.ts
@@ -275,11 +275,13 @@ export class GfHoldingDetailDialogComponent implements OnDestroy, OnInit {
             SymbolProfile?.userId === this.user?.id;
 
           this.historicalDataItems = historicalData.map(
-            ({ averagePrice, date, marketPrice }) => {
-              this.benchmarkDataItems.push({
-                date,
-                value: averagePrice
-              });
+            ({ averagePrice, date, marketPrice, quantity }) => {
+              if (quantity) {
+                this.benchmarkDataItems.push({
+                  date,
+                  value: averagePrice
+                });
+              }
 
               return {
                 date,
@@ -426,15 +428,6 @@ export class GfHoldingDetailDialogComponent implements OnDestroy, OnInit {
           ) {
             this.benchmarkDataItems[0].value = this.averagePrice;
           }
-
-          this.benchmarkDataItems = this.benchmarkDataItems.map(
-            ({ date, value }) => {
-              return {
-                date,
-                value: value === 0 ? null : value
-              };
-            }
-          );
 
           if (this.hasPermissionToReadMarketDataOfOwnAssetProfile) {
             this.fetchMarketData();


### PR DESCRIPTION
When I get free assets (welcome gifts, stacking rewards, free share allocation, ...), I create activities with the "BUY" type and zero as the unit price.

If for a holding, the first activity or all activities are purchases with a zero value, then in the holding detail dialog the change and performance are not shown, and the chart does not display the average buy price when it's zero and use it as the first value of the market price.

This pull request fix it: the chart is correctly displayed and the performance is 100% if the average buy price is 0.

Here an example with a gift of 2€ worth of bitcoin :
```json
{
  "activities": [
    {
      "accountId": "...",
      "comment": null,
      "fee": 0,
      "quantity": 0.00002155,
      "type": "BUY",
      "unitPrice": 0,
      "currency": "USD",
      "dataSource": "COINGECKO",
      "date": "2025-05-16T22:00:00.000Z",
      "symbol": "bitcoin",
      "tags": []
    }
  ]
}
```

Before:
![before](https://github.com/user-attachments/assets/b64d6c6d-2f7b-4dbe-9c32-6dbf62422f6f)

After:
![after](https://github.com/user-attachments/assets/9952aa47-ca7f-4ba8-97ef-4606a3ff2690)
