### PR TITLE
Fix import activities dialog overflow for long notice lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the import activities dialog so long notice lists remain scrollable within the viewport
 - Improved the style of the activity type component
 
 ## 2.253.0 - 2026-03-06

--- a/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.scss
+++ b/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.scss
@@ -2,7 +2,9 @@
   display: block;
 
   .mat-mdc-dialog-content {
-    max-height: unset;
+    max-height: calc(100vh - 10rem);
+    min-height: 0;
+    overflow-y: auto;
 
     a {
       color: rgba(var(--palette-primary-500), 1);


### PR DESCRIPTION
## Summary

Fixes #6600

Keep the import activities dialog content inside the viewport when an import produces many notices. The dialog content area now scrolls instead of allowing the modal to grow past the screen height.

## Changes

- cap the import dialog content height relative to the viewport
- enable vertical scrolling inside the dialog content area
- add a changelog entry

## Test plan

- [x] `npx nx lint client --quiet`
- [x] `npx prettier --check CHANGELOG.md apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.scss`
