### PR TITLE
Fix Docker HOST:PORT setup by introducing exposed host and port setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ We provide official container images hosted on [Docker Hub](https://hub.docker.c
 ### Supported Environment Variables
 
 | Name                     | Type                  | Default Value | Description                                                                                                                         |
-| ------------------------ | --------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------| --------------------- |---------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `ACCESS_TOKEN_SALT`      | `string`              |               | A random string used as salt for access tokens                                                                                      |
 | `API_KEY_COINGECKO_DEMO` | `string` (optional)   |               | The _CoinGecko_ Demo API key                                                                                                        |
 | `API_KEY_COINGECKO_PRO`  | `string` (optional)   |               | The _CoinGecko_ Pro API key                                                                                                         |
 | `DATABASE_URL`           | `string`              |               | The database connection URL, e.g. `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?sslmode=prefer` |
+| `EXPOSE_HOST`            | `string` (optional)   | `0.0.0.0`     | The host where the Ghostfolio application will be exposed by Docker                                                                 |
+| `EXPOSE_PORT`            | `string` (optional)   | `3333`        | The port where the Ghostfolio application will be exposed by Docker                                                                 |
 | `HOST`                   | `string` (optional)   | `0.0.0.0`     | The host where the Ghostfolio application will run on                                                                               |
 | `JWT_SECRET_KEY`         | `string`              |               | A random string used for _JSON Web Tokens_ (JWT)                                                                                    |
 | `LOG_LEVELS`             | `string[]` (optional) |               | The logging levels for the Ghostfolio application, e.g. `["debug","error","log","warn"]`                                            |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,14 +12,14 @@ services:
     env_file:
       - ../.env
     ports:
-      - 3333:3333
+      - ${EXPOSE_HOST:-0.0.0.0}:${EXPOSE_PORT:-3333}:${PORT:-3333}
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'curl -f http://localhost:3333/api/v1/health']
+      test: ['CMD-SHELL', 'curl -f http://localhost:$${PORT:-3333}/api/v1/health']
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The current setup does not allow to specify HOST and PORT for the exposed service when using `docker compose`. As these variables are also interpreted by the ghostfolio application, new variables EXPOSED_HOST and EXPOSED_PORT are introduced to control where the service is actually exposed on the Docker host.

### Enhancements to environment variables:
* Added `EXPOSE_HOST` and `EXPOSE_PORT` environment variables to the supported list in `README.md` for configuring the host and port where the application is exposed by Docker. (`README.md`, [README.mdL89-R95](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R95))

### Updates to `docker-compose.yml`:
* Updated the `ports` configuration to use `EXPOSE_HOST` and `EXPOSE_PORT` variable for dynamic host and port assignment. (`docker/docker-compose.yml`, [docker/docker-compose.ymlL15-R22](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L15-R22))
* Modified the health check command to dynamically reference the `PORT` variable, ensuring compatibility with custom port configurations. (`docker/docker-compose.yml`, [docker/docker-compose.ymlL15-R22](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L15-R22))