### PR TITLE
Task/eliminate OnDestroy lifecycle hook from markets page component

### DIFF
--- a/apps/client/src/app/pages/markets/markets-page.component.ts
+++ b/apps/client/src/app/pages/markets/markets-page.component.ts
@@ -1,7 +1,6 @@
 import { GfHomeMarketComponent } from '@ghostfolio/client/components/home-market/home-market.component';
 
-import { Component, OnDestroy } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Component } from '@angular/core';
 
 @Component({
   host: { class: 'page' },
@@ -10,11 +9,4 @@ import { Subject } from 'rxjs';
   styleUrls: ['./markets-page.scss'],
   templateUrl: './markets-page.html'
 })
-export class GfMarketsPageComponent implements OnDestroy {
-  private unsubscribeSubject = new Subject<void>();
-
-  public ngOnDestroy() {
-    this.unsubscribeSubject.next();
-    this.unsubscribeSubject.complete();
-  }
-}
+export class GfMarketsPageComponent {}


### PR DESCRIPTION
## Summary

Removed the unused `OnDestroy` lifecycle hook and `Subject` from the markets page component. The `unsubscribeSubject` was created but never piped into any subscriptions, so the whole cleanup pattern was dead code.

## Changes

Cleaned up `markets-page.component.ts`:
- Removed `OnDestroy` import from `@angular/core`
- Removed `Subject` import from `rxjs`
- Removed `implements OnDestroy`
- Removed the `unsubscribeSubject` field and `ngOnDestroy()` method

Since this component has no active subscriptions, there's nothing to replace with `DestroyRef`. The component just becomes a clean, empty class.

Follows the same direction as #6419.

Fixes #6652

This contribution was developed with AI assistance (Claude Code).