### PR TITLE
Feature/extend search in assistant by accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Included accounts in the search results of the assistant
+
 ### Changed
 
 - Migrated the prompt dialog component from `ngModel` to form control

--- a/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
+++ b/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
@@ -50,7 +50,14 @@ export class GfAssistantListItemComponent
   public constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
   public ngOnChanges() {
-    if (this.item?.mode === SearchMode.ASSET_PROFILE) {
+    if (this.item?.mode === SearchMode.ACCOUNT) {
+      this.queryParams = {
+        accountDetailDialog: true,
+        accountId: this.item.id
+      };
+
+      this.routerLink = internalRoutes.accounts.routerLink;
+    } else if (this.item?.mode === SearchMode.ASSET_PROFILE) {
       this.queryParams = {
         assetProfileDialog: true,
         dataSource: this.item?.dataSource,
@@ -67,13 +74,6 @@ export class GfAssistantListItemComponent
       };
 
       this.routerLink = [];
-    } else if (this.item?.mode === SearchMode.ACCOUNT) {
-      this.queryParams = {
-        accountDetailDialog: true,
-        accountId: (this.item as any).id
-      };
-
-      this.routerLink = internalRoutes.accounts.routerLink;
     } else if (this.item?.mode === SearchMode.QUICK_LINK) {
       this.queryParams = {};
       this.routerLink = this.item.routerLink;

--- a/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
+++ b/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
@@ -60,17 +60,17 @@ export class GfAssistantListItemComponent
     } else if (this.item?.mode === SearchMode.ASSET_PROFILE) {
       this.queryParams = {
         assetProfileDialog: true,
-        dataSource: this.item?.dataSource,
-        symbol: this.item?.symbol
+        dataSource: this.item.dataSource,
+        symbol: this.item.symbol
       };
 
       this.routerLink =
         internalRoutes.adminControl.subRoutes.marketData.routerLink;
     } else if (this.item?.mode === SearchMode.HOLDING) {
       this.queryParams = {
-        dataSource: this.item?.dataSource,
+        dataSource: this.item.dataSource,
         holdingDetailDialog: true,
-        symbol: this.item?.symbol
+        symbol: this.item.symbol
       };
 
       this.routerLink = [];

--- a/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
+++ b/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
@@ -67,6 +67,13 @@ export class GfAssistantListItemComponent
       };
 
       this.routerLink = [];
+    } else if (this.item?.mode === SearchMode.ACCOUNT) {
+      this.queryParams = {
+        accountDetailDialog: true,
+        accountId: (this.item as any).id
+      };
+
+      this.routerLink = internalRoutes.accounts.routerLink;
     } else if (this.item?.mode === SearchMode.QUICK_LINK) {
       this.queryParams = {};
       this.routerLink = this.item.routerLink;

--- a/libs/ui/src/lib/assistant/assistant.html
+++ b/libs/ui/src/lib/assistant/assistant.html
@@ -40,9 +40,11 @@
       <div class="overflow-auto py-2 result-container">
         @if (
           !isLoading.assetProfiles &&
+          !isLoading.accounts &&
           !isLoading.holdings &&
           !isLoading.quickLinks &&
           searchResults.assetProfiles?.length === 0 &&
+          searchResults.accounts?.length === 0 &&
           searchResults.holdings?.length === 0 &&
           searchResults.quickLinks?.length === 0
         ) {
@@ -65,6 +67,32 @@
                 />
               }
               @if (isLoading.quickLinks) {
+                <ngx-skeleton-loader
+                  animation="pulse"
+                  class="mx-3"
+                  [theme]="{
+                    height: '1.5rem',
+                    width: '100%'
+                  }"
+                />
+              }
+            </div>
+          }
+          @if (isLoading.accounts || searchResults?.accounts?.length !== 0) {
+            <div>
+              <div class="font-weight-bold px-3 text-muted title" i18n>
+                Accounts
+              </div>
+              @for (
+                searchResultItem of searchResults.accounts;
+                track searchResultItem
+              ) {
+                <gf-assistant-list-item
+                  [item]="searchResultItem"
+                  (clicked)="onCloseAssistant()"
+                />
+              }
+              @if (isLoading.accounts) {
                 <ngx-skeleton-loader
                   animation="pulse"
                   class="mx-3"

--- a/libs/ui/src/lib/assistant/assistant.html
+++ b/libs/ui/src/lib/assistant/assistant.html
@@ -39,12 +39,12 @@
     @if (searchFormControl.value) {
       <div class="overflow-auto py-2 result-container">
         @if (
-          !isLoading.assetProfiles &&
           !isLoading.accounts &&
+          !isLoading.assetProfiles &&
           !isLoading.holdings &&
           !isLoading.quickLinks &&
-          searchResults.assetProfiles?.length === 0 &&
           searchResults.accounts?.length === 0 &&
+          searchResults.assetProfiles?.length === 0 &&
           searchResults.holdings?.length === 0 &&
           searchResults.quickLinks?.length === 0
         ) {

--- a/libs/ui/src/lib/assistant/enums/search-mode.ts
+++ b/libs/ui/src/lib/assistant/enums/search-mode.ts
@@ -1,4 +1,5 @@
 export enum SearchMode {
+  ACCOUNT = 'account',
   ASSET_PROFILE = 'assetProfile',
   HOLDING = 'holding',
   QUICK_LINK = 'quickLink'

--- a/libs/ui/src/lib/assistant/interfaces/interfaces.ts
+++ b/libs/ui/src/lib/assistant/interfaces/interfaces.ts
@@ -3,6 +3,12 @@ import { AccountWithValue, DateRange } from '@ghostfolio/common/types';
 
 import { SearchMode } from '../enums/search-mode';
 
+export interface IAccountSearchResultItem
+  extends Pick<AccountWithValue, 'id' | 'name'> {
+  mode: SearchMode.ACCOUNT;
+  routerLink: string[];
+}
+
 export interface IAssetSearchResultItem extends AssetProfileIdentifier {
   assetSubClassString: string;
   currency: string;
@@ -21,19 +27,14 @@ export interface IQuickLinkSearchResultItem {
   routerLink: string[];
 }
 
-export interface IAccountSearchResultItem
-  extends Pick<AccountWithValue, 'id' | 'name' | 'platform'> {
-  mode: SearchMode.ACCOUNT;
-}
-
 export type ISearchResultItem =
-  | IAssetSearchResultItem
   | IAccountSearchResultItem
+  | IAssetSearchResultItem
   | IQuickLinkSearchResultItem;
 
 export interface ISearchResults {
-  assetProfiles: ISearchResultItem[];
   accounts: ISearchResultItem[];
+  assetProfiles: ISearchResultItem[];
   holdings: ISearchResultItem[];
   quickLinks: ISearchResultItem[];
 }

--- a/libs/ui/src/lib/assistant/interfaces/interfaces.ts
+++ b/libs/ui/src/lib/assistant/interfaces/interfaces.ts
@@ -1,5 +1,5 @@
 import { AssetProfileIdentifier } from '@ghostfolio/common/interfaces';
-import { DateRange } from '@ghostfolio/common/types';
+import { AccountWithValue, DateRange } from '@ghostfolio/common/types';
 
 import { SearchMode } from '../enums/search-mode';
 
@@ -21,12 +21,19 @@ export interface IQuickLinkSearchResultItem {
   routerLink: string[];
 }
 
+export interface IAccountSearchResultItem
+  extends Pick<AccountWithValue, 'id' | 'name' | 'platform'> {
+  mode: SearchMode.ACCOUNT;
+}
+
 export type ISearchResultItem =
   | IAssetSearchResultItem
+  | IAccountSearchResultItem
   | IQuickLinkSearchResultItem;
 
 export interface ISearchResults {
   assetProfiles: ISearchResultItem[];
+  accounts: ISearchResultItem[];
   holdings: ISearchResultItem[];
   quickLinks: ISearchResultItem[];
 }


### PR DESCRIPTION
This PR extends the UI assistant search to include Accounts alongside Holdings and Quick Links.
Issue #5336

Summary
- Added SearchMode.ACCOUNT
- Implemented accounts search using GET /account?query=
- Merged results into assistant flow and UI section between Quick Links and Holdings
- Updated placeholder: 'Find account, holding or page...'
- Clicking an account opens the Account Detail Dialog