### PR TITLE
Feature/extend accounts endpoint by allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved the dynamic numerical precision for various values in the account detail dialog
 - Extended the accounts endpoint by dividend and interest
+- Extended the accounts endpoint by allocations
 - Improved the language localization for Portuguese (`pt`)
 - Improved the language localization for Spanish (`es`)
 

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -226,7 +226,7 @@ export class PortfolioService {
           interestInBaseCurrency,
           transactionCount,
           valueInBaseCurrency,
-          allocationInPercentage: null, // TODO
+          allocationInPercentage: 0,
           balanceInBaseCurrency: this.exchangeRateDataService.toCurrency(
             account.balance,
             account.currency,
@@ -296,6 +296,11 @@ export class PortfolioService {
         account.valueInBaseCurrency
       );
       transactionCount += account.transactionCount;
+    }
+
+    for (const account of accounts) {
+      account.allocationInPercentage =
+        account.valueInBaseCurrency / totalValueInBaseCurrency.toNumber();
     }
 
     return {


### PR DESCRIPTION
The `PortfolioService.getAccountsWithAggregations` was extended by the calculation of `allocationInPercentage`

Fixes: https://github.com/ghostfolio/ghostfolio/issues/5267