### PR TITLE
Bugfix/fix Update Cash Balance checkbox disabled for past dates

### DIFF
--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -49,6 +49,7 @@ import { calendarClearOutline, refreshOutline } from 'ionicons/icons';
 import { EMPTY, Subject } from 'rxjs';
 import { catchError, delay, takeUntil } from 'rxjs/operators';
 
+import { shouldEnableUpdateAccountBalance } from './create-or-update-activity-dialog.helper';
 import { CreateOrUpdateActivityDialogParams } from './interfaces/interfaces';
 import { ActivityType } from './types/activity-type.type';
 
@@ -272,12 +273,7 @@ export class GfCreateOrUpdateActivityDialogComponent implements OnDestroy {
         this.activityForm.get('currencyOfUnitPrice').setValue(currency);
 
         if (['FEE', 'INTEREST'].includes(type)) {
-          if (this.activityForm.get('accountId').value) {
-            this.activityForm.get('updateAccountBalance').enable();
-          } else {
-            this.activityForm.get('updateAccountBalance').disable();
-            this.activityForm.get('updateAccountBalance').setValue(false);
-          }
+          this.updateAccountBalanceState();
         }
       }
     });
@@ -303,13 +299,6 @@ export class GfCreateOrUpdateActivityDialogComponent implements OnDestroy {
       });
 
     this.activityForm.get('date').valueChanges.subscribe(() => {
-      if (isToday(this.activityForm.get('date').value)) {
-        this.activityForm.get('updateAccountBalance').enable();
-      } else {
-        this.activityForm.get('updateAccountBalance').disable();
-        this.activityForm.get('updateAccountBalance').setValue(false);
-      }
-
       this.changeDetectorRef.markForCheck();
     });
 
@@ -388,8 +377,7 @@ export class GfCreateOrUpdateActivityDialogComponent implements OnDestroy {
             .get('searchSymbol')
             .removeValidators(Validators.required);
           this.activityForm.get('searchSymbol').updateValueAndValidity();
-          this.activityForm.get('updateAccountBalance').disable();
-          this.activityForm.get('updateAccountBalance').setValue(false);
+          this.updateAccountBalanceState();
         } else if (['FEE', 'INTEREST', 'LIABILITY'].includes(type)) {
           const currency =
             this.data.accounts.find(({ id }) => {
@@ -426,15 +414,7 @@ export class GfCreateOrUpdateActivityDialogComponent implements OnDestroy {
             this.activityForm.get('unitPrice').setValue(0);
           }
 
-          if (
-            ['FEE', 'INTEREST'].includes(type) &&
-            this.activityForm.get('accountId').value
-          ) {
-            this.activityForm.get('updateAccountBalance').enable();
-          } else {
-            this.activityForm.get('updateAccountBalance').disable();
-            this.activityForm.get('updateAccountBalance').setValue(false);
-          }
+          this.updateAccountBalanceState();
         } else {
           this.activityForm
             .get('dataSource')
@@ -446,7 +426,7 @@ export class GfCreateOrUpdateActivityDialogComponent implements OnDestroy {
             .get('searchSymbol')
             .setValidators(Validators.required);
           this.activityForm.get('searchSymbol').updateValueAndValidity();
-          this.activityForm.get('updateAccountBalance').enable();
+          this.updateAccountBalanceState();
         }
 
         this.changeDetectorRef.markForCheck();
@@ -560,6 +540,21 @@ export class GfCreateOrUpdateActivityDialogComponent implements OnDestroy {
   public ngOnDestroy() {
     this.unsubscribeSubject.next();
     this.unsubscribeSubject.complete();
+  }
+
+  private updateAccountBalanceState() {
+    if (
+      shouldEnableUpdateAccountBalance({
+        accountId: this.activityForm.get('accountId').value,
+        dataSource: this.activityForm.get('dataSource').value,
+        type: this.activityForm.get('type').value
+      })
+    ) {
+      this.activityForm.get('updateAccountBalance').enable();
+    } else {
+      this.activityForm.get('updateAccountBalance').disable();
+      this.activityForm.get('updateAccountBalance').setValue(false);
+    }
   }
 
   private updateAssetProfile() {

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.helper.spec.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.helper.spec.ts
@@ -1,0 +1,117 @@
+import { shouldEnableUpdateAccountBalance } from './create-or-update-activity-dialog.helper';
+
+describe('shouldEnableUpdateAccountBalance', () => {
+  describe('BUY type', () => {
+    it('should enable regardless of date', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'YAHOO',
+          type: 'BUY'
+        })
+      ).toBe(true);
+    });
+
+    it('should disable when dataSource is MANUAL (transitional from VALUABLE)', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'MANUAL',
+          type: 'BUY'
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('SELL type', () => {
+    it('should enable', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'YAHOO',
+          type: 'SELL'
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe('DIVIDEND type', () => {
+    it('should enable', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'YAHOO',
+          type: 'DIVIDEND'
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe('FEE type', () => {
+    it('should enable when accountId is set', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'MANUAL',
+          type: 'FEE'
+        })
+      ).toBe(true);
+    });
+
+    it('should disable when accountId is empty', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: null,
+          dataSource: 'MANUAL',
+          type: 'FEE'
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('INTEREST type', () => {
+    it('should enable when accountId is set', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'MANUAL',
+          type: 'INTEREST'
+        })
+      ).toBe(true);
+    });
+
+    it('should disable when accountId is empty', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: null,
+          dataSource: 'MANUAL',
+          type: 'INTEREST'
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('VALUABLE type', () => {
+    it('should always disable', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'MANUAL',
+          type: 'VALUABLE'
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('LIABILITY type', () => {
+    it('should always disable', () => {
+      expect(
+        shouldEnableUpdateAccountBalance({
+          accountId: 'account-1',
+          dataSource: 'MANUAL',
+          type: 'LIABILITY'
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.helper.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.helper.ts
@@ -1,0 +1,21 @@
+export function shouldEnableUpdateAccountBalance({
+  accountId,
+  dataSource,
+  type
+}: {
+  accountId: string | null;
+  dataSource: string | null;
+  type: string;
+}): boolean {
+  const isManualBuy = dataSource === 'MANUAL' && type === 'BUY';
+
+  if (['VALUABLE', 'LIABILITY'].includes(type) || isManualBuy) {
+    return false;
+  }
+
+  if (['FEE', 'INTEREST'].includes(type)) {
+    return !!accountId;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Fixed the "Update Cash Balance" checkbox becoming disabled when selecting a past date in the create activity dialog
- The root cause was three independent `valueChanges` subscribers (`date`, `type`, `accountId`) each controlling the checkbox's enabled state without coordination — whichever fired last won
- Extracted the enable/disable decision into a pure helper function (`shouldEnableUpdateAccountBalance`) that encodes the full business rules in one place, and removed the date-based restriction entirely

### Decision rules (unchanged from original `type` handler logic)
| Activity Type | Checkbox enabled when... |
|---------------|------------------------|
| BUY, SELL, DIVIDEND | Always |
| FEE, INTEREST | Account is selected |
| VALUABLE, LIABILITY | Never |

## Test plan
- [x] 10 unit tests covering all activity types and edge cases (MANUAL BUY, null accountId)
- [ ] Manual: create a BUY activity, change date to yesterday, verify checkbox remains enabled
- [ ] Manual: create a FEE activity without account, verify checkbox is disabled
- [ ] Manual: switch types back and forth with a past date, verify checkbox state is consistent

Closes #6327