### PR TITLE
Feature/decrease border radius and margin of dialogs on mobile

### DIFF
--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -213,6 +213,14 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
     );
   }
 
+  @include mat.dialog-overrides(
+    (
+      container-max-width: 80vw,
+      container-shape: 4px,
+      container-small-max-width: 96vw
+    )
+  );
+
   @include mat.fab-overrides(
     (
       container-color: var(--gf-theme-primary-500)

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -230,14 +230,21 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
     (
       active-focus-label-text-color: var(--gf-theme-primary-500),
       active-hover-label-text-color: var(--gf-theme-primary-500),
-      active-indicator-height: 0,
       active-label-text-color: var(--gf-theme-primary-500),
       active-ripple-color: var(--gf-theme-primary-500),
-      container-height: 2rem,
-      inactive-ripple-color: var(--gf-theme-primary-500),
-      label-text-tracking: normal
+      inactive-ripple-color: var(--gf-theme-primary-500)
     )
   );
+
+  .page.has-tabs {
+    @include mat.tabs-overrides(
+      (
+        active-indicator-height: 0,
+        container-height: 2rem,
+        label-text-tracking: normal
+      )
+    );
+  }
 }
 
 :root {


### PR DESCRIPTION
Hi @dtslvr, this PR is part of #5316. Please take a look :)

### Changes
- Added `dialog-overrides`.
- Moved some `tabs-overrides` to `.page.has-tabs` so that they only impact the navigation sidebar.