### PR TITLE
Fix Incorrect Percentages in Impersonation View

### DIFF
--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.html
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.html
@@ -351,7 +351,7 @@
           [benchmarkDataLabel]="portfolioEvolutionDataLabel"
           [currency]="user?.settings?.baseCurrency"
           [historicalDataItems]="performanceDataItems"
-          [isInPercent]="user.settings.isRestrictedView || (hasImpersonationId && hasRestrictedAccess)"
+          [isInPercent]="user.settings.isRestrictedView || hasImpersonationId"
           [isLoading]="isLoadingInvestmentChart"
           [locale]="user?.settings?.locale"
         />
@@ -407,7 +407,7 @@
           [benchmarkDataLabel]="investmentTimelineDataLabel"
           [currency]="user?.settings?.baseCurrency"
           [groupBy]="mode"
-          [isInPercent]="user.settings.isRestrictedView || (hasImpersonationId && hasRestrictedAccess)"
+          [isInPercent]="user.settings.isRestrictedView || hasImpersonationId"
           [isLoading]="isLoadingInvestmentTimelineChart"
           [locale]="user?.settings?.locale"
           [savingsRate]="savingsRate"
@@ -442,7 +442,7 @@
           [benchmarkDataLabel]="dividendTimelineDataLabel"
           [currency]="user?.settings?.baseCurrency"
           [groupBy]="mode"
-          [isInPercent]="user.settings.isRestrictedView || (hasImpersonationId && hasRestrictedAccess)"
+          [isInPercent]="user.settings.isRestrictedView || hasImpersonationId"
           [isLoading]="isLoadingDividendTimelineChart"
           [locale]="user?.settings?.locale"
         />


### PR DESCRIPTION
Fixes [#4605](https://github.com/ghostfolio/ghostfolio/issues/4605)

What I have done:

- Removed `hasImpersonationId` from the `isInPercent` binding for `gf-investment-chart` components in `apps/client/src/app/pages/portfolio/analysis/analysis-page.html`.
- The `isInPercent` property now solely uses `user.settings.isRestrictedView`.

What it does:

- When impersonating a user with full access, actual values are displayed.
- Percentages are only shown when the viewed account is specifically set to `isRestrictedView`.
- The chart display aligns with the intended access permissions during impersonation.