### PR TITLE
Task/eliminate OnDestroy lifecycle hook from home page

### DIFF
--- a/apps/client/src/app/pages/user-account/user-account-page.component.ts
+++ b/apps/client/src/app/pages/user-account/user-account-page.component.ts
@@ -6,16 +6,16 @@ import {
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
-  DestroyRef,
+  OnDestroy,
   OnInit
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
 import { IonIcon } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { diamondOutline, keyOutline, settingsOutline } from 'ionicons/icons';
 import { DeviceDetectorService } from 'ngx-device-detector';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   host: { class: 'page has-tabs' },
@@ -25,19 +25,20 @@ import { DeviceDetectorService } from 'ngx-device-detector';
   styleUrls: ['./user-account-page.scss'],
   templateUrl: './user-account-page.html'
 })
-export class GfUserAccountPageComponent implements OnInit {
+export class GfUserAccountPageComponent implements OnDestroy, OnInit {
   public deviceType: string;
   public tabs: TabConfiguration[] = [];
   public user: User;
 
+  private unsubscribeSubject = new Subject<void>();
+
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    private destroyRef: DestroyRef,
     private deviceService: DeviceDetectorService,
     private userService: UserService
   ) {
     this.userService.stateChanged
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(takeUntil(this.unsubscribeSubject))
       .subscribe((state) => {
         if (state?.user) {
           this.user = state.user;
@@ -71,5 +72,10 @@ export class GfUserAccountPageComponent implements OnInit {
 
   public ngOnInit() {
     this.deviceType = this.deviceService.getDeviceInfo().deviceType;
+  }
+
+  public ngOnDestroy() {
+    this.unsubscribeSubject.next();
+    this.unsubscribeSubject.complete();
   }
 }


### PR DESCRIPTION
Closes #6420 

This PR removes the OnDestroy lifecycle hook from the home page component.
Switched from Subject and takeUntil to DestroyRef and takeUntilDestroyed from @angular/core/rxjs-interop for handling RxJS subscription cleanup and Removed the ngOnDestroy hook from both components.

Follows the implementation pattern from PR https://github.com/ghostfolio/ghostfolio/pull/6419.