### PR TITLE
Turkish locale translation and correction of the word resources

### DIFF
--- a/apps/client/src/locales/messages.tr.xlf
+++ b/apps/client/src/locales/messages.tr.xlf
@@ -112,7 +112,7 @@
       </trans-unit>
       <trans-unit id="452ef1b96854fe05618303ee601f8fed3b866c9f" datatype="html">
         <source>Resources</source>
-        <target state="translated">Piyasalar</target>
+        <target state="translated">Kaynaklar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/app.component.html</context>
           <context context-type="linenumber">64</context>
@@ -7606,7 +7606,7 @@
       </trans-unit>
       <trans-unit id="3920411961658116502" datatype="html">
         <source>Demo user account has been synced.</source>
-        <target state="new">Demo user account has been synced.</target>
+        <target state="translated">Demo kullanıcı hesabı senkronize edildi.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-overview/admin-overview.component.ts</context>
           <context context-type="linenumber">223</context>
@@ -7614,7 +7614,7 @@
       </trans-unit>
       <trans-unit id="18fe01d6ae816d6787148e59ea1a39d0bb542e24" datatype="html">
         <source>Sync Demo User Account</source>
-        <target state="new">Sync Demo User Account</target>
+        <target state="translated">Demo Kullanıcı Hesabını Senkronize Et</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-overview/admin-overview.html</context>
           <context context-type="linenumber">181</context>


### PR DESCRIPTION
Fixes #3628
This update addresses missing Turkish translations in Ghostfolio’s user interface. The following changes have been made:
Searched the Turkish translation file (messages.tr.xlf) for all entries with state="new". Translated the content of each element for untranslated entries, ensuring accurate and context-appropriate Turkish localization. Changed the state attribute from "new" to "translated" for all newly translated entries. Also made correction to the word resources