### PR TITLE
fix: scraper test returns meaningful errors (fixes #6313)

### DIFF
--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -259,7 +259,12 @@ export class AdminController {
     } catch (error) {
       Logger.error(error, 'AdminController');
 
-      throw new HttpException(error.message, StatusCodes.BAD_REQUEST);
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Scraper test failed. Check the URL, selector, and that the site returns the expected content.';
+
+      throw new HttpException(message, StatusCodes.BAD_REQUEST);
     }
   }
 

--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts
@@ -691,9 +691,20 @@ export class GfAssetProfileDialogComponent implements OnDestroy, OnInit {
         symbol: this.data.symbol
       })
       .pipe(
-        catchError(({ error }) => {
+        catchError((err: HttpErrorResponse) => {
+          const body: unknown = err.error;
+          const message: string =
+            typeof body === 'object' &&
+            body !== null &&
+            'message' in body &&
+            typeof (body as { message: unknown }).message === 'string'
+              ? (body as { message: string }).message
+              : typeof err.message === 'string'
+                ? err.message
+                : $localize`Scraper test failed`;
+
           this.notificationService.alert({
-            message: error?.message,
+            message,
             title: $localize`Error`
           });
           return EMPTY;


### PR DESCRIPTION
## Description
Fixes #6313

When testing scraper configuration (Admin Control → Market Data → edit MANUAL asset → Scraper Configuration → Test), failures only showed a generic message: "Could not parse the current market price for …". There was no indication of the real cause (e.g. HTTP 429, selector not matching, or parse failure).

## Changes

### Backend – `manual.service.ts` (`scrape()`)
- **Network:** Wrap `fetch` in try/catch and throw a clear error on failure (timeout, unreachable, etc.).
- **HTTP status:** If `!response.ok`, throw with status and a short explanation (e.g. rate limiting / blocking).
- **JSON path:** If the selector matches nothing, throw: "Selector did not match any value in the response. Check the path expression."
- **HTML selector:** If the selector matches no element (empty text), throw: "Selector matched no element on the page. Check the selector and that the page structure matches."
- **Object/array match:** If the matched value is an object/array, throw instead of stringifying to `[object Object]`.
- **Parse failure:** If `extractNumberFromString` returns `undefined`/NaN, throw with a short preview of the selected text.

### Backend – `admin.controller.ts` (`testMarketData`)
- In the catch block, use `error instanceof Error ? error.message : 'Scraper test failed. …'` so the client always receives a string message.

### Frontend – `asset-profile-dialog.component.ts`
- In `catchError`, read the message from `err.error?.message` (Nest response body) with fallbacks, and type the callback as `HttpErrorResponse` and `body` as `unknown` to satisfy lint.

## Testing
- [x] Test with URL that returns 429 → message includes "HTTP 429" and mentions blocking/rate-limiting.
- [x] Test with invalid selector → message says selector matched no element / no value.
- [x] Test with valid URL + selector that returns a number → test succeeds and shows price.

<img width="801" height="444" alt="image" src="https://github.com/user-attachments/assets/54f82e08-e6b9-443b-a4e2-fe33640dc538" />
