### PR TITLE
docs: clarify .env.dev vs .env.example usage

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,6 +9,8 @@
 - Create a local copy of this Git repository (clone)
 - Copy the file `.env.dev` to `.env` and populate it with your data (`cp .env.dev .env`)
 
+> **Note:** `.env.example` is intended for self-hosting the full application via Docker and uses Docker-internal hostnames (e.g. `postgres:5432`), which will not work when running Prisma or the API directly on the host.
+
 ### Setup
 
 1. Run `npm install`


### PR DESCRIPTION
## Description

Added a brief note in `DEVELOPMENT.md` to clarify the distinction between `.env.dev` (for local development) and `.env.example` (for self-hosted Docker deployments).

This helps new contributors avoid confusion when setting up the development environment, as the two files use different hostnames (`localhost` vs Docker-internal `postgres`).

## Changes

- Added a single-line note after the `.env.dev` prerequisite in `DEVELOPMENT.md`

## Type of Change

- [x] Documentation update