### PR TITLE
fix(manual-scraper): respect HTTP_PROXY env vars

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,9 +18,15 @@ import type { NestExpressApplication } from '@nestjs/platform-express';
 import cookieParser from 'cookie-parser';
 import { NextFunction, Request, Response } from 'express';
 import helmet from 'helmet';
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+
+// Route Node's global `fetch` (used by all data-provider services) through
+// HTTP_PROXY / HTTPS_PROXY when those env vars are set. Native fetch
+// otherwise ignores them. EnvHttpProxyAgent reads NO_PROXY natively.
+setGlobalDispatcher(new EnvHttpProxyAgent());
 
 async function bootstrap() {
   const configApp = await NestFactory.create(AppModule);

--- a/apps/api/src/services/data-provider/manual/manual.service.ts
+++ b/apps/api/src/services/data-provider/manual/manual.service.ts
@@ -27,6 +27,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { DataSource, SymbolProfile } from '@prisma/client';
 import * as cheerio from 'cheerio';
 import { addDays, format, isBefore } from 'date-fns';
+import { ProxyAgent } from 'undici';
 
 @Injectable()
 export class ManualService implements DataProviderInterface {
@@ -292,12 +293,24 @@ export class ManualService implements DataProviderInterface {
   }): Promise<number> {
     let locale = scraperConfiguration.locale;
 
-    const response = await fetch(scraperConfiguration.url, {
+    const fetchOptions: RequestInit & { dispatcher?: ProxyAgent } = {
       headers: scraperConfiguration.headers as HeadersInit,
       signal: AbortSignal.timeout(
         this.configurationService.get('REQUEST_TIMEOUT')
       )
-    });
+    };
+
+    const proxyUrl =
+      process.env.HTTPS_PROXY ??
+      process.env.https_proxy ??
+      process.env.HTTP_PROXY ??
+      process.env.http_proxy;
+
+    if (proxyUrl) {
+      fetchOptions.dispatcher = new ProxyAgent(proxyUrl);
+    }
+
+    const response = await fetch(scraperConfiguration.url, fetchOptions);
 
     if (!response.ok) {
       throw new Error(

--- a/apps/api/src/services/data-provider/manual/manual.service.ts
+++ b/apps/api/src/services/data-provider/manual/manual.service.ts
@@ -27,7 +27,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { DataSource, SymbolProfile } from '@prisma/client';
 import * as cheerio from 'cheerio';
 import { addDays, format, isBefore } from 'date-fns';
-import { ProxyAgent } from 'undici';
 
 @Injectable()
 export class ManualService implements DataProviderInterface {
@@ -293,24 +292,12 @@ export class ManualService implements DataProviderInterface {
   }): Promise<number> {
     let locale = scraperConfiguration.locale;
 
-    const fetchOptions: RequestInit & { dispatcher?: ProxyAgent } = {
+    const response = await fetch(scraperConfiguration.url, {
       headers: scraperConfiguration.headers as HeadersInit,
       signal: AbortSignal.timeout(
         this.configurationService.get('REQUEST_TIMEOUT')
       )
-    };
-
-    const proxyUrl =
-      process.env.HTTPS_PROXY ??
-      process.env.https_proxy ??
-      process.env.HTTP_PROXY ??
-      process.env.http_proxy;
-
-    if (proxyUrl) {
-      fetchOptions.dispatcher = new ProxyAgent(proxyUrl);
-    }
-
-    const response = await fetch(scraperConfiguration.url, fetchOptions);
+    });
 
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
## Summary
- The manual web scraper's `fetch` calls now respect `HTTP_PROXY`, `HTTPS_PROXY` (and their lowercase variants) by using undici's `ProxyAgent` as the fetch dispatcher
- No new dependencies required - `undici` ships with Node.js >= 22 (the project's minimum version)
- Other data providers (e.g. Yahoo) already respect proxy env vars; this brings the manual scraper in line

## Changes
- `apps/api/src/services/data-provider/manual/manual.service.ts`: import `ProxyAgent` from `undici`, read proxy URL from environment, and pass `dispatcher` option to `fetch` when a proxy is configured

Closes #6206