### PR TITLE
Bugfix: Localize month names in FIRE calculator

### DIFF
--- a/libs/ui/src/lib/fire-calculator/fire-calculator.component.html
+++ b/libs/ui/src/lib/fire-calculator/fire-calculator.component.html
@@ -31,9 +31,7 @@
         <mat-form-field appearance="outline" class="w-100">
           <mat-label i18n>Retirement Date</mat-label>
           <div>
-            {{
-              calculatorForm.get('retirementDate')?.value | date: 'MMMM yyyy'
-            }}
+            {{ getFormattedRetirementDate() }}
           </div>
           <input
             class="d-none"

--- a/libs/ui/src/lib/fire-calculator/fire-calculator.component.ts
+++ b/libs/ui/src/lib/fire-calculator/fire-calculator.component.ts
@@ -3,7 +3,7 @@ import {
   transformTickToAbbreviation
 } from '@ghostfolio/common/chart-helper';
 import { primaryColorRgb } from '@ghostfolio/common/config';
-import { getLocale } from '@ghostfolio/common/helper';
+import { getDateFnsLocale, getLocale } from '@ghostfolio/common/helper';
 import { FireCalculationCompleteEvent } from '@ghostfolio/common/interfaces';
 import { ColorScheme } from '@ghostfolio/common/types';
 
@@ -47,6 +47,7 @@ import {
   add,
   addDays,
   addYears,
+  format,
   getMonth,
   setMonth,
   setYear,
@@ -233,6 +234,20 @@ export class GfFireCalculatorComponent implements OnChanges, OnDestroy {
     }
 
     this.calculatorForm.get('retirementDate').disable({ emitEvent: false });
+  }
+
+  public getFormattedRetirementDate(): string {
+    const retirementDate = this.calculatorForm.get('retirementDate')?.value;
+
+    if (!retirementDate) {
+      return '';
+    }
+
+    const dateFnsLocale = getDateFnsLocale(this.locale);
+
+    return format(retirementDate, 'MMMM yyyy', {
+      locale: dateFnsLocale
+    });
   }
 
   public setMonthAndYear(


### PR DESCRIPTION
Hi @dtslvr this PR fixes issue #6070 by localizing the retirement date display in the FIRE calculator component without causing regressions in Angular Material tables.

### Background
A previous fix (#6077) was reverted because it modified `LOCALE_ID `globally, which broke Angular Material tables. There was also a discrepancy between how dev and production builds handled locales.

### What Changed
Instead of changing global locale settings, I'm using date-fns directly in the FIRE calculator component:
Before:
`{{ calculatorForm.get('retirementDate')?.value | date: 'MMMM yyyy' }}`

After:
```
// Added method to component
public getFormattedRetirementDate(): string {
  const retirementDate = this.calculatorForm.get('retirementDate')?.value;
  if (!retirementDate) return '';
  
  const dateFnsLocale = getDateFnsLocale(this.locale);
  return format(retirementDate, 'MMMM yyyy', { locale: dateFnsLocale });
}
```

`{{ getFormattedRetirementDate() }}`

### Why This Works
- Only affects the FIRE calculator component
- Doesn't touch `main.ts` or global `LOCALE_ID`
- Angular Material tables keep working as before
- Uses the `locale `that's already passed as an `@Input()` to the component
- `date-fns` behaves the same in dev and production