### PR TITLE
Feature/change entrypoint.sh to run app with main PID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `node main` to `exec node main` in the `entrypoint.sh` file to improve the container signal handling
 - Improved the language localization for Catalan (`ca`)
 - Improved the language localization for Español (`es`)
 - Improved the language localization for Turkish (`tr`)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,4 +9,4 @@ echo "Seeding the database"
 npx prisma db seed
 
 echo "Starting the server"
-node main
+exec node main


### PR DESCRIPTION
Using exec to call `node main` ensures that SIGTERM and SIGINT are propagated to the app when the container is requested to shut down.