### PR TITLE
Task/eliminate OnDestroy lifecycle hook from allocations page

### DIFF
--- a/apps/client/src/app/pages/portfolio/allocations/allocations-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/allocations/allocations-page.component.ts
@@ -22,7 +22,12 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 import { GfWorldMapChartComponent } from '@ghostfolio/ui/world-map-chart';
 
 import { NgClass } from '@angular/common';
-import { ChangeDetectorRef, Component, DestroyRef, OnInit } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  OnInit
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';


### PR DESCRIPTION
Closes #6423 

Removed OnDestroy implementation and ngOnDestroy method.
Replaced unsubscribeSubject with DestroyRef.
Updated multiple subscriptions to use takeUntilDestroyed(this.destroyRef)

Follows the implementation used in PR https://github.com/ghostfolio/ghostfolio/pull/6419