### PR TITLE
Task/eliminate OnDestroy lifecycle hook from markets component

### DIFF
--- a/apps/client/src/app/components/markets/markets.component.ts
+++ b/apps/client/src/app/components/markets/markets.component.ts
@@ -18,8 +18,8 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  DestroyRef,
   CUSTOM_ELEMENTS_SCHEMA,
+  DestroyRef,
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';


### PR DESCRIPTION
Replaces the manual `Subject` + `takeUntil` + `OnDestroy` pattern with Angular's `DestroyRef` + `takeUntilDestroyed` in the markets component, following the same approach used in #6419.

### Changes
- Replaced `unsubscribeSubject` with injected `DestroyRef`
- Swapped `takeUntil(this.unsubscribeSubject)` for `takeUntilDestroyed(this.destroyRef)`
- Removed `ngOnDestroy()` method and `OnDestroy` import
- Cleaned up unused `Subject` and `takeUntil` imports

Closes #6583