### PR TITLE
Task/revert adding styles to ui:storybook target

### DIFF
--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -31,12 +31,7 @@
         "browserTarget": "ui:build-storybook",
         "compodoc": false,
         "configDir": "libs/ui/.storybook",
-        "port": 4400,
-        "styles": [
-          "apps/client/src/assets/fonts/inter.css",
-          "apps/client/src/styles/theme.scss",
-          "apps/client/src/styles.scss"
-        ]
+        "port": 4400
       },
       "configurations": {
         "ci": {


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #5246 and reverts #5258. Please take a look :)

This is done because the issue has been fixed in Nx 22, as confirmed in https://github.com/nrwl/nx/issues/32097.

### Changes
* Removed styles option to `ui:storybook` target.