### PR TITLE
[codex] add community link for public eval dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Grant access of type _Public_ in the _Access_ tab of _My Ghostfolio_.
 
 Discover a variety of community projects for Ghostfolio: https://github.com/topics/ghostfolio
 
+Example evaluation resource: [Ghostfolio Agent Eval Dataset](https://github.com/thisisyoussef/ghostfolio-agent-eval-dataset) (deterministic finance-agent golden cases).
+
 Are you building your own project? Add the `ghostfolio` topic to your _GitHub_ repository to get listed as well. [Learn more →](https://docs.github.com/en/articles/classifying-your-repository-with-topics)
 
 ## Contributing


### PR DESCRIPTION
## Summary

This PR adds one community resource link to the README Community Projects section:

- [Ghostfolio Agent Eval Dataset](https://github.com/thisisyoussef/ghostfolio-agent-eval-dataset)

## Why

A public deterministic eval dataset is now available for teams building finance-focused assistants and tools around Ghostfolio-related workflows. Adding a lightweight link in Community Projects improves discoverability without changing application behavior.

## Scope

- Docs only (`README.md`)
- No backend, frontend, API, schema, or dependency changes

## Validation

- Verified markdown link format and placement under `## Community Projects`
- Confirmed repository URL resolves
