### PR TITLE
fix: create SymbolProfile when missing before update (fixes #6308)

### DIFF
--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -614,6 +614,19 @@ export class AdminService {
         );
       }
     } else {
+      const [existingProfile] =
+        await this.symbolProfileService.getSymbolProfiles([
+          { dataSource, symbol }
+        ]);
+
+      if (!existingProfile) {
+        await this.addAssetProfile({
+          dataSource,
+          symbol,
+          currency: currency as string
+        });
+      }
+
       const symbolProfileOverrides = {
         assetClass: assetClass as AssetClass,
         assetSubClass: assetSubClass as AssetSubClass,

--- a/apps/client/src/app/components/admin-market-data/admin-market-data.component.ts
+++ b/apps/client/src/app/components/admin-market-data/admin-market-data.component.ts
@@ -439,7 +439,14 @@ export class GfAdminMarketDataComponent
             symbol,
             colorScheme: this.user?.settings.colorScheme,
             deviceType: this.deviceType,
-            locale: this.user?.settings?.locale
+            locale: this.user?.settings?.locale,
+            onSaved: () => {
+              this.loadData({
+                pageIndex: this.paginator?.pageIndex ?? 0,
+                sortColumn: this.sort?.active,
+                sortDirection: this.sort?.direction
+              });
+            }
           },
           height: this.deviceType === 'mobile' ? '98vh' : '80vh',
           width: this.deviceType === 'mobile' ? '100vw' : '50rem'
@@ -450,6 +457,12 @@ export class GfAdminMarketDataComponent
           .pipe(takeUntil(this.unsubscribeSubject))
           .subscribe(
             (newAssetProfileIdentifier: AssetProfileIdentifier | undefined) => {
+              this.loadData({
+                pageIndex: this.paginator?.pageIndex ?? 0,
+                sortColumn: this.sort?.active,
+                sortDirection: this.sort?.direction
+              });
+
               if (newAssetProfileIdentifier) {
                 this.onOpenAssetProfileDialog(newAssetProfileIdentifier);
               } else {

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
@@ -582,6 +582,7 @@ export class GfAssetProfileDialogComponent implements OnDestroy, OnInit {
             }
           );
 
+          this.data.onSaved?.();
           this.initialize();
         },
         error: (error) => {

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/interfaces/interfaces.ts
@@ -7,5 +7,6 @@ export interface AssetProfileDialogParams {
   dataSource: DataSource;
   deviceType: string;
   locale: string;
+  onSaved?: () => void;
   symbol: string;
 }


### PR DESCRIPTION
## Description
Fixes #6308

When adding a new currency (e.g. AUD) via Admin Control → "+" → Add Currency, saving the asset profile could fail with a 500 error and "Could not save asset profile" if the `SymbolProfile` did not exist yet (e.g. when Data Gathering was disabled or the background job had not run).

**Root cause:** `patchAssetProfileData` always called `updateSymbolProfile`, which uses `prisma.symbolProfile.update()`. That fails with Prisma P2025 when the record does not exist.

**Backend fix:** Before updating, we now check if the profile exists. If it does not, we create it via `addAssetProfile` (which fetches from the data provider and creates the profile), then perform the update as before.

**Frontend fix:** The admin market data table did not refresh after saving an asset profile. We now:
- Refresh the table when the asset profile dialog closes (so the list is up to date when returning to it).
- Refresh the table immediately on save via an optional `onSaved` callback, so the new/updated row appears without closing the dialog.

## Changes
- **apps/api/src/app/admin/admin.service.ts:** Ensure `SymbolProfile` exists before update in `patchAssetProfileData`; create via `addAssetProfile` when missing.
- **apps/client/.../admin-market-data.component.ts:** Call `loadData()` in dialog `afterClosed()` and pass `onSaved` callback to refresh table on save.
- **apps/client/.../asset-profile-dialog:** Invoke `onSaved` on successful save; add optional `onSaved` to `AssetProfileDialogParams`.

## Testing
- [x] Add currency (e.g. AUD) with Data Gathering disabled → Save → profile is created and saved, no 500.
- [x] Table refreshes immediately after Save and again when dialog is closed.