### PR TITLE
Feature/improve redactAttributes in object helper with redactyle.js

### DIFF
--- a/apps/api/src/helper/redactyle.helper.ts
+++ b/apps/api/src/helper/redactyle.helper.ts
@@ -1,0 +1,8 @@
+import Redactyl = require('redactyl.js');
+export class RedactylNullSupported extends Redactyl {
+  text: string | null = null;
+  setText(text) {
+    this.text = text;
+    return this;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "passport-google-oauth20": "2.0.0",
         "passport-headerapikey": "1.2.2",
         "passport-jwt": "4.0.1",
+        "redactyl.js": "^1.6.0",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.1",
         "stripe": "18.2.1",
@@ -30035,6 +30036,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/redactyl.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redactyl.js/-/redactyl.js-1.6.0.tgz",
+      "integrity": "sha512-K5HZ+fVPfR7PWABroIUb+of2HVDM/VNcHYCTB1ZTqXVpCAwpj++c0eSHg0oJcDIBaNAe59DeKHzJ6rC7p91B5g=="
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "passport-google-oauth20": "2.0.0",
     "passport-headerapikey": "1.2.2",
     "passport-jwt": "4.0.1",
+    "redactyl.js": "^1.6.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.1",
     "stripe": "18.2.1",


### PR DESCRIPTION
Implemented [redactyle.js](https://www.npmjs.com/package/redactyl.js) into object helper's `redactAttributes()`.

**PS:** Redactyle.js does not support null as redacted value so we needed to extend Redactyle class and override the `setText()` method.

