### PR TITLE
Bugfix/resolve admin version fallback in production

### DIFF
--- a/apps/api/src/environments/environment.prod.ts
+++ b/apps/api/src/environments/environment.prod.ts
@@ -1,7 +1,30 @@
 import { DEFAULT_HOST, DEFAULT_PORT } from '@ghostfolio/common/config';
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const getVersion = () => {
+  if (process.env.APP_VERSION) {
+    return process.env.APP_VERSION;
+  }
+
+  if (process.env.npm_package_version) {
+    return process.env.npm_package_version;
+  }
+
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    );
+
+    return packageJson.version ?? 'dev';
+  } catch {
+    return 'dev';
+  }
+};
+
 export const environment = {
   production: true,
   rootUrl: `http://${DEFAULT_HOST}:${DEFAULT_PORT}`,
-  version: process.env.npm_package_version ?? 'dev'
+  version: getVersion()
 };


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #6726, please take a look

### Summary
Fix the version displayed on the Admin page in production.

The API no longer relies only on `npm_package_version`, which may be unavailable in some production environments. It now resolves the version from `APP_VERSION`, `npm_package_version`, or the runtime `package.json` before falling back to `dev`.

### Changes
- Updated the production API environment to resolve the app version more reliably.
- Added fallbacks for `APP_VERSION`, `npm_package_version`, and the runtime `package.json`.
- Prevented the Admin page from incorrectly showing `dev` in self-hosted production setups.