### PR TITLE
Fix: mark tags field as dirty on tags change in activity dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed an issue with `unitPriceInAssetProfileCurrency` in the value redaction interceptor for the impersonation mode
+- Fixed an issue where the save button was not enabled when editing tags in the activity dialog
 
 ## 2.200.0 - 2025-09-17
 

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -575,6 +575,7 @@ export class GfCreateOrUpdateActivityDialog implements OnDestroy {
 
   public onTagsChanged(tags: Tag[]) {
     this.activityForm.get('tags').setValue(tags);
+    this.activityForm.get('tags').markAsDirty();
   }
 
   public ngOnDestroy() {


### PR DESCRIPTION
Save button was not enabled when editing activity tags. See #5548