### PR TITLE
Fix Docker call to include .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ We provide official container images hosted on [Docker Hub](https://hub.docker.c
 Run the following command to start the Docker images from [Docker Hub](https://hub.docker.com/r/ghostfolio/ghostfolio):
 
 ```bash
-docker compose -f docker/docker-compose.yml up -d
+docker compose -f docker/docker-compose.yml --env-file .env up -d
 ```
 
 #### b. Build and run environment
@@ -126,8 +126,8 @@ docker compose -f docker/docker-compose.yml up -d
 Run the following commands to build and start the Docker images:
 
 ```bash
-docker compose -f docker/docker-compose.build.yml build
-docker compose -f docker/docker-compose.build.yml up -d
+docker compose -f docker/docker-compose.build.yml --env-file .env build
+docker compose -f docker/docker-compose.build.yml --env-file .env up -d
 ```
 
 #### Setup


### PR DESCRIPTION
Docker compose only includes `.env` if it is located in the same directory as the `docker-compose.yml`, otherwise it needs to be explicitly stated.

Fix the example in README to reflect that behavior.
