### PR TITLE
Feature/extend user detail dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extended the user detail dialog in the users section of the admin control panel
 
+### Fixed
+
+- Ensured the locale is available in the settings dialog to customize the rule thresholds of the _X-ray_ page
+
 ## 2.211.0 - 2025-10-25
 
 ### Added

--- a/apps/client/src/app/components/rule/rule.component.ts
+++ b/apps/client/src/app/components/rule/rule.component.ts
@@ -51,6 +51,7 @@ export class GfRuleComponent implements OnInit {
   @Input() categoryName: string;
   @Input() hasPermissionToUpdateUserSettings: boolean;
   @Input() isLoading: boolean;
+  @Input() locale: string;
   @Input() rule: PortfolioReportRule;
   @Input() settings: XRayRulesSettings['AccountClusterRiskCurrentInvestment'];
 
@@ -82,6 +83,7 @@ export class GfRuleComponent implements OnInit {
       data: {
         rule,
         categoryName: this.categoryName,
+        locale: this.locale,
         settings: this.settings
       } as RuleSettingsDialogParams,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'

--- a/apps/client/src/app/components/rules/rules.component.html
+++ b/apps/client/src/app/components/rules/rules.component.html
@@ -12,6 +12,7 @@
             [hasPermissionToUpdateUserSettings]="
               hasPermissionToUpdateUserSettings
             "
+            [locale]="locale"
             [rule]="rule"
             [settings]="settings?.[rule.key]"
             (ruleUpdated)="onRuleUpdated($event)"

--- a/apps/client/src/app/components/rules/rules.component.ts
+++ b/apps/client/src/app/components/rules/rules.component.ts
@@ -26,6 +26,7 @@ export class GfRulesComponent {
   @Input() categoryName: string;
   @Input() hasPermissionToUpdateUserSettings: boolean;
   @Input() isLoading: boolean;
+  @Input() locale: string;
   @Input() rules: PortfolioReportRule[];
   @Input() settings: XRayRulesSettings;
 

--- a/apps/client/src/app/pages/portfolio/x-ray/x-ray-page.component.html
+++ b/apps/client/src/app/pages/portfolio/x-ray/x-ray-page.component.html
@@ -76,6 +76,7 @@
               !hasImpersonationId && hasPermissionToUpdateUserSettings
             "
             [isLoading]="isLoading"
+            [locale]="user?.settings?.locale"
             [rules]="category.rules"
             [settings]="user?.settings?.xRayRules"
             (rulesUpdated)="onRulesUpdated($event)"
@@ -90,6 +91,7 @@
               !hasImpersonationId && hasPermissionToUpdateUserSettings
             "
             [isLoading]="isLoading"
+            [locale]="user?.settings?.locale"
             [rules]="inactiveRules"
             [settings]="user?.settings?.xRayRules"
             (rulesUpdated)="onRulesUpdated($event)"


### PR DESCRIPTION
Hi @dtslvr ! 
This PR fulfils the request in **Fixes #5831 ** by adding the six new data points to the user detail dialog.

### What I did

* Updated the `user-detail-dialog.html` template to include the new rows for:
    * Accounts
    * Activities
    * Role
    * Country
    * Engagement per Day
    * API Requests Today
* Mapped the HTML to the correct data properties available in the `AdminUsers` interface (e.g., `accountCount`, `activityCount`, `dailyApiRequests`, etc.).