### PR TITLE
Fix de-CH number separator parsing on Node 22

### DIFF
--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -3,6 +3,8 @@ import {
   getNumberFormatGroup
 } from '@ghostfolio/common/helper';
 
+const DE_CH_GROUP_SEPARATORS = ["'", '’'];
+
 describe('Helper', () => {
   describe('Extract number from string', () => {
     it('Get decimal number', () => {
@@ -26,6 +28,12 @@ describe('Helper', () => {
     it('Get decimal number with group (dot notation)', () => {
       expect(
         extractNumberFromString({ locale: 'de-CH', value: '99’999.99' })
+      ).toEqual(99999.99);
+    });
+
+    it('Get decimal number with straight apostrophe group (dot notation)', () => {
+      expect(
+        extractNumberFromString({ locale: 'de-CH', value: "99'999.99" })
       ).toEqual(99999.99);
     });
 
@@ -54,12 +62,12 @@ describe('Helper', () => {
     });
 
     it('Get de-CH number format group', () => {
-      expect(getNumberFormatGroup('de-CH')).toEqual('’');
+      expect(DE_CH_GROUP_SEPARATORS).toContain(getNumberFormatGroup('de-CH'));
     });
 
     it('Get de-CH number format group when it is default', () => {
       languageGetter.mockReturnValue('de-CH');
-      expect(getNumberFormatGroup()).toEqual('’');
+      expect(DE_CH_GROUP_SEPARATORS).toContain(getNumberFormatGroup());
     });
 
     it('Get de-DE number format group', () => {

--- a/libs/common/src/lib/helper.ts
+++ b/libs/common/src/lib/helper.ts
@@ -148,10 +148,15 @@ export function extractNumberFromString({
   try {
     // Remove non-numeric characters (excluding international formatting characters)
     const numericValue = value.replace(/[^\d.,'’\s]/g, '');
+    const groupSeparator = getNumberFormatGroup(locale);
+    const normalizedNumericValue =
+      groupSeparator === "'" || groupSeparator === '’'
+        ? numericValue.replace(/['’]/g, groupSeparator)
+        : numericValue;
 
     const parser = new NumberParser(locale);
 
-    return parser.parse(numericValue);
+    return parser.parse(normalizedNumericValue);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- normalize straight and curly apostrophe group separators for locales whose grouping uses an apostrophe
- keep the de-CH parser accepting copied Swiss-formatted numbers even when ICU returns a different apostrophe variant
- make the de-CH helper spec portable across Node 22 ICU separator changes

## Testing
- `NX_SKIP_NX_CACHE=true npx -y -p node@22 -c "node /Users/clawdchad/clawd/projects/ghostfolio/node_modules/nx/bin/nx.js run common:test --runInBand --testPathPatterns=libs/common/src/lib/helper.spec.ts"`
- `NX_SKIP_NX_CACHE=true npx -y -p node@22 -c "node /Users/clawdchad/clawd/projects/ghostfolio/node_modules/nx/bin/nx.js run common:test --runInBand"`
- `npx nx run common:lint`
- `npx prettier --check libs/common/src/lib/helper.ts libs/common/src/lib/helper.spec.ts`

This should unblock the shared `common:test` failure currently hitting open PRs such as #6487.