### PR TITLE
Task/prefix create watchlist item dialog component with Gf

### DIFF
--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
@@ -36,13 +36,13 @@ import { Subject } from 'rxjs';
   styleUrls: ['./create-watchlist-item-dialog.component.scss'],
   templateUrl: 'create-watchlist-item-dialog.html'
 })
-export class CreateWatchlistItemDialogComponent implements OnInit, OnDestroy {
+export class GfCreateWatchlistItemDialogComponent implements OnInit, OnDestroy {
   public createWatchlistItemForm: FormGroup;
 
   private unsubscribeSubject = new Subject<void>();
 
   public constructor(
-    public readonly dialogRef: MatDialogRef<CreateWatchlistItemDialogComponent>,
+    public readonly dialogRef: MatDialogRef<GfCreateWatchlistItemDialogComponent>,
     public readonly formBuilder: FormBuilder
   ) {}
 

--- a/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
+++ b/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
@@ -149,14 +149,17 @@ export class HomeWatchlistComponent implements OnDestroy, OnInit {
       .subscribe((user) => {
         this.user = user;
 
-        const dialogRef = this.dialog.open(GfCreateWatchlistItemDialogComponent, {
-          autoFocus: false,
-          data: {
-            deviceType: this.deviceType,
-            locale: this.user?.settings?.locale
-          } as CreateWatchlistItemDialogParams,
-          width: this.deviceType === 'mobile' ? '100vw' : '50rem'
-        });
+        const dialogRef = this.dialog.open(
+          GfCreateWatchlistItemDialogComponent,
+          {
+            autoFocus: false,
+            data: {
+              deviceType: this.deviceType,
+              locale: this.user?.settings?.locale
+            } as CreateWatchlistItemDialogParams,
+            width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+          }
+        );
 
         dialogRef
           .afterClosed()

--- a/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
+++ b/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
@@ -28,7 +28,7 @@ import { DeviceDetectorService } from 'ngx-device-detector';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { CreateWatchlistItemDialogComponent } from './create-watchlist-item-dialog/create-watchlist-item-dialog.component';
+import { GfCreateWatchlistItemDialogComponent } from './create-watchlist-item-dialog/create-watchlist-item-dialog.component';
 import { CreateWatchlistItemDialogParams } from './create-watchlist-item-dialog/interfaces/interfaces';
 
 @Component({
@@ -149,7 +149,7 @@ export class HomeWatchlistComponent implements OnDestroy, OnInit {
       .subscribe((user) => {
         this.user = user;
 
-        const dialogRef = this.dialog.open(CreateWatchlistItemDialogComponent, {
+        const dialogRef = this.dialog.open(GfCreateWatchlistItemDialogComponent, {
           autoFocus: false,
           data: {
             deviceType: this.deviceType,


### PR DESCRIPTION
Fixes #5594

This PR renames the CreateWatchlistItemDialog component to GfCreateWatchlistItemDialog to follow the project’s standard Gf* naming style. All files, exports, and imports using this component have been updated to keep the code consistent.