### PR TITLE
Fix average price for short positions

### DIFF
--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -926,13 +926,21 @@ export abstract class PortfolioCalculator {
           .mul(factor)
           .plus(oldAccumulatedSymbol.quantity);
 
-        if (type === 'BUY') {
+        if (type === 'BUY' && oldAccumulatedSymbol.investment.gte(0)) {
           investment = oldAccumulatedSymbol.investment.plus(
             quantity.mul(unitPrice)
           );
-        } else if (type === 'SELL') {
+        } else if (type === 'BUY' && oldAccumulatedSymbol.investment.lt(0)) {
+          investment = oldAccumulatedSymbol.investment.plus(
+            quantity.mul(oldAccumulatedSymbol.averagePrice)
+          );
+        } else if (type === 'SELL' && oldAccumulatedSymbol.investment.gt(0)) {
           investment = oldAccumulatedSymbol.investment.minus(
             quantity.mul(oldAccumulatedSymbol.averagePrice)
+          );
+        } else if (type === 'SELL' && oldAccumulatedSymbol.investment.lte(0)) {
+          investment = oldAccumulatedSymbol.investment.minus(
+            quantity.mul(unitPrice)
           );
         }
 
@@ -942,8 +950,8 @@ export abstract class PortfolioCalculator {
           investment,
           skipErrors,
           symbol,
-          averagePrice: newQuantity.gt(0)
-            ? investment.div(newQuantity)
+          averagePrice: !newQuantity.eq(0)
+            ? investment.div(newQuantity).abs()
             : new Big(0),
           dividend: new Big(0),
           fee: oldAccumulatedSymbol.fee.plus(fee),


### PR DESCRIPTION
This improves average price calculation for short positions. I am aware some tests are still to be added, @dtslvr please advise.

A few comments:
1) This only improves average price. In general, many other calculations still remain incorrect for short positions.
2) The following assumptions are made about short positions values:
- quantity - negative
- price - positive
- investment - positive
3) A case where positions are flipped, is still not supported. For example, going from +50 to -50 by selling 100 units, in an ideal world should be broken down into 2 parts for performance calculation