### PR TITLE
Task/various improvements in Storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Integrated a theme switcher into _Storybook_ to support toggling between the light and dark mode
+
+### Fixed
+
+- Fixed the _Storybook_ setup by resolving missing `@angular/material` styles
+
 ## 3.0.1 - 2026-04-26
 
 ### Changed

--- a/libs/ui/.storybook/main.mjs
+++ b/libs/ui/.storybook/main.mjs
@@ -5,7 +5,10 @@ const require = createRequire(import.meta.url);
 
 /** @type {import('@storybook/angular').StorybookConfig} */
 const config = {
-  addons: [getAbsolutePath('@storybook/addon-docs')],
+  addons: [
+    getAbsolutePath('@storybook/addon-docs'),
+    getAbsolutePath('@storybook/addon-themes')
+  ],
   framework: {
     name: getAbsolutePath('@storybook/angular'),
     options: {}

--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -3,11 +3,11 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 const preview = {
   decorators: [
     withThemeByClassName({
-      defaultTheme: 'light',
+      defaultTheme: 'Light',
       parentSelector: 'body',
       themes: {
-        dark: 'theme-dark',
-        light: 'theme-light'
+        Dark: 'theme-dark',
+        Light: 'theme-light'
       }
     })
   ]

--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -3,12 +3,12 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 const preview = {
   decorators: [
     withThemeByClassName({
-      themes: {
-        light: 'theme-light',
-        dark: 'theme-dark'
-      },
       defaultTheme: 'light',
-      parentSelector: 'body'
+      parentSelector: 'body',
+      themes: {
+        dark: 'theme-dark',
+        light: 'theme-light'
+      }
     })
   ]
 };

--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -1,0 +1,20 @@
+import { withThemeByClassName } from '@storybook/addon-themes';
+
+const preview = {
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: 'theme-light',
+        dark: 'theme-dark'
+      },
+      defaultTheme: 'light',
+      parentSelector: 'body'
+    })
+  ]
+};
+
+if (typeof document !== 'undefined') {
+  document.body.classList.add('mat-typography');
+}
+
+export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
         "@nx/workspace": "22.6.5",
         "@schematics/angular": "21.2.6",
         "@storybook/addon-docs": "10.1.10",
+        "@storybook/addon-themes": "^10.1.10",
         "@storybook/angular": "10.1.10",
         "@trivago/prettier-plugin-sort-imports": "6.0.2",
         "@types/big.js": "6.2.2",
@@ -13452,6 +13453,23 @@
         "@storybook/react-dom-shim": "10.1.10",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.1.10"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.1.10.tgz",
+      "integrity": "sha512-YlTzREQnUFZ6wepo4MppiobkFrsF1EuObh+vaEhjEj5Cs1oH+kqP5Db+rXi8rbrxnVXaWKmDgqZMtB7kVN4Dnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "ts-dedent": "^2.0.0"
       },
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "@nx/workspace": "22.6.5",
         "@schematics/angular": "21.2.6",
         "@storybook/addon-docs": "10.1.10",
-        "@storybook/addon-themes": "^10.1.10",
+        "@storybook/addon-themes": "10.1.10",
         "@storybook/angular": "10.1.10",
         "@trivago/prettier-plugin-sort-imports": "6.0.2",
         "@types/big.js": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "@nx/workspace": "22.6.5",
     "@schematics/angular": "21.2.6",
     "@storybook/addon-docs": "10.1.10",
+    "@storybook/addon-themes": "^10.1.10",
     "@storybook/angular": "10.1.10",
     "@trivago/prettier-plugin-sort-imports": "6.0.2",
     "@types/big.js": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@nx/workspace": "22.6.5",
     "@schematics/angular": "21.2.6",
     "@storybook/addon-docs": "10.1.10",
-    "@storybook/addon-themes": "^10.1.10",
+    "@storybook/addon-themes": "10.1.10",
     "@storybook/angular": "10.1.10",
     "@trivago/prettier-plugin-sort-imports": "6.0.2",
     "@types/big.js": "6.2.2",


### PR DESCRIPTION
Fixes issue #6773 while adding support for the dark theme.
Otherwise, if this solution doesn't suit you, just add this to the file [preview.js](https://github.com/ghostfolio/ghostfolio/blob/main/libs/ui/.storybook/preview.js)

```
if (typeof document !== 'undefined') {
  document.body.classList.add('theme-light');
}
```
---

> Hey,
> 
> Previously, the theme was loaded by default:
> 
> [ghostfolio/apps/client/src/styles/theme.scss](https://github.com/ghostfolio/ghostfolio/blob/0be83cf033558bc67d4d498e425773b2dd484e6d/apps/client/src/styles/theme.scss#L85)
> 
> Line 85 in [0be83cf](/ghostfolio/ghostfolio/commit/0be83cf033558bc67d4d498e425773b2dd484e6d)
> 
>  @include mat.all-component-themes($gf-theme-default); 
> Now it is wrapped in a CSS class:
> 
> [ghostfolio/apps/client/src/styles/theme.scss](https://github.com/ghostfolio/ghostfolio/blob/75e2b855c0880ed443f39b490c4842a8eba83b1c/apps/client/src/styles/theme.scss#L144-L159)
> 
> Lines 144 to 159 in [75e2b85](/ghostfolio/ghostfolio/commit/75e2b855c0880ed443f39b490c4842a8eba83b1c)
> 
>  .theme-light { 
>    $gf-theme-default: mat.define-theme( 
>      ( 
>        color: ( 
>          primary: $_primary, 
>          theme-type: light, 
>          tertiary: $_tertiary 
>        ), 
>        density: ( 
>          scale: -3 
>        ), 
>        // typography: $gf-typography 
>      ) 
>    ); 
>   
>    @include mat.all-component-themes($gf-theme-default);

