### PR TITLE
Feature/improve language localization for FR 20250611

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the language localization for French (`fr`)
-  
+
 ## 2.170.0 - 2025-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Improved the language localization for French (`fr`)
+  
 ## 2.170.0 - 2025-06-11
 
 ### Added

--- a/apps/client/src/locales/messages.fr.xlf
+++ b/apps/client/src/locales/messages.fr.xlf
@@ -7646,7 +7646,7 @@
       </trans-unit>
       <trans-unit id="7784226024223865620" datatype="html">
         <source>Find holding or page...</source>
-        <target state="translated">Rechercher une collection ou une page...</target>
+        <target state="translated">Rechercher une position ou une page...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/assistant/assistant.component.ts</context>
           <context context-type="linenumber">152</context>


### PR DESCRIPTION
This pull request includes a minor update to the French locale file to improve the translation of a UI string. 

* [`apps/client/src/locales/messages.fr.xlf`](diffhunk://#diff-14ce698ea2c29412533b7b954a4729d31a3f769e1110c294098c9db9b8ba56ffL7649-R7649): Updated the translation of "Find holding or page..." from "Rechercher une collection ou une page..." to "Rechercher une position ou une page..." for better accuracy.

I would like to ensure consistency in the translation of holding, which was introduced in #4894. In investment terminology, position is a more precise term than collection, aligning better with the existing translations.

Existing translations in the file: 
![image](https://github.com/user-attachments/assets/383fe3ca-60bb-4a03-85ba-3504a82259f0)
![image](https://github.com/user-attachments/assets/68c30b3f-a173-4415-b7d5-e126ab379c48)
![image](https://github.com/user-attachments/assets/e78f87d5-6d5f-4f8a-b8b7-24f1e1c0d213)
![image](https://github.com/user-attachments/assets/0792fd9a-28cf-4615-96b1-eb19a9885841)

#3589 


