### PR TITLE
fix(rule-settings-dialog): disable Save button until form is modified

### DIFF
--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.component.ts
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.component.ts
@@ -3,7 +3,7 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 
 import { CommonModule } from '@angular/common';
 import { Component, Inject } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import {
   MAT_DIALOG_DATA,
@@ -17,21 +17,31 @@ import { RuleSettingsDialogParams } from './interfaces/interfaces';
 @Component({
   imports: [
     CommonModule,
-    FormsModule,
     GfValueComponent,
     MatButtonModule,
     MatDialogModule,
-    MatSliderModule
+    MatSliderModule,
+    ReactiveFormsModule
   ],
   selector: 'gf-rule-settings-dialog',
   styleUrls: ['./rule-settings-dialog.scss'],
   templateUrl: './rule-settings-dialog.html'
 })
 export class GfRuleSettingsDialogComponent {
-  public settings: XRayRulesSettings['AccountClusterRiskCurrentInvestment'];
+  public settingsForm = new FormGroup({
+    thresholdMax: new FormControl(this.data.settings?.thresholdMax ?? null),
+    thresholdMin: new FormControl(this.data.settings?.thresholdMin ?? null)
+  });
 
   public constructor(
     @Inject(MAT_DIALOG_DATA) public data: RuleSettingsDialogParams,
     public dialogRef: MatDialogRef<GfRuleSettingsDialogComponent>
   ) {}
+
+  public onSave() {
+    this.dialogRef.close({
+      ...this.data.settings,
+      ...this.settingsForm.value
+    });
+  }
 }

--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
@@ -1,138 +1,139 @@
 <div mat-dialog-title>{{ data.categoryName }} › {{ data.rule.name }}</div>
 
-<div class="py-3" mat-dialog-content>
-  @if (
-    data.rule.configuration.thresholdMin && data.rule.configuration.thresholdMax
-  ) {
-    <div class="w-100">
-      <h6 class="d-flex mb-0">
-        <ng-container i18n>Threshold range</ng-container>:
-        <gf-value
-          class="ml-1"
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.settings.thresholdMin"
-        />
-        <span class="mx-1">-</span>
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.settings.thresholdMax"
-        />
-      </h6>
-      <div class="align-items-center d-flex w-100">
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.rule.configuration.threshold.min"
-        />
-        <mat-slider
-          class="flex-grow-1"
-          [max]="data.rule.configuration.threshold.max"
-          [min]="data.rule.configuration.threshold.min"
-          [step]="data.rule.configuration.threshold.step"
-        >
-          <input matSliderStartThumb [(ngModel)]="data.settings.thresholdMin" />
-          <input matSliderEndThumb [(ngModel)]="data.settings.thresholdMax" />
-        </mat-slider>
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.rule.configuration.threshold.max"
-        />
+<form [formGroup]="settingsForm">
+  <div class="py-3" mat-dialog-content>
+    @if (
+      data.rule.configuration.thresholdMin && data.rule.configuration.thresholdMax
+    ) {
+      <div class="w-100">
+        <h6 class="d-flex mb-0">
+          <ng-container i18n>Threshold range</ng-container>:
+          <gf-value
+            class="ml-1"
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="settingsForm.controls.thresholdMin.value"
+          />
+          <span class="mx-1">-</span>
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="settingsForm.controls.thresholdMax.value"
+          />
+        </h6>
+        <div class="align-items-center d-flex w-100">
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="data.rule.configuration.threshold.min"
+          />
+          <mat-slider
+            class="flex-grow-1"
+            [max]="data.rule.configuration.threshold.max"
+            [min]="data.rule.configuration.threshold.min"
+            [step]="data.rule.configuration.threshold.step"
+          >
+            <input formControlName="thresholdMin" matSliderStartThumb />
+            <input formControlName="thresholdMax" matSliderEndThumb />
+          </mat-slider>
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="data.rule.configuration.threshold.max"
+          />
+        </div>
       </div>
-    </div>
-  } @else {
-    <div
-      class="w-100"
-      [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMin }"
-    >
-      <h6 class="d-flex mb-0">
-        <ng-container i18n>Threshold Min</ng-container>:
-        <gf-value
-          class="ml-1"
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.settings.thresholdMin"
-        />
-      </h6>
-      <div class="align-items-center d-flex w-100">
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.rule.configuration.threshold.min"
-        />
-        <mat-slider
-          class="flex-grow-1"
-          name="thresholdMin"
-          [max]="data.rule.configuration.threshold.max"
-          [min]="data.rule.configuration.threshold.min"
-          [step]="data.rule.configuration.threshold.step"
-        >
-          <input matSliderThumb [(ngModel)]="data.settings.thresholdMin" />
-        </mat-slider>
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.rule.configuration.threshold.max"
-        />
+    } @else {
+      <div
+        class="w-100"
+        [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMin }"
+      >
+        <h6 class="d-flex mb-0">
+          <ng-container i18n>Threshold Min</ng-container>:
+          <gf-value
+            class="ml-1"
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="settingsForm.controls.thresholdMin.value"
+          />
+        </h6>
+        <div class="align-items-center d-flex w-100">
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="data.rule.configuration.threshold.min"
+          />
+          <mat-slider
+            class="flex-grow-1"
+            [max]="data.rule.configuration.threshold.max"
+            [min]="data.rule.configuration.threshold.min"
+            [step]="data.rule.configuration.threshold.step"
+          >
+            <input formControlName="thresholdMin" matSliderThumb />
+          </mat-slider>
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="data.rule.configuration.threshold.max"
+          />
+        </div>
       </div>
-    </div>
-    <div
-      class="w-100"
-      [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMax }"
-    >
-      <h6 class="d-flex mb-0">
-        <ng-container i18n>Threshold Max</ng-container>:
-        <gf-value
-          class="ml-1"
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.settings.thresholdMax"
-        />
-      </h6>
-      <div class="align-items-center d-flex w-100">
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.rule.configuration.threshold.min"
-        />
-        <mat-slider
-          class="flex-grow-1"
-          name="thresholdMax"
-          [max]="data.rule.configuration.threshold.max"
-          [min]="data.rule.configuration.threshold.min"
-          [step]="data.rule.configuration.threshold.step"
-        >
-          <input matSliderThumb [(ngModel)]="data.settings.thresholdMax" />
-        </mat-slider>
-        <gf-value
-          [isPercent]="data.rule.configuration.threshold.unit === '%'"
-          [locale]="data.locale"
-          [precision]="2"
-          [value]="data.rule.configuration.threshold.max"
-        />
+      <div
+        class="w-100"
+        [ngClass]="{ 'd-none': !data.rule.configuration.thresholdMax }"
+      >
+        <h6 class="d-flex mb-0">
+          <ng-container i18n>Threshold Max</ng-container>:
+          <gf-value
+            class="ml-1"
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="settingsForm.controls.thresholdMax.value"
+          />
+        </h6>
+        <div class="align-items-center d-flex w-100">
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="data.rule.configuration.threshold.min"
+          />
+          <mat-slider
+            class="flex-grow-1"
+            [max]="data.rule.configuration.threshold.max"
+            [min]="data.rule.configuration.threshold.min"
+            [step]="data.rule.configuration.threshold.step"
+          >
+            <input formControlName="thresholdMax" matSliderThumb />
+          </mat-slider>
+          <gf-value
+            [isPercent]="data.rule.configuration.threshold.unit === '%'"
+            [locale]="data.locale"
+            [precision]="2"
+            [value]="data.rule.configuration.threshold.max"
+          />
+        </div>
       </div>
-    </div>
-  }
-</div>
+    }
+  </div>
 
-<div align="end" mat-dialog-actions>
-  <button i18n mat-button (click)="dialogRef.close()">Close</button>
-  <button
-    color="primary"
-    mat-flat-button
-    (click)="dialogRef.close(data.settings)"
-  >
-    <ng-container i18n>Save</ng-container>
-  </button>
-</div>
+  <div align="end" mat-dialog-actions>
+    <button i18n mat-button (click)="dialogRef.close()">Close</button>
+    <button
+      color="primary"
+      mat-flat-button
+      [disabled]="settingsForm.pristine"
+      (click)="onSave()"
+    >
+      <ng-container i18n>Save</ng-container>
+    </button>
+  </div>
+</form>


### PR DESCRIPTION
I was exploring the X-ray section in Portfolio when I noticed the Save button in the rule settings dialog is always enabled on open, even when no changes have been made to the threshold sliders. This makes it unclear to users whether clicking Save will actually change anything.

## What changed

Migrated the component from `ngModel` / `FormsModule` to `FormGroup` / `ReactiveFormsModule` as suggested in the issue. The Save button now uses `[disabled]="settingsForm.pristine"` to remain disabled until the user actually moves a slider.

- `rule-settings-dialog.component.ts`: replaced `FormsModule` import with `ReactiveFormsModule`, added `FormGroup` with `thresholdMin`/`thresholdMax` `FormControl`s initialized from `data.settings`, added `onSave()` method that merges form values back into `data.settings` before closing the dialog
- `rule-settings-dialog.html`: wrapped template in `<form [formGroup]="settingsForm">`, replaced `[(ngModel)]` bindings with `formControlName`, updated `gf-value` display bindings to use `settingsForm.controls.*value`, added `[disabled]="settingsForm.pristine"` to the Save button

Closes #6479