### PR TITLE
Task/eliminate OnDestroy lifecycle hook from open page component

### DIFF
--- a/apps/client/src/app/pages/open/open-page.component.ts
+++ b/apps/client/src/app/pages/open/open-page.component.ts
@@ -7,11 +7,11 @@ import {
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
-  OnDestroy,
+  DestroyRef,
   OnInit
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
-import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   host: { class: 'page' },
@@ -21,15 +21,14 @@ import { Subject, takeUntil } from 'rxjs';
   styleUrls: ['./open-page.scss'],
   templateUrl: './open-page.html'
 })
-export class GfOpenPageComponent implements OnDestroy, OnInit {
+export class GfOpenPageComponent implements OnInit {
   public statistics: Statistics;
   public user: User;
-
-  private unsubscribeSubject = new Subject<void>();
 
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
     private dataService: DataService,
+    private destroyRef: DestroyRef,
     private userService: UserService
   ) {
     const { statistics } = this.dataService.fetchInfo();
@@ -39,7 +38,7 @@ export class GfOpenPageComponent implements OnDestroy, OnInit {
 
   public ngOnInit() {
     this.userService.stateChanged
-      .pipe(takeUntil(this.unsubscribeSubject))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (state?.user) {
           this.user = state.user;
@@ -47,10 +46,5 @@ export class GfOpenPageComponent implements OnDestroy, OnInit {
           this.changeDetectorRef.markForCheck();
         }
       });
-  }
-
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
   }
 }


### PR DESCRIPTION
## Summary

Replace manual `Subject`-based teardown with Angular's built-in `DestroyRef` and `takeUntilDestroyed` in the open page component.

## Changes

In `apps/client/src/app/pages/open/open-page.component.ts`:

- Replaced `OnDestroy` interface with `DestroyRef` injection
- Replaced `takeUntil(this.unsubscribeSubject)` with `takeUntilDestroyed(this.destroyRef)`
- Removed `unsubscribeSubject` field and `ngOnDestroy()` method
- Removed unused `Subject` and `takeUntil` imports from `rxjs`

Follows the same pattern as PR #6419 and other recent OnDestroy elimination PRs.

Closes #6588

This contribution was developed with AI assistance (Claude Code).