### PR TITLE
Bugfix/fix Storybook styles after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Excluded the holdings originated of `FEE`, `INTEREST` and `LIABILITY` activities from the closed holdings on the portfolio holdings page
+- Fixed an issue with serving _Storybook_ related to missing styles
 
 ## 2.185.0 - 2025-07-26
 

--- a/libs/ui/.storybook/preview-head.html
+++ b/libs/ui/.storybook/preview-head.html
@@ -1,8 +1,0 @@
-<script
-  src="https://unpkg.com/ionicons@5.5.1/dist/ionicons/ionicons.esm.js"
-  type="module"
-></script>
-<script
-  nomodule
-  src="https://unpkg.com/ionicons@5.5.1/dist/ionicons/ionicons.js"
-></script>

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -26,10 +26,10 @@
     "storybook": {
       "executor": "@storybook/angular:start-storybook",
       "options": {
-        "port": 4400,
-        "configDir": "libs/ui/.storybook",
         "browserTarget": "ui:build-storybook",
         "compodoc": false,
+        "configDir": "libs/ui/.storybook",
+        "port": 4400,
         "styles": [
           "apps/client/src/assets/fonts/inter.css",
           "apps/client/src/styles/theme.scss",
@@ -46,10 +46,10 @@
       "executor": "@storybook/angular:build-storybook",
       "outputs": ["{options.outputDir}"],
       "options": {
-        "outputDir": "dist/apps/client/development/storybook",
-        "configDir": "libs/ui/.storybook",
         "browserTarget": "ui:build-storybook",
         "compodoc": false,
+        "configDir": "libs/ui/.storybook",
+        "outputDir": "dist/apps/client/development/storybook",
         "styles": [
           "apps/client/src/assets/fonts/inter.css",
           "apps/client/src/styles/theme.scss",

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -29,7 +29,12 @@
         "port": 4400,
         "configDir": "libs/ui/.storybook",
         "browserTarget": "ui:build-storybook",
-        "compodoc": false
+        "compodoc": false,
+        "styles": [
+          "apps/client/src/assets/fonts/inter.css",
+          "apps/client/src/styles/theme.scss",
+          "apps/client/src/styles.scss"
+        ]
       },
       "configurations": {
         "ci": {


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #5246. Please take a look :)

### Changes
* Added styles option to `ui:storybook` target.
* Removed `ionicons` loading scripts, since `ionicons` are now directly imported to the components.