### PR TITLE
Task/format y-axis tick labels with toLocaleString based on locale

### DIFF
--- a/libs/ui/src/lib/line-chart/line-chart.component.ts
+++ b/libs/ui/src/lib/line-chart/line-chart.component.ts
@@ -261,7 +261,10 @@ export class GfLineChartComponent
                       }
 
                       if (typeof tickValue === 'number') {
-                        return tickValue.toFixed(2);
+                        return Number(tickValue).toLocaleString(this.locale, {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2
+                        });
                       }
 
                       return tickValue;


### PR DESCRIPTION
hi @dtslvr, this PR resolves #5591, please take a look

### Changes

- **Formatted y-axis tick labels with `toLocaleString()`** for proper locale-aware number formatting
- **Replaced `toFixed(2)` with `Number(tickValue).toLocaleString(this.locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })`**
- **Maintains existing behavior** for `yMinLabel` and `yMaxLabel` overrides