### PR TITLE
Remove min-width from currency and status containers

### DIFF
--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.scss
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.scss
@@ -4,7 +4,6 @@
   .currency-container,
   .status-container {
     flex: 1;
-    min-width: 2.5rem;
   }
 
   .status-container {


### PR DESCRIPTION
Currency Codes wrap to the next line on mobile widths, disrupting the visual flow of the homepage and causing a horizontal overflow. This change removes the min-width, which causes the flex overflow.

Before:

<img width="540" height="924" alt="Screenshot from 2025-11-24 13-23-58" src="https://github.com/user-attachments/assets/46eba195-56c2-4025-98e5-f03f8aca97ef" />

After:


<img width="540" height="957" alt="Screenshot from 2025-11-24 13-25-45" src="https://github.com/user-attachments/assets/6a129c01-06a5-4131-9411-629433b38674" />
