### PR TITLE
Replace asset profile count with value component in admin settings

### DIFF
--- a/apps/client/src/app/components/admin-settings/admin-settings.component.html
+++ b/apps/client/src/app/components/admin-settings/admin-settings.component.html
@@ -48,11 +48,14 @@
         </ng-container>
 
         <ng-container matColumnDef="assetProfileCount">
-          <th *matHeaderCellDef class="px-1 py-2 text-right" mat-header-cell>
+          <th *matHeaderCellDef class="px-1 py-2 justify-content-end" mat-header-cell>
             <ng-container i18n>Asset Profiles</ng-container>
           </th>
           <td *matCellDef="let element" class="px-1 py-2 text-right" mat-cell>
-            {{ element.assetProfileCount }}
+            <gf-value
+              class="d-inline-block justify-content-end"
+              [value]="element.assetProfileCount"
+            />
           </td>
         </ng-container>
 


### PR DESCRIPTION
## Description
This PR implements the enhancement requested in #4781 to improve the display of asset profile counts in the admin settings component.

### Changes Made
- Replaced raw `element.assetProfileCount` with `<gf-value>` component
- Added `justify-content-end` class to align column header
- Maintained consistency with the Value column in accounts table component