### PR TITLE
 Task/refactor PortfolioDividends interface to PortfolioDividendsResponse interface

### DIFF
--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -19,7 +19,7 @@ import {
 } from '@ghostfolio/common/config';
 import {
   PortfolioDetails,
-  PortfolioDividends,
+  PortfolioDividendsResponse,
   PortfolioHoldingResponse,
   PortfolioHoldingsResponse,
   PortfolioInvestments,
@@ -305,7 +305,7 @@ export class PortfolioController {
     @Query('range') dateRange: DateRange = 'max',
     @Query('symbol') filterBySymbol?: string,
     @Query('tags') filterByTags?: string
-  ): Promise<PortfolioDividends> {
+  ): Promise<PortfolioDividendsResponse> {
     const filters = this.apiService.buildFiltersFromQueryParams({
       filterByAccounts,
       filterByAssetClasses,

--- a/apps/client/src/app/services/data.service.ts
+++ b/apps/client/src/app/services/data.service.ts
@@ -42,7 +42,7 @@ import {
   MarketDataOfMarketsResponse,
   OAuthResponse,
   PortfolioDetails,
-  PortfolioDividends,
+  PortfolioDividendsResponse,
   PortfolioHoldingResponse,
   PortfolioHoldingsResponse,
   PortfolioInvestments,
@@ -270,9 +270,12 @@ export class DataService {
     params = params.append('groupBy', groupBy);
     params = params.append('range', range);
 
-    return this.http.get<PortfolioDividends>('/api/v1/portfolio/dividends', {
-      params
-    });
+    return this.http.get<PortfolioDividendsResponse>(
+      '/api/v1/portfolio/dividends',
+      {
+        params
+      }
+    );
   }
 
   public fetchDividendsImport({ dataSource, symbol }: AssetProfileIdentifier) {

--- a/libs/common/src/lib/interfaces/index.ts
+++ b/libs/common/src/lib/interfaces/index.ts
@@ -30,7 +30,6 @@ import type { LookupItem } from './lookup-item.interface';
 import type { MarketData } from './market-data.interface';
 import type { PortfolioChart } from './portfolio-chart.interface';
 import type { PortfolioDetails } from './portfolio-details.interface';
-import type { PortfolioDividends } from './portfolio-dividends.interface';
 import type { PortfolioInvestments } from './portfolio-investments.interface';
 import type { PortfolioPerformance } from './portfolio-performance.interface';
 import type { PortfolioPosition } from './portfolio-position.interface';
@@ -56,6 +55,7 @@ import type { LookupResponse } from './responses/lookup-response.interface';
 import type { MarketDataDetailsResponse } from './responses/market-data-details-response.interface';
 import type { MarketDataOfMarketsResponse } from './responses/market-data-of-markets-response.interface';
 import type { OAuthResponse } from './responses/oauth-response.interface';
+import type { PortfolioDividendsResponse } from './responses/portfolio-dividends-response.interface';
 import { PortfolioHoldingResponse } from './responses/portfolio-holding-response.interface';
 import type { PortfolioHoldingsResponse } from './responses/portfolio-holdings-response.interface';
 import type { PortfolioPerformanceResponse } from './responses/portfolio-performance-response.interface';
@@ -122,7 +122,7 @@ export {
   OAuthResponse,
   PortfolioChart,
   PortfolioDetails,
-  PortfolioDividends,
+  PortfolioDividendsResponse,
   PortfolioHoldingResponse,
   PortfolioHoldingsResponse,
   PortfolioInvestments,

--- a/libs/common/src/lib/interfaces/portfolio-dividends.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-dividends.interface.ts
@@ -1,5 +1,0 @@
-import { InvestmentItem } from './investment-item.interface';
-
-export interface PortfolioDividends {
-  dividends: InvestmentItem[];
-}

--- a/libs/common/src/lib/interfaces/responses/portfolio-dividends-response.interface.ts
+++ b/libs/common/src/lib/interfaces/responses/portfolio-dividends-response.interface.ts
@@ -1,0 +1,5 @@
+import { InvestmentItem } from '../investment-item.interface';
+
+export interface PortfolioDividendsResponse {
+  dividends: InvestmentItem[];
+}


### PR DESCRIPTION
### Summary
This PR refactors the `PortfolioDividends` interface:

- Renamed `PortfolioDividends` → `PortfolioDividendsResponse`
- Moved the interface file from 
  `libs/common/src/lib/interfaces/portfolio-dividends.interface.ts` 
  → `libs/common/src/lib/interfaces/responses/portfolio-dividends-response.interface.ts`
- Updated all imports and type references across the project



### Changes Made
- Deleted the old file `portfolio-dividends.interface.ts`
- Created the new file `portfolio-dividends-response.interface.ts`
- Updated:
  - `apps/api/src/app/portfolio/portfolio.controller.ts`
  - `apps/client/src/app/services/data.service.ts`
  - `libs/common/src/lib/interfaces/index.ts`

### Fixes

Fixes #5768 



