### PR TITLE
Task/eliminate OnDestroy lifecycle hook from public page component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Eliminated the `OnDestroy` lifecycle hook from the public page component
 - Removed the deprecated `committedFunds` from the summary of the portfolio details endpoint
 - Upgraded `Nx` from version `22.4.5` to `22.5.3`
 


### PR DESCRIPTION
Replaces the manual `Subject` + `takeUntil` + `OnDestroy` pattern with Angular's `DestroyRef` + `takeUntilDestroyed`, following the same approach used in #6419.

### Changes
- Replaced `unsubscribeSubject` with injected `DestroyRef`
- Swapped `takeUntil(this.unsubscribeSubject)` for `takeUntilDestroyed(this.destroyRef)`
- Removed `ngOnDestroy()` method and `OnDestroy` import
- Cleaned up unused `Subject` and `takeUntil` imports
- Added changelog entry

Closes #6424