### PR TITLE
Eliminate OnDestroy lifecycle hook from public page

### DIFF
--- a/apps/client/src/app/pages/public/public-page.component.ts
+++ b/apps/client/src/app/pages/public/public-page.component.ts
@@ -19,8 +19,10 @@ import {
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
+  DestroyRef,
   OnInit
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableDataSource } from '@angular/material/table';
@@ -29,8 +31,8 @@ import { AssetClass } from '@prisma/client';
 import { StatusCodes } from 'http-status-codes';
 import { isNumber } from 'lodash';
 import { DeviceDetectorService } from 'ngx-device-detector';
-import { EMPTY, Subject } from 'rxjs';
-import { catchError, takeUntil } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 @Component({
   host: { class: 'page' },
@@ -83,12 +85,12 @@ export class GfPublicPageComponent implements OnInit {
   public UNKNOWN_KEY = UNKNOWN_KEY;
 
   private accessId: string;
-  private unsubscribeSubject = new Subject<void>();
 
   public constructor(
     private activatedRoute: ActivatedRoute,
     private changeDetectorRef: ChangeDetectorRef,
     private dataService: DataService,
+    private destroyRef: DestroyRef,
     private deviceService: DeviceDetectorService,
     private router: Router
   ) {
@@ -110,7 +112,7 @@ export class GfPublicPageComponent implements OnInit {
     this.dataService
       .fetchPublicPortfolio(this.accessId)
       .pipe(
-        takeUntil(this.unsubscribeSubject),
+        takeUntilDestroyed(this.destroyRef),
         catchError((error) => {
           if (error.status === StatusCodes.NOT_FOUND) {
             console.error(error);
@@ -247,8 +249,4 @@ export class GfPublicPageComponent implements OnInit {
     }
   }
 
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
-  }
 }


### PR DESCRIPTION
Closes #6424

Replaces the `OnDestroy` + `Subject` + `takeUntil` pattern with `DestroyRef` + `takeUntilDestroyed` in the public page component.

Follows the implementation pattern from PR #6419.