### PR TITLE
Feature/Set up language localization for Regional Market Cluster Risks

### DIFF
--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1268,26 +1268,36 @@ export class PortfolioService {
               [
                 new RegionalMarketClusterRiskAsiaPacific(
                   this.exchangeRateDataService,
+                  this.i18nService,
+                  userSettings.language,
                   marketsAdvancedTotalInBaseCurrency,
                   marketsAdvanced.asiaPacific.valueInBaseCurrency
                 ),
                 new RegionalMarketClusterRiskEmergingMarkets(
                   this.exchangeRateDataService,
+                  this.i18nService,
+                  userSettings.language,
                   marketsAdvancedTotalInBaseCurrency,
                   marketsAdvanced.emergingMarkets.valueInBaseCurrency
                 ),
                 new RegionalMarketClusterRiskEurope(
                   this.exchangeRateDataService,
+                  this.i18nService,
+                  userSettings.language,
                   marketsAdvancedTotalInBaseCurrency,
                   marketsAdvanced.europe.valueInBaseCurrency
                 ),
                 new RegionalMarketClusterRiskJapan(
                   this.exchangeRateDataService,
+                  this.i18nService,
+                  userSettings.language,
                   marketsAdvancedTotalInBaseCurrency,
                   marketsAdvanced.japan.valueInBaseCurrency
                 ),
                 new RegionalMarketClusterRiskNorthAmerica(
                   this.exchangeRateDataService,
+                  this.i18nService,
+                  userSettings.language,
                   marketsAdvancedTotalInBaseCurrency,
                   marketsAdvanced.northAmerica.valueInBaseCurrency
                 )

--- a/apps/api/src/app/user/user.service.ts
+++ b/apps/api/src/app/user/user.service.ts
@@ -327,10 +327,14 @@ export class UserService {
         new RegionalMarketClusterRiskAsiaPacific(
           undefined,
           undefined,
+          undefined,
+          undefined,
           undefined
         ).getSettings(user.settings.settings),
       RegionalMarketClusterRiskEmergingMarkets:
         new RegionalMarketClusterRiskEmergingMarkets(
+          undefined,
+          undefined,
           undefined,
           undefined,
           undefined
@@ -338,15 +342,21 @@ export class UserService {
       RegionalMarketClusterRiskEurope: new RegionalMarketClusterRiskEurope(
         undefined,
         undefined,
+        undefined,
+        undefined,
         undefined
       ).getSettings(user.settings.settings),
       RegionalMarketClusterRiskJapan: new RegionalMarketClusterRiskJapan(
+        undefined,
+        undefined,
         undefined,
         undefined,
         undefined
       ).getSettings(user.settings.settings),
       RegionalMarketClusterRiskNorthAmerica:
         new RegionalMarketClusterRiskNorthAmerica(
+          undefined,
+          undefined,
           undefined,
           undefined,
           undefined

--- a/apps/api/src/models/rules/regional-market-cluster-risk/asia-pacific.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/asia-pacific.ts
@@ -1,5 +1,6 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -10,10 +11,13 @@ export class RegionalMarketClusterRiskAsiaPacific extends Rule<Settings> {
 
   public constructor(
     protected exchangeRateDataService: ExchangeRateDataService,
+    private i18nService: I18nService,
+    languageCode: string,
     currentValueInBaseCurrency: number,
     asiaPacificValueInBaseCurrency: number
   ) {
     super(exchangeRateDataService, {
+      languageCode,
       key: RegionalMarketClusterRiskAsiaPacific.name
     });
 
@@ -28,26 +32,40 @@ export class RegionalMarketClusterRiskAsiaPacific extends Rule<Settings> {
 
     if (asiaPacificMarketValueRatio > ruleSettings.thresholdMax) {
       return {
-        evaluation: `The Asia-Pacific market contribution of your current investment (${(asiaPacificMarketValueRatio * 100).toPrecision(3)}%) exceeds ${(
-          ruleSettings.thresholdMax * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskAsiaPacific.false.max',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (asiaPacificMarketValueRatio * 100).toPrecision(3),
+            thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     } else if (asiaPacificMarketValueRatio < ruleSettings.thresholdMin) {
       return {
-        evaluation: `The Asia-Pacific market contribution of your current investment (${(asiaPacificMarketValueRatio * 100).toPrecision(3)}%) is below ${(
-          ruleSettings.thresholdMin * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskAsiaPacific.false.min',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (asiaPacificMarketValueRatio * 100).toPrecision(3),
+            thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     }
 
     return {
-      evaluation: `The Asia-Pacific market contribution of your current investment (${(asiaPacificMarketValueRatio * 100).toPrecision(3)}%) is within the range of ${(
-        ruleSettings.thresholdMin * 100
-      ).toPrecision(
-        3
-      )}% and ${(ruleSettings.thresholdMax * 100).toPrecision(3)}%`,
+      evaluation: this.i18nService.getTranslation({
+        id: 'rule.regionClusterRiskAsiaPacific.true',
+        languageCode: this.getLanguageCode(),
+        placeholders: {
+          valueRatio: (asiaPacificMarketValueRatio * 100).toPrecision(3),
+          thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3),
+          thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+        }
+      }),
       value: true
     };
   }
@@ -66,6 +84,10 @@ export class RegionalMarketClusterRiskAsiaPacific extends Rule<Settings> {
   }
 
   public getName() {
+    return this.i18nService.getTranslation({
+      id: 'rule.regionClusterRiskAsiaPacific',
+      languageCode: this.getLanguageCode()
+    });
     return 'Asia-Pacific';
   }
 

--- a/apps/api/src/models/rules/regional-market-cluster-risk/emerging-markets.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/emerging-markets.ts
@@ -1,5 +1,6 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -10,10 +11,13 @@ export class RegionalMarketClusterRiskEmergingMarkets extends Rule<Settings> {
 
   public constructor(
     protected exchangeRateDataService: ExchangeRateDataService,
+    private i18nService: I18nService,
+    languageCode: string,
     currentValueInBaseCurrency: number,
     emergingMarketsValueInBaseCurrency: number
   ) {
     super(exchangeRateDataService, {
+      languageCode,
       key: RegionalMarketClusterRiskEmergingMarkets.name
     });
 
@@ -30,26 +34,40 @@ export class RegionalMarketClusterRiskEmergingMarkets extends Rule<Settings> {
 
     if (emergingMarketsValueRatio > ruleSettings.thresholdMax) {
       return {
-        evaluation: `The Emerging Markets contribution of your current investment (${(emergingMarketsValueRatio * 100).toPrecision(3)}%) exceeds ${(
-          ruleSettings.thresholdMax * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskEmergingMarkets.false.max',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (emergingMarketsValueRatio * 100).toPrecision(3),
+            thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     } else if (emergingMarketsValueRatio < ruleSettings.thresholdMin) {
       return {
-        evaluation: `The Emerging Markets contribution of your current investment (${(emergingMarketsValueRatio * 100).toPrecision(3)}%) is below ${(
-          ruleSettings.thresholdMin * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskEmergingMarkets.false.min',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (emergingMarketsValueRatio * 100).toPrecision(3),
+            thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     }
 
     return {
-      evaluation: `The Emerging Markets contribution of your current investment (${(emergingMarketsValueRatio * 100).toPrecision(3)}%) is within the range of ${(
-        ruleSettings.thresholdMin * 100
-      ).toPrecision(
-        3
-      )}% and ${(ruleSettings.thresholdMax * 100).toPrecision(3)}%`,
+      evaluation: this.i18nService.getTranslation({
+        id: 'rule.regionClusterRiskEmergingMarkets.true',
+        languageCode: this.getLanguageCode(),
+        placeholders: {
+          valueRatio: (emergingMarketsValueRatio * 100).toPrecision(3),
+          thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3),
+          thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+        }
+      }),
       value: true
     };
   }
@@ -68,6 +86,10 @@ export class RegionalMarketClusterRiskEmergingMarkets extends Rule<Settings> {
   }
 
   public getName() {
+    return this.i18nService.getTranslation({
+      id: 'rule.regionClusterRiskEmergingMarkets',
+      languageCode: this.getLanguageCode()
+    });
     return 'Emerging Markets';
   }
 

--- a/apps/api/src/models/rules/regional-market-cluster-risk/europe.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/europe.ts
@@ -1,5 +1,6 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -10,10 +11,13 @@ export class RegionalMarketClusterRiskEurope extends Rule<Settings> {
 
   public constructor(
     protected exchangeRateDataService: ExchangeRateDataService,
+    private i18nService: I18nService,
+    languageCode: string,
     currentValueInBaseCurrency: number,
     europeValueInBaseCurrency: number
   ) {
     super(exchangeRateDataService, {
+      languageCode,
       key: RegionalMarketClusterRiskEurope.name
     });
 
@@ -28,26 +32,40 @@ export class RegionalMarketClusterRiskEurope extends Rule<Settings> {
 
     if (europeMarketValueRatio > ruleSettings.thresholdMax) {
       return {
-        evaluation: `The Europe market contribution of your current investment (${(europeMarketValueRatio * 100).toPrecision(3)}%) exceeds ${(
-          ruleSettings.thresholdMax * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskEurope.false.max',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (europeMarketValueRatio * 100).toPrecision(3),
+            thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     } else if (europeMarketValueRatio < ruleSettings.thresholdMin) {
       return {
-        evaluation: `The Europe market contribution of your current investment (${(europeMarketValueRatio * 100).toPrecision(3)}%) is below ${(
-          ruleSettings.thresholdMin * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskEurope.false.min',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (europeMarketValueRatio * 100).toPrecision(3),
+            thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     }
 
     return {
-      evaluation: `The Europe market contribution of your current investment (${(europeMarketValueRatio * 100).toPrecision(3)}%) is within the range of ${(
-        ruleSettings.thresholdMin * 100
-      ).toPrecision(
-        3
-      )}% and ${(ruleSettings.thresholdMax * 100).toPrecision(3)}%`,
+      evaluation: this.i18nService.getTranslation({
+        id: 'rule.regionClusterRiskEurope.true',
+        languageCode: this.getLanguageCode(),
+        placeholders: {
+          valueRatio: (europeMarketValueRatio * 100).toPrecision(3),
+          thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3),
+          thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+        }
+      }),
       value: true
     };
   }
@@ -66,6 +84,10 @@ export class RegionalMarketClusterRiskEurope extends Rule<Settings> {
   }
 
   public getName() {
+    return this.i18nService.getTranslation({
+      id: 'rule.regionClusterRiskEurope',
+      languageCode: this.getLanguageCode()
+    });
     return 'Europe';
   }
 

--- a/apps/api/src/models/rules/regional-market-cluster-risk/japan.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/japan.ts
@@ -1,5 +1,6 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -10,10 +11,13 @@ export class RegionalMarketClusterRiskJapan extends Rule<Settings> {
 
   public constructor(
     protected exchangeRateDataService: ExchangeRateDataService,
+    private i18nService: I18nService,
+    languageCode: string,
     currentValueInBaseCurrency: number,
     japanValueInBaseCurrency: number
   ) {
     super(exchangeRateDataService, {
+      languageCode,
       key: RegionalMarketClusterRiskJapan.name
     });
 
@@ -28,26 +32,40 @@ export class RegionalMarketClusterRiskJapan extends Rule<Settings> {
 
     if (japanMarketValueRatio > ruleSettings.thresholdMax) {
       return {
-        evaluation: `The Japan market contribution of your current investment (${(japanMarketValueRatio * 100).toPrecision(3)}%) exceeds ${(
-          ruleSettings.thresholdMax * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskJapan.false.max',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (japanMarketValueRatio * 100).toPrecision(3),
+            thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     } else if (japanMarketValueRatio < ruleSettings.thresholdMin) {
       return {
-        evaluation: `The Japan market contribution of your current investment (${(japanMarketValueRatio * 100).toPrecision(3)}%) is below ${(
-          ruleSettings.thresholdMin * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskJapan.false.min',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (japanMarketValueRatio * 100).toPrecision(3),
+            thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     }
 
     return {
-      evaluation: `The Japan market contribution of your current investment (${(japanMarketValueRatio * 100).toPrecision(3)}%) is within the range of ${(
-        ruleSettings.thresholdMin * 100
-      ).toPrecision(
-        3
-      )}% and ${(ruleSettings.thresholdMax * 100).toPrecision(3)}%`,
+      evaluation: this.i18nService.getTranslation({
+        id: 'rule.regionClusterRiskJapan.true',
+        languageCode: this.getLanguageCode(),
+        placeholders: {
+          valueRatio: (japanMarketValueRatio * 100).toPrecision(3),
+          thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3),
+          thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+        }
+      }),
       value: true
     };
   }
@@ -66,6 +84,10 @@ export class RegionalMarketClusterRiskJapan extends Rule<Settings> {
   }
 
   public getName() {
+    return this.i18nService.getTranslation({
+      id: 'rule.regionClusterRiskJapan',
+      languageCode: this.getLanguageCode()
+    });
     return 'Japan';
   }
 

--- a/apps/api/src/models/rules/regional-market-cluster-risk/north-america.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/north-america.ts
@@ -1,5 +1,6 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -10,10 +11,13 @@ export class RegionalMarketClusterRiskNorthAmerica extends Rule<Settings> {
 
   public constructor(
     protected exchangeRateDataService: ExchangeRateDataService,
+    private i18nService: I18nService,
+    languageCode: string,
     currentValueInBaseCurrency: number,
     northAmericaValueInBaseCurrency: number
   ) {
     super(exchangeRateDataService, {
+      languageCode,
       key: RegionalMarketClusterRiskNorthAmerica.name
     });
 
@@ -28,26 +32,40 @@ export class RegionalMarketClusterRiskNorthAmerica extends Rule<Settings> {
 
     if (northAmericaMarketValueRatio > ruleSettings.thresholdMax) {
       return {
-        evaluation: `The North America market contribution of your current investment (${(northAmericaMarketValueRatio * 100).toPrecision(3)}%) exceeds ${(
-          ruleSettings.thresholdMax * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskNorthAmerica.false.max',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (northAmericaMarketValueRatio * 100).toPrecision(3),
+            thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     } else if (northAmericaMarketValueRatio < ruleSettings.thresholdMin) {
       return {
-        evaluation: `The North America market contribution of your current investment (${(northAmericaMarketValueRatio * 100).toPrecision(3)}%) is below ${(
-          ruleSettings.thresholdMin * 100
-        ).toPrecision(3)}%`,
+        evaluation: this.i18nService.getTranslation({
+          id: 'rule.regionClusterRiskNorthAmerica.false.min',
+          languageCode: this.getLanguageCode(),
+          placeholders: {
+            valueRatio: (northAmericaMarketValueRatio * 100).toPrecision(3),
+            thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3)
+          }
+        }),
         value: false
       };
     }
 
     return {
-      evaluation: `The North America market contribution of your current investment (${(northAmericaMarketValueRatio * 100).toPrecision(3)}%) is within the range of ${(
-        ruleSettings.thresholdMin * 100
-      ).toPrecision(
-        3
-      )}% and ${(ruleSettings.thresholdMax * 100).toPrecision(3)}%`,
+      evaluation: this.i18nService.getTranslation({
+        id: 'rule.regionClusterRiskNorthAmerica.true',
+        languageCode: this.getLanguageCode(),
+        placeholders: {
+          valueRatio: (northAmericaMarketValueRatio * 100).toPrecision(3),
+          thresholdMin: (ruleSettings.thresholdMin * 100).toPrecision(3),
+          thresholdMax: (ruleSettings.thresholdMax * 100).toPrecision(3)
+        }
+      }),
       value: true
     };
   }
@@ -66,6 +84,10 @@ export class RegionalMarketClusterRiskNorthAmerica extends Rule<Settings> {
   }
 
   public getName() {
+    return this.i18nService.getTranslation({
+      id: 'rule.regionClusterRiskNorthAmerica',
+      languageCode: this.getLanguageCode()
+    });
     return 'North America';
   }
 

--- a/apps/client/src/app/pages/i18n/i18n-page.html
+++ b/apps/client/src/app/pages/i18n/i18n-page.html
@@ -11,6 +11,82 @@
         performance, portfolio, software, stock, trading, wealth, web3
       </li>
       <li i18n="@@myAccount">My Account</li>
+
+      <!-- Regional Market Cluster Risk Rules -->
+      <li i18n="@@rule.regionClusterRiskAsiaPacific">Asia-Pacific</li>
+      <li i18n="@@rule.regionClusterRiskAsiaPacific.false.max">
+        The Asia-Pacific market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is exceeds $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskAsiaPacific.false.min">
+        The Asia-Pacific market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is below $&#123;thresholdMin&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskAsiaPacific.true">
+        The Asia-Pacific market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is within the range of
+        $&#123;thresholdMin&#125;% and $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskEmergingMarkets">Emerging Markets</li>
+      <li i18n="@@rule.regionClusterRiskEmergingMarkets.false.max">
+        The Emerging Markets contribution of your current investment
+        ($&#123;valueRatio&#125;%) exceeds $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskEmergingMarkets.false.min">
+        The Emerging Markets contribution of your current investment
+        ($&#123;valueRatio&#125;%) is below $&#123;thresholdMin&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskEmergingMarkets.true">
+        The Emerging Markets contribution of your current investment
+        ($&#123;valueRatio&#125;%) is within the range of
+        $&#123;thresholdMin&#125;% and $&#123;thresholdMax&#125;%
+      </li>
+
+      <li i18n="@@rule.regionClusterRiskEurope">Europe</li>
+      <li i18n="@@rule.regionClusterRiskEurope.false.max">
+        The Europe market contribution of your current investment
+        ($&#123;valueRatio&#125;%) exceeds $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskEurope.false.min">
+        The Europe market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is below $&#123;thresholdMin&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskEurope.true">
+        The Europe market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is within the range of
+        $&#123;thresholdMin&#125;% and $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskJapan">Japan</li>
+      <li i18n="@@rule.regionClusterRiskJapan.false.max">
+        The Japan market contribution of your current investment
+        ($&#123;valueRatio&#125;%) exceeds $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskJapan.false.min">
+        The Japan market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is below $&#123;thresholdMin&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskJapan.true">
+        The Japan market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is within the range of
+        $&#123;thresholdMin&#125;% and $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskNorthAmerica">North America</li>
+      <li i18n="@@rule.regionClusterRiskNorthAmerica.false.max">
+        The North America market contribution of your current investment
+        ($&#123;valueRatio&#125;%) exceeds $&#123;thresholdMax&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskNorthAmerica.false.min">
+        The North America market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is below $&#123;thresholdMin&#125;%
+      </li>
+      <li i18n="@@rule.regionClusterRiskNorthAmerica.true">
+        The North America market contribution of your current investment
+        ($&#123;valueRatio&#125;%) is within the range of
+        $&#123;thresholdMin&#125;% and $&#123;thresholdMax&#125;%
+      </li>
+
+      <!-- Regional Market Cluster Risk Rules End -->
+
       <li i18n="@@rule.accountClusterRiskCurrentInvestment">Investment</li>
       <li i18n="@@rule.accountClusterRiskCurrentInvestment.false">
         Over $&#123;thresholdMax&#125;% of your current investment is at


### PR DESCRIPTION
- Added i18n support setup for static X-ray rule: Regional Market Cluster Risks
- Followed the approach in #4959 as guidance

Note:
I haven’t made changes to the `.xlf` files yet. I understand they can be generated using `i18n-page.html`, but when I tried, the generated files didn’t include the expected translation entries for this rule.

Should I manually update all `.xlf` files to add the translations?