### PR TITLE
Task/improve type safety for GfValueComponent

### DIFF
--- a/libs/ui/src/lib/value/value.component.ts
+++ b/libs/ui/src/lib/value/value.component.ts
@@ -54,7 +54,7 @@ export class GfValueComponent implements OnChanges {
     };
   });
 
-  private get hasPrecision(): boolean {
+  private get hasPrecision() {
     const precision = this.precision();
     return precision !== undefined && precision >= 0;
   }


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

### Changes

* Resolve `precision` input type error.
* Added `hasPrecision` getter and `getFormatOptions` method.
* Changed `precision` input to use the modern signal input instead of input decorator.

### Error resolved

```console
libs/ui/src/lib/value/value.component.ts:142:5 - error TS2322: Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'.

142     this.precision = this.precision >= 0 ? this.precision : undefined;
        ~~~~~~~~~~~~~~
```