### PR TITLE
fix(exchange-rate): return aValue fallback when exchange rate data is missing

### DIFF
--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -349,7 +349,11 @@ export class ExchangeRateDataService {
       'ExchangeRateDataService'
     );
 
-    return undefined;
+    Logger.warn(
+      `No exchange rate data found for ${aFromCurrency} -> ${aToCurrency} on ${aDate.toISOString()}, returning original value as fallback`,
+      'ExchangeRateDataService'
+    );
+    return aValue;
   }
 
   private async getExchangeRates({


### PR DESCRIPTION
## Summary

Fixes #6482

### Problem

`toCurrencyAtDate()` returns `undefined` when no historical exchange rate data is available for the requested date. This `undefined` propagates into activity fields like `feeInBaseCurrency` and `valueInBaseCurrency`, which are then passed to big.js — causing `[big.js] Invalid number` crashes on the Overview, Portfolio, and Holdings pages.

### Fix

Instead of returning `undefined`, log a `Logger.warn()` message and return `aValue` as a 1:1 fallback. This prevents the crash while gracefully degrading when exchange rate data is incomplete (e.g., on a fresh install or when historical market data is missing).

### Change

In `exchange-rate-data.service.ts`, line 352:

**Before:**
```typescript
return undefined;
```

**After:**
```typescript
Logger.warn(
  `No exchange rate data found for ${aFromCurrency} -> ${aToCurrency} on ${aDate.toISOString()}, returning original value as fallback`,
  'ExchangeRateDataService'
);
return aValue;
```