### PR TITLE
Feature/reflect global settings in data gathering checkbox of asset profile dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `Account` to `account` in the `Order` database schema
 - Improved the language localization for German (`de`)
 - Upgraded `prettier` from version `3.5.3` to `3.6.2`
+- Improved the _Asset Profile_ dialog to synchronize the state of the _Data Gathering_ checkbox with global settings
 
 ## 2.175.0 - 2025-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Improved the asset profile dialog’s data gathering checkbox of the admin control panel to reflect the global settings
+
 ## 2.180.0 - 2025-07-08
 
 ### Added
@@ -98,7 +104,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `Account` to `account` in the `Order` database schema
 - Improved the language localization for German (`de`)
 - Upgraded `prettier` from version `3.5.3` to `3.6.2`
-- Improved the _Asset Profile_ dialog to synchronize the state of the _Data Gathering_ checkbox with global settings
 
 ## 2.175.0 - 2025-06-28
 

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
@@ -5,7 +5,10 @@ import { AdminService } from '@ghostfolio/client/services/admin.service';
 import { DataService } from '@ghostfolio/client/services/data.service';
 import { UserService } from '@ghostfolio/client/services/user/user.service';
 import { validateObjectForForm } from '@ghostfolio/client/util/form.util';
-import { ghostfolioScraperApiSymbolPrefix } from '@ghostfolio/common/config';
+import {
+  ghostfolioScraperApiSymbolPrefix,
+  PROPERTY_IS_DATA_GATHERING_ENABLED
+} from '@ghostfolio/common/config';
 import { DATE_FORMAT } from '@ghostfolio/common/helper';
 import {
   AdminMarketDataDetails,
@@ -133,6 +136,7 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
   public ghostfolioScraperApiSymbolPrefix = ghostfolioScraperApiSymbolPrefix;
   public historicalDataItems: LineChartItem[];
   public isBenchmark = false;
+  public isDataGatheringEnabled: boolean;
   public isEditAssetProfileIdentifierMode = false;
   public marketDataItems: MarketData[] = [];
 
@@ -282,6 +286,16 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
         });
 
         this.assetProfileForm.markAsPristine();
+
+        this.changeDetectorRef.markForCheck();
+      });
+
+    this.adminService
+      .fetchAdminData()
+      .pipe(takeUntil(this.unsubscribeSubject))
+      .subscribe(({ settings }) => {
+        this.isDataGatheringEnabled =
+          settings[PROPERTY_IS_DATA_GATHERING_ENABLED] === false ? false : true;
 
         this.changeDetectorRef.markForCheck();
       });

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
@@ -200,6 +200,16 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
   public initialize() {
     this.historicalDataItems = undefined;
 
+    this.adminService
+      .fetchAdminData()
+      .pipe(takeUntil(this.unsubscribeSubject))
+      .subscribe(({ settings }) => {
+        this.isDataGatheringEnabled =
+          settings[PROPERTY_IS_DATA_GATHERING_ENABLED] === false ? false : true;
+
+        this.changeDetectorRef.markForCheck();
+      });
+
     this.userService.stateChanged
       .pipe(takeUntil(this.unsubscribeSubject))
       .subscribe((state) => {
@@ -286,16 +296,6 @@ export class AssetProfileDialog implements OnDestroy, OnInit {
         });
 
         this.assetProfileForm.markAsPristine();
-
-        this.changeDetectorRef.markForCheck();
-      });
-
-    this.adminService
-      .fetchAdminData()
-      .pipe(takeUntil(this.unsubscribeSubject))
-      .subscribe(({ settings }) => {
-        this.isDataGatheringEnabled =
-          settings[PROPERTY_IS_DATA_GATHERING_ENABLED] === false ? false : true;
 
         this.changeDetectorRef.markForCheck();
       });

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -534,8 +534,8 @@
     <div class="gf-spacer">
       <mat-checkbox
         color="primary"
-        [checked]="assetProfile?.isActive ?? false"
-        [disabled]="isEditAssetProfileIdentifierMode"
+        [checked]="isDataGatheringEnabled && (assetProfile?.isActive ?? false)"
+        [disabled]="!isDataGatheringEnabled || isEditAssetProfileIdentifierMode"
         (change)="onToggleIsActive($event)"
       >
         <ng-container i18n>Data Gathering</ng-container>


### PR DESCRIPTION
Data gathering checkbox asset profile dialog is in sync with global settings.

Fixes: https://github.com/ghostfolio/ghostfolio/issues/5045