### PR TITLE
Feature/restore active state (background color) of sidebar navigation

### DIFF
--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -264,10 +264,6 @@ body {
 
     .page {
       &.has-tabs {
-        .mat-mdc-tab-nav-bar {
-          --mat-tab-inactive-label-text-color: rgba(var(--light-primary-text));
-        }
-
         @media (min-width: 576px) {
           .mat-mdc-tab-header {
             background-color: rgba(var(--palette-foreground-base-dark), 0.02);
@@ -522,21 +518,8 @@ ngx-skeleton-loader {
       }
     }
 
-    .mat-mdc-tab-nav-bar {
-      --mat-tab-active-focus-indicator-color: transparent;
-      --mat-tab-active-hover-indicator-color: transparent;
-      --mat-tab-inactive-label-text-color: rgba(var(--dark-primary-text));
-      --mat-tab-active-indicator-color: transparent;
-    }
-
     .mat-mdc-tab-nav-panel {
       padding: 2rem 0;
-    }
-
-    @media (max-width: 575.98px) {
-      .mat-mdc-tab-link {
-        --mat-tab-container-height: 3rem;
-      }
     }
 
     @media (min-width: 576px) {
@@ -546,8 +529,6 @@ ngx-skeleton-loader {
         background-color: rgba(var(--palette-foreground-base), 0.02);
         padding: 2rem 0;
         width: 14rem;
-        --mat-tab-label-text-tracking: normal;
-        --mat-tab-container-height: 2rem;
 
         .mat-mdc-tab-links {
           flex-direction: column;

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -175,6 +175,15 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       row-item-outline-color: rgba(var(--dark-dividers))
     )
   );
+  @include mat.tabs-overrides(
+    (
+      active-focus-label-text-color: var(--gf-theme-primary-500),
+      active-hover-label-text-color: var(--gf-theme-primary-500),
+      active-label-text-color: var(--gf-theme-primary-500),
+      active-ripple-color: var(--gf-theme-primary-500),
+      inactive-ripple-color: var(--gf-theme-primary-500)
+    )
+  );
 
   --mdc-outlined-card-container-color: unset;
 }
@@ -211,6 +220,15 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
   @include mat.table-overrides(
     (
       row-item-outline-color: rgba(var(--light-dividers))
+    )
+  );
+  @include mat.tabs-overrides(
+    (
+      active-focus-label-text-color: var(--gf-theme-primary-500),
+      active-hover-label-text-color: var(--gf-theme-primary-500),
+      active-label-text-color: var(--gf-theme-primary-500),
+      active-ripple-color: var(--gf-theme-primary-500),
+      inactive-ripple-color: var(--gf-theme-primary-500)
     )
   );
 

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -175,15 +175,6 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       row-item-outline-color: rgba(var(--dark-dividers))
     )
   );
-  @include mat.tabs-overrides(
-    (
-      active-focus-label-text-color: var(--gf-theme-primary-500),
-      active-hover-label-text-color: var(--gf-theme-primary-500),
-      active-label-text-color: var(--gf-theme-primary-500),
-      active-ripple-color: var(--gf-theme-primary-500),
-      inactive-ripple-color: var(--gf-theme-primary-500)
-    )
-  );
 
   --mdc-outlined-card-container-color: unset;
 }
@@ -222,17 +213,31 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       row-item-outline-color: rgba(var(--light-dividers))
     )
   );
+
+  --mdc-outlined-card-container-color: unset;
+}
+
+.theme-dark,
+.theme-light {
+  @media (max-width: 575.98px) {
+    @include mat.tabs-overrides(
+      (
+        container-height: 3rem
+      )
+    );
+  }
   @include mat.tabs-overrides(
     (
       active-focus-label-text-color: var(--gf-theme-primary-500),
       active-hover-label-text-color: var(--gf-theme-primary-500),
+      active-indicator-height: 0,
       active-label-text-color: var(--gf-theme-primary-500),
       active-ripple-color: var(--gf-theme-primary-500),
-      inactive-ripple-color: var(--gf-theme-primary-500)
+      container-height: 2rem,
+      inactive-ripple-color: var(--gf-theme-primary-500),
+      label-text-tracking: normal
     )
   );
-
-  --mdc-outlined-card-container-color: unset;
 }
 
 :root {

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -165,11 +165,6 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       title-text-line-height: 1.2
     )
   );
-  @include mat.fab-overrides(
-    (
-      container-color: var(--gf-theme-primary-500)
-    )
-  );
   @include mat.table-overrides(
     (
       row-item-outline-color: rgba(var(--dark-dividers))
@@ -203,11 +198,6 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       title-text-line-height: 1.2
     )
   );
-  @include mat.fab-overrides(
-    (
-      container-color: var(--gf-theme-primary-500)
-    )
-  );
   @include mat.table-overrides(
     (
       row-item-outline-color: rgba(var(--light-dividers))
@@ -226,6 +216,12 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       )
     );
   }
+
+  @include mat.fab-overrides(
+    (
+      container-color: var(--gf-theme-primary-500)
+    )
+  );
   @include mat.tabs-overrides(
     (
       active-focus-label-text-color: var(--gf-theme-primary-500),

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -170,8 +170,6 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       row-item-outline-color: rgba(var(--dark-dividers))
     )
   );
-
-  --mdc-outlined-card-container-color: unset;
 }
 
 .theme-dark {
@@ -203,8 +201,6 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
       row-item-outline-color: rgba(var(--light-dividers))
     )
   );
-
-  --mdc-outlined-card-container-color: unset;
 }
 
 .theme-dark,


### PR DESCRIPTION
Hi @dtslvr, this PR is part of #5316. Please take a look :)

### Changes
- Added `tabs-overrides`.
- Removed unused SCSS variables declarations.
- Removed `--mdc-outlined-card-container-color` (renamed to `--mat-card-outlined-container-color`, but I don't think it's needed anymore).
- Combined overrides which apply to both themes.

```
.theme-dark, .theme-light {
  ... 
}
```
