### PR TITLE
Feature/extend holdings endpoint by performance with currency effect for cash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Extended holdings endpoint by performance with currency effect for cash
+
 ### Changed
 
 - Improved the language localization for German (`de`)


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #5612. Please take a look :)

### Changes
* Extended holdings endpoint by performance with currency effect for cash:
  * The `getDetails` method in `PortfolioService` now fetches historical exchange rate data for all currencies associated with the user's cash accounts. This is done once per call to ensure efficiency.
  * The `getCashPositions` method has been updated to accept this historical data. It then calculates the `netPerformanceWithCurrencyEffect` for each cash position by comparing the current value of the cash in the base currency against its value at the time the account was created.
  * The `netPerformancePercentWithCurrencyEffect` is then derived from `netPerformanceWithCurrencyEffect` value relative to the initial investment.
* Updated changelog.
* Added comments to clarify the new logic.


