### PR TITLE
Task/eliminate OnDestroy lifecycle hook from portfolio page

### DIFF
--- a/apps/client/src/app/pages/portfolio/portfolio-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/portfolio-page.component.ts
@@ -2,7 +2,13 @@ import { UserService } from '@ghostfolio/client/services/user/user.service';
 import { TabConfiguration, User } from '@ghostfolio/common/interfaces';
 import { internalRoutes } from '@ghostfolio/common/routes/routes';
 
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  OnInit
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
 import { addIcons } from 'ionicons';
@@ -14,8 +20,6 @@ import {
   swapVerticalOutline
 } from 'ionicons/icons';
 import { DeviceDetectorService } from 'ngx-device-detector';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 @Component({
   host: { class: 'page has-tabs' },
@@ -24,20 +28,19 @@ import { takeUntil } from 'rxjs/operators';
   styleUrls: ['./portfolio-page.scss'],
   templateUrl: './portfolio-page.html'
 })
-export class PortfolioPageComponent implements OnDestroy, OnInit {
+export class PortfolioPageComponent implements OnInit {
   public deviceType: string;
   public tabs: TabConfiguration[] = [];
   public user: User;
 
-  private unsubscribeSubject = new Subject<void>();
-
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
+    private destroyRef: DestroyRef,
     private deviceService: DeviceDetectorService,
     private userService: UserService
   ) {
     this.userService.stateChanged
-      .pipe(takeUntil(this.unsubscribeSubject))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (state?.user) {
           this.tabs = [
@@ -86,10 +89,5 @@ export class PortfolioPageComponent implements OnDestroy, OnInit {
 
   public ngOnInit() {
     this.deviceType = this.deviceService.getDeviceInfo().deviceType;
-  }
-
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
   }
 }


### PR DESCRIPTION
Closes #6422

Replaces the `OnDestroy` + `Subject` + `takeUntil` pattern with `DestroyRef` + `takeUntilDestroyed` in the portfolio page component.

Follows the implementation pattern from PR #6419.