### PR TITLE
Task/restore active indicator color of tabs to primary color

### DIFF
--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -386,8 +386,11 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
 
   @include mat.tabs-overrides(
     (
+      active-focus-indicator-color: var(--gf-theme-primary-500),
       active-focus-label-text-color: var(--gf-theme-primary-500),
+      active-hover-indicator-color: var(--gf-theme-primary-500),
       active-hover-label-text-color: var(--gf-theme-primary-500),
+      active-indicator-color: var(--gf-theme-primary-500),
       active-label-text-color: var(--gf-theme-primary-500),
       active-ripple-color: var(--gf-theme-primary-500),
       inactive-ripple-color: var(--gf-theme-primary-500)


### PR DESCRIPTION
Hi @dtslvr, this PR is part of #5316. Please take a look :)

### Changes
- Added overrides for `active-focus-indicator-color`, `active-hover-indicator-color` and `active-indicator-color`.