### PR TITLE
Include first and last date of each calendar year in getChartDateMap()

### DIFF
--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -889,6 +889,23 @@ export abstract class PortfolioCalculator {
       }
     }
 
+    const startYear = startDate.getFullYear();
+    const endYear = endDate.getFullYear();
+
+    for (let year = startYear; year <= endYear; year++) {
+      const firstDay = new Date(year, 0, 1);  // January 1st
+      const lastDay = new Date(year, 11, 31); // December 31st
+
+      // Add only if they lie within the selected range
+      if (!isBefore(firstDay, startDate) && !isAfter(firstDay, endDate)) {
+        chartDateMap[format(firstDay, DATE_FORMAT)] = true;
+      }
+
+      if (!isBefore(lastDay, startDate) && !isAfter(lastDay, endDate)) {
+        chartDateMap[format(lastDay, DATE_FORMAT)] = true;
+      }
+    }
+
     return chartDateMap;
   }
 


### PR DESCRIPTION
## Description
Closes #5853 — The `getChartDateMap()` function currently includes transaction dates, stepped intervals, and key date ranges but **does not include the first and last dates of each calendar year**.  
This enhancement lays the groundwork for accurate performance calculations per calendar year.

---

## What’s New
- Added logic to include:
  - `YYYY-01-01` (first day of each year)
  - `YYYY-12-31` (last day of each year)
- Applied the logic for all calendar years between `startDate` and `endDate`.
- Ensured inclusion only when dates fall within the overall range.
- Maintained consistent date formatting using existing `DATE_FORMAT`.

---
