### PR TITLE
Task/improve type safety in home watchlist and create watchlist item dialog

### DIFF
--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
@@ -2,10 +2,8 @@ import { GfSymbolAutocompleteComponent } from '@ghostfolio/ui/symbol-autocomplet
 
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import {
-  AbstractControl,
   FormBuilder,
   FormControl,
-  FormGroup,
   FormsModule,
   ReactiveFormsModule,
   ValidationErrors,
@@ -14,6 +12,9 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { SymbolProfile } from '@prisma/client';
+
+import { CreateWatchlistItemForm } from './interfaces/interfaces';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,7 +32,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
   templateUrl: 'create-watchlist-item-dialog.html'
 })
 export class GfCreateWatchlistItemDialogComponent implements OnInit {
-  public createWatchlistItemForm: FormGroup;
+  public createWatchlistItemForm: CreateWatchlistItemForm;
 
   public constructor(
     public readonly dialogRef: MatDialogRef<GfCreateWatchlistItemDialogComponent>,
@@ -41,7 +42,9 @@ export class GfCreateWatchlistItemDialogComponent implements OnInit {
   public ngOnInit() {
     this.createWatchlistItemForm = this.formBuilder.group(
       {
-        searchSymbol: new FormControl(null, [Validators.required])
+        searchSymbol: new FormControl<SymbolProfile | null>(null, [
+          Validators.required
+        ])
       },
       {
         validators: this.validator
@@ -56,18 +59,18 @@ export class GfCreateWatchlistItemDialogComponent implements OnInit {
   public onSubmit() {
     this.dialogRef.close({
       dataSource:
-        this.createWatchlistItemForm.get('searchSymbol').value.dataSource,
-      symbol: this.createWatchlistItemForm.get('searchSymbol').value.symbol
+        this.createWatchlistItemForm.controls.searchSymbol.value?.dataSource,
+      symbol: this.createWatchlistItemForm.controls.searchSymbol.value?.symbol
     });
   }
 
-  private validator(control: AbstractControl): ValidationErrors {
-    const searchSymbolControl = control.get('searchSymbol');
+  private validator(control: CreateWatchlistItemForm): ValidationErrors {
+    const searchSymbolControl = control.controls.searchSymbol;
 
     if (
       searchSymbolControl.valid &&
-      searchSymbolControl.value.dataSource &&
-      searchSymbolControl.value.symbol
+      searchSymbolControl.value?.dataSource &&
+      searchSymbolControl.value?.symbol
     ) {
       return { incomplete: false };
     }

--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
@@ -1,3 +1,4 @@
+import type { AssetProfileIdentifier } from '@ghostfolio/common/interfaces';
 import { GfSymbolAutocompleteComponent } from '@ghostfolio/ui/symbol-autocomplete';
 
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
@@ -12,7 +13,6 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { SymbolProfile } from '@prisma/client';
 
 import { CreateWatchlistItemForm } from './interfaces/interfaces';
 
@@ -35,7 +35,7 @@ export class GfCreateWatchlistItemDialogComponent {
   protected readonly createWatchlistItemForm: CreateWatchlistItemForm =
     new FormGroup(
       {
-        searchSymbol: new FormControl<SymbolProfile | null>(null, [
+        searchSymbol: new FormControl<AssetProfileIdentifier | null>(null, [
           Validators.required
         ])
       },

--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
@@ -1,14 +1,9 @@
 import { GfSymbolAutocompleteComponent } from '@ghostfolio/ui/symbol-autocomplete';
 
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  OnInit
-} from '@angular/core';
-import {
-  FormBuilder,
   FormControl,
+  FormGroup,
   FormsModule,
   ReactiveFormsModule,
   ValidationErrors,
@@ -36,15 +31,9 @@ import { CreateWatchlistItemForm } from './interfaces/interfaces';
   styleUrls: ['./create-watchlist-item-dialog.component.scss'],
   templateUrl: 'create-watchlist-item-dialog.html'
 })
-export class GfCreateWatchlistItemDialogComponent implements OnInit {
-  protected createWatchlistItemForm: CreateWatchlistItemForm;
-
-  private readonly dialogRef =
-    inject<MatDialogRef<GfCreateWatchlistItemDialogComponent>>(MatDialogRef);
-  private readonly formBuilder = inject(FormBuilder);
-
-  public ngOnInit() {
-    this.createWatchlistItemForm = this.formBuilder.group(
+export class GfCreateWatchlistItemDialogComponent {
+  protected readonly createWatchlistItemForm: CreateWatchlistItemForm =
+    new FormGroup(
       {
         searchSymbol: new FormControl<SymbolProfile | null>(null, [
           Validators.required
@@ -54,7 +43,9 @@ export class GfCreateWatchlistItemDialogComponent implements OnInit {
         validators: this.validator
       }
     );
-  }
+
+  private readonly dialogRef =
+    inject<MatDialogRef<GfCreateWatchlistItemDialogComponent>>(MatDialogRef);
 
   protected onCancel() {
     this.dialogRef.close();

--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/create-watchlist-item-dialog.component.ts
@@ -1,6 +1,11 @@
 import { GfSymbolAutocompleteComponent } from '@ghostfolio/ui/symbol-autocomplete';
 
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit
+} from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -32,12 +37,11 @@ import { CreateWatchlistItemForm } from './interfaces/interfaces';
   templateUrl: 'create-watchlist-item-dialog.html'
 })
 export class GfCreateWatchlistItemDialogComponent implements OnInit {
-  public createWatchlistItemForm: CreateWatchlistItemForm;
+  protected createWatchlistItemForm: CreateWatchlistItemForm;
 
-  public constructor(
-    public readonly dialogRef: MatDialogRef<GfCreateWatchlistItemDialogComponent>,
-    public readonly formBuilder: FormBuilder
-  ) {}
+  private readonly dialogRef =
+    inject<MatDialogRef<GfCreateWatchlistItemDialogComponent>>(MatDialogRef);
+  private readonly formBuilder = inject(FormBuilder);
 
   public ngOnInit() {
     this.createWatchlistItemForm = this.formBuilder.group(
@@ -52,11 +56,11 @@ export class GfCreateWatchlistItemDialogComponent implements OnInit {
     );
   }
 
-  public onCancel() {
+  protected onCancel() {
     this.dialogRef.close();
   }
 
-  public onSubmit() {
+  protected onSubmit() {
     this.dialogRef.close({
       dataSource:
         this.createWatchlistItemForm.controls.searchSymbol.value?.dataSource,

--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/interfaces/interfaces.ts
@@ -1,5 +1,6 @@
+import type { AssetProfileIdentifier } from '@ghostfolio/common/interfaces';
+
 import type { FormControl, FormGroup } from '@angular/forms';
-import type { SymbolProfile } from '@prisma/client';
 
 export interface CreateWatchlistItemDialogParams {
   deviceType: string;
@@ -7,5 +8,5 @@ export interface CreateWatchlistItemDialogParams {
 }
 
 export type CreateWatchlistItemForm = FormGroup<{
-  searchSymbol: FormControl<SymbolProfile | null>;
+  searchSymbol: FormControl<AssetProfileIdentifier | null>;
 }>;

--- a/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/components/home-watchlist/create-watchlist-item-dialog/interfaces/interfaces.ts
@@ -1,4 +1,11 @@
+import type { FormControl, FormGroup } from '@angular/forms';
+import type { SymbolProfile } from '@prisma/client';
+
 export interface CreateWatchlistItemDialogParams {
   deviceType: string;
   locale: string;
 }
+
+export type CreateWatchlistItemForm = FormGroup<{
+  searchSymbol: FormControl<SymbolProfile | null>;
+}>;

--- a/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
+++ b/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
@@ -48,27 +48,29 @@ import { CreateWatchlistItemDialogParams } from './create-watchlist-item-dialog/
   templateUrl: './home-watchlist.html'
 })
 export class GfHomeWatchlistComponent implements OnInit {
-  public hasImpersonationId: boolean;
-  public hasPermissionToCreateWatchlistItem: boolean;
-  public hasPermissionToDeleteWatchlistItem: boolean;
-  public user: User;
-  public watchlist: Benchmark[];
+  protected hasImpersonationId: boolean;
+  protected hasPermissionToCreateWatchlistItem: boolean;
+  protected hasPermissionToDeleteWatchlistItem: boolean;
+  protected user: User;
+  protected watchlist: Benchmark[];
 
-  private readonly deviceDetectorService = inject(DeviceDetectorService);
-  private readonly deviceType = computed(
+  protected readonly deviceType = computed(
     () => this.deviceDetectorService.deviceInfo().deviceType
   );
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private dialog: MatDialog,
-    private impersonationStorageService: ImpersonationStorageService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService
-  ) {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly dialog = inject(MatDialog);
+  private readonly impersonationStorageService = inject(
+    ImpersonationStorageService
+  );
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
     this.impersonationStorageService
       .onChangeHasImpersonation()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -114,7 +116,7 @@ export class GfHomeWatchlistComponent implements OnInit {
     this.loadWatchlistData();
   }
 
-  public onWatchlistItemDeleted({
+  protected onWatchlistItemDeleted({
     dataSource,
     symbol
   }: AssetProfileIdentifier) {

--- a/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
+++ b/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
@@ -1,5 +1,6 @@
 import { ImpersonationStorageService } from '@ghostfolio/client/services/impersonation-storage.service';
 import { UserService } from '@ghostfolio/client/services/user/user.service';
+import { locale as defaultLocale } from '@ghostfolio/common/config';
 import {
   AssetProfileIdentifier,
   Benchmark,
@@ -149,7 +150,7 @@ export class GfHomeWatchlistComponent implements OnInit {
           autoFocus: false,
           data: {
             deviceType: this.deviceType,
-            locale: this.user?.settings?.locale
+            locale: this.user?.settings?.locale ?? defaultLocale
           },
           width: this.deviceType === 'mobile' ? '100vw' : '50rem'
         });

--- a/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
+++ b/apps/client/src/app/components/home-watchlist/home-watchlist.component.ts
@@ -15,8 +15,10 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
+  inject,
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -46,26 +48,27 @@ import { CreateWatchlistItemDialogParams } from './create-watchlist-item-dialog/
   templateUrl: './home-watchlist.html'
 })
 export class GfHomeWatchlistComponent implements OnInit {
-  public deviceType: string;
   public hasImpersonationId: boolean;
   public hasPermissionToCreateWatchlistItem: boolean;
   public hasPermissionToDeleteWatchlistItem: boolean;
   public user: User;
   public watchlist: Benchmark[];
 
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly deviceType = computed(
+    () => this.deviceDetectorService.deviceInfo().deviceType
+  );
+
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
     private dataService: DataService,
     private destroyRef: DestroyRef,
-    private deviceService: DeviceDetectorService,
     private dialog: MatDialog,
     private impersonationStorageService: ImpersonationStorageService,
     private route: ActivatedRoute,
     private router: Router,
     private userService: UserService
   ) {
-    this.deviceType = this.deviceService.getDeviceInfo().deviceType;
-
     this.impersonationStorageService
       .onChangeHasImpersonation()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -149,10 +152,10 @@ export class GfHomeWatchlistComponent implements OnInit {
         >(GfCreateWatchlistItemDialogComponent, {
           autoFocus: false,
           data: {
-            deviceType: this.deviceType,
+            deviceType: this.deviceType(),
             locale: this.user?.settings?.locale ?? defaultLocale
           },
-          width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+          width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
         });
 
         dialogRef

--- a/apps/client/src/app/components/home-watchlist/home-watchlist.html
+++ b/apps/client/src/app/components/home-watchlist/home-watchlist.html
@@ -11,7 +11,7 @@
     <div class="col-xs-12 col-md-10 offset-md-1">
       <gf-benchmark
         [benchmarks]="watchlist"
-        [deviceType]="deviceType"
+        [deviceType]="deviceType()"
         [hasPermissionToDeleteItem]="hasPermissionToDeleteWatchlistItem"
         [locale]="user?.settings?.locale || undefined"
         [user]="user"


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- **Typed Forms Modernization**: Refactored `GfCreateWatchlistItemDialogComponent` to use strict Angular 14+ Typed Forms, declaring properties inline natively with `new FormGroup()` and removing outdated `FormBuilder` and `ngOnInit` boilerplate.
- **Signal-Based Component Architecture**: Enhances `GfHomeWatchlistComponent` by moving DI overhead to modern `inject()` wrappers and surfacing `deviceType` via `computed` with native `ngx-device-detector` signals (`getDeviceInfo()` is deprecated).
- **Strict Encapsulation**: Tightened access modifiers in `GfHomeWatchlistComponent`, sealing properties and event handlers (`ngOnInit`, etc.) as `protected` and ensuring correct `typescript-eslint/member-ordering`.
- **Strict Parameter Fallbacks**: Patched type mismatch when supplying `data.locale` to dialog components by providing default locale fallbacks and stricter interface compliance.

## Context

### Strict Angular UI Standards

Certain components in the Watchlist module (specifically the `GfCreateWatchlistItemDialogComponent` and `GfHomeWatchlistComponent`) were exposing internal state publicly and relying on untyped `.controls` chains. This PR modernizes the module by cleanly encapsulating state, securing the strict-typing constraints, and adopting modern Angular reactivity patterns (`inject`/`computed`).

## Resolved type errors

6 errors (before: 226, after: 220).