### PR TITLE
Bugfix/missing reflect-metadata polyfill in apps/client

### DIFF
--- a/apps/client/src/polyfills.ts
+++ b/apps/client/src/polyfills.ts
@@ -52,3 +52,4 @@ import 'zone.js'; // Included with Angular CLI.
  */
 
 import '@angular/localize/init';
+import 'reflect-metadata';


### PR DESCRIPTION
Hi @dtslvr, this PR fixes #5949 regarding the `TypeError: Reflect.getMetadata is not a function` runtime error in the `apps/client` application.

This error appeared after DTOs (like `UpdateBulkMarketDataDto`) using `class-transformer` and `class-validator` decorators were moved to a shared library (`libs/common`).

While the NestJS API loads this polyfill automatically as part of its core dependencies, the Angular client does not. This fix explicitly adds the `reflect-metadata` polyfill to `apps/client/src/polyfills.ts` to make the `Reflect` API available in the browser and allow the decorators to function correctly.