### PR TITLE
fix(assistant): enable Apply and Reset buttons when filters are active

### DIFF
--- a/libs/ui/src/lib/assistant/assistant.component.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.ts
@@ -762,11 +762,20 @@ export class GfAssistantComponent implements OnChanges, OnDestroy, OnInit {
       );
     });
 
+    const account =
+      this.user?.settings?.['filters.accounts']?.[0] ?? null;
+    const assetClass =
+      this.user?.settings?.['filters.assetClasses']?.[0] ?? null;
+    const tag = this.user?.settings?.['filters.tags']?.[0] ?? null;
+
     this.portfolioFilterFormControl.setValue({
-      account: this.user?.settings?.['filters.accounts']?.[0] ?? null,
-      assetClass: this.user?.settings?.['filters.assetClasses']?.[0] ?? null,
+      account,
+      assetClass,
       holding: selectedHolding ?? null,
-      tag: this.user?.settings?.['filters.tags']?.[0] ?? null
+      tag
     });
+
+    if (account || assetClass || selectedHolding || tag) {
+      this.portfolioFilterFormControl.markAsDirty();
+    }
   }
-}


### PR DESCRIPTION
Fixes #6466

The Apply Filters button was always disabled because `setPortfolioFilterFormValues()` 
used `setValue()` which does not mark the form as dirty. The button's disabled 
condition checks `filterForm.dirty`, so it never became enabled.

Fix: call `markAsDirty()` on the form control after setting values, 
but only when at least one active filter exists.