### PR TITLE
Bugfix/implement text-nowrap for activity type badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the style of the activity type component
 - Extended the asset profile details dialog in the admin control panel to support editing countries for all asset types
 - Extended the asset profile details dialog in the admin control panel to support editing sectors for all asset types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improved the style of the activity type component
 - Extended the asset profile details dialog in the admin control panel to support editing countries for all asset types
 - Extended the asset profile details dialog in the admin control panel to support editing sectors for all asset types
+
+### Fixed
+
+- Improved the style of the activity type component
 
 ## 2.253.0 - 2026-03-06
 

--- a/libs/ui/src/lib/activity-type/activity-type.component.html
+++ b/libs/ui/src/lib/activity-type/activity-type.component.html
@@ -20,5 +20,7 @@
   } @else if (activityType === 'SELL') {
     <ion-icon name="arrow-down-circle-outline" />
   }
-  <span class="d-none d-lg-block mx-1">{{ activityTypeLabel }}</span>
+  <span class="d-none d-lg-block mx-1 text-nowrap">
+    {{ activityTypeLabel }}
+  </span>
 </div>


### PR DESCRIPTION
Hi @dtslvr, this PR fixes an issue on activity type badge when the text has more than 1 word and is wrapped into 2 lines.

I added `text-nowrap` class so that the text is not wrapped.

### Before
<img width="165" height="222" alt="Screenshot 2026-04-09 at 11 36 28" src="https://github.com/user-attachments/assets/f7260c0b-1faf-4bfe-8ed9-11bcb88d1729" />

### After
<img width="135" height="224" alt="Screenshot 2026-04-09 at 11 36 58" src="https://github.com/user-attachments/assets/0a92a723-d99d-4fb1-9e26-5bbeb131e0c5" />
