### PR TITLE
feat: migrate historical market data editor to form control

### DIFF
--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
@@ -11,7 +11,7 @@ import {
   signal
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { DateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -50,7 +50,10 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
   public readonly data =
     inject<HistoricalMarketDataEditorDialogParams>(MAT_DIALOG_DATA);
 
-  protected readonly marketPrice = signal(this.data.marketPrice);
+  public readonly form = new FormGroup({
+    dateString: new FormControl<string | null>({ value: this.data.dateString, disabled: true }),
+    marketPrice: new FormControl<number | undefined>(this.data.marketPrice)
+  });
 
   private readonly destroyRef = inject(DestroyRef);
   private readonly locale =
@@ -83,14 +86,17 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ marketPrice }) => {
-        this.marketPrice.set(marketPrice);
+        this.form.controls.marketPrice.setValue(marketPrice);
+        this.form.controls.marketPrice.markAsDirty();
 
         this.changeDetectorRef.markForCheck();
       });
   }
 
   public onUpdate() {
-    if (this.marketPrice() === undefined) {
+    const marketPrice = this.form.controls.marketPrice.value;
+
+    if (marketPrice === undefined || marketPrice === null) {
       return;
     }
 
@@ -101,7 +107,7 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
           marketData: [
             {
               date: this.data.dateString,
-              marketPrice: this.marketPrice()
+              marketPrice: marketPrice
             }
           ]
         },

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
@@ -114,8 +114,8 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
         marketData: {
           marketData: [
             {
-              date: this.data.dateString,
-              marketPrice
+              marketPrice,
+              date: this.data.dateString
             }
           ]
         },

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
@@ -24,6 +24,7 @@ import { MatInputModule } from '@angular/material/input';
 import { IonIcon } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { calendarClearOutline, refreshOutline } from 'ionicons/icons';
+import { isNil } from 'lodash';
 
 import { HistoricalMarketDataEditorDialogParams } from './interfaces/interfaces';
 
@@ -95,7 +96,7 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
   public onUpdate() {
     const marketPrice = this.form.controls.marketPrice.value;
 
-    if (marketPrice === undefined || marketPrice === null) {
+    if (isNil(marketPrice)) {
       return;
     }
 
@@ -106,7 +107,7 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
           marketData: [
             {
               date: this.data.dateString,
-              marketPrice: marketPrice
+              marketPrice
             }
           ]
         },

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
@@ -10,7 +10,12 @@ import {
   inject
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule
+} from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { DateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -51,7 +56,10 @@ export class GfHistoricalMarketDataEditorDialogComponent implements OnInit {
     inject<HistoricalMarketDataEditorDialogParams>(MAT_DIALOG_DATA);
 
   public readonly form = new FormGroup({
-    dateString: new FormControl<string | null>({ value: this.data.dateString, disabled: true }),
+    dateString: new FormControl<string | null>({
+      value: this.data.dateString,
+      disabled: true
+    }),
     marketPrice: new FormControl<number | undefined>(this.data.marketPrice)
   });
 

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.component.ts
@@ -7,8 +7,7 @@ import {
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
   OnInit,
-  inject,
-  signal
+  inject
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.html
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.html
@@ -6,10 +6,10 @@
         <mat-label i18n>Date</mat-label>
         <input
           disabled
+          formControlName="dateString"
           matInput
           name="date"
           [matDatepicker]="date"
-          formControlName="dateString"
         />
         <mat-datepicker-toggle class="mr-2" matSuffix [for]="date">
           <ion-icon
@@ -25,10 +25,10 @@
       <mat-form-field appearance="outline" class="w-100">
         <mat-label i18n>Market Price</mat-label>
         <input
+          formControlName="marketPrice"
           matInput
           name="marketPrice"
           type="number"
-          formControlName="marketPrice"
         />
         <span class="ml-2" matTextSuffix>{{ data.currency }}</span>
       </mat-form-field>
@@ -47,7 +47,7 @@
     <button
       color="primary"
       mat-flat-button
-      [disabled]="!form.dirty"
+      [disabled]="!(form.dirty && form.valid)"
       (click)="onUpdate()"
     >
       <ng-container i18n>Save</ng-container>

--- a/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.html
+++ b/libs/ui/src/lib/historical-market-data-editor/historical-market-data-editor-dialog/historical-market-data-editor-dialog.html
@@ -1,4 +1,4 @@
-<form class="d-flex flex-column h-100">
+<form class="d-flex flex-column h-100" [formGroup]="form">
   <h1 i18n mat-dialog-title>Details for {{ data.symbol }}</h1>
   <div class="flex-grow-1 py-3" mat-dialog-content>
     <div class="mb-3">
@@ -9,7 +9,7 @@
           matInput
           name="date"
           [matDatepicker]="date"
-          [(ngModel)]="data.dateString"
+          formControlName="dateString"
         />
         <mat-datepicker-toggle class="mr-2" matSuffix [for]="date">
           <ion-icon
@@ -28,8 +28,7 @@
           matInput
           name="marketPrice"
           type="number"
-          [ngModel]="marketPrice()"
-          (ngModelChange)="marketPrice.set($event)"
+          formControlName="marketPrice"
         />
         <span class="ml-2" matTextSuffix>{{ data.currency }}</span>
       </mat-form-field>
@@ -45,7 +44,12 @@
   </div>
   <div class="justify-content-end" mat-dialog-actions>
     <button i18n mat-button (click)="onCancel()">Cancel</button>
-    <button color="primary" mat-flat-button (click)="onUpdate()">
+    <button
+      color="primary"
+      mat-flat-button
+      [disabled]="!form.dirty"
+      (click)="onUpdate()"
+    >
       <ng-container i18n>Save</ng-container>
     </button>
   </div>


### PR DESCRIPTION
## Summary
This PR migrates the historical market data editor dialog component from `ngModel` to form control, as requested in #6488.

## Problem
Closes #6488

## Solution
- Replaced `signal(this.data.marketPrice)` with a `FormGroup` containing `dateString` and `marketPrice`.
- Updated the template to use `ReactiveFormsModule` and bind to the new form controls.
- Disabled the Save button when the form is not dirty.

## Testing
- Verified manually by making changes to the form and checking that the save button enables.
- Verified that saving works correctly by pulling values from `this.form.controls.marketPrice.value`.

## Checklist
- [x] Tested changes locally
- [x] Follows project conventions