### PR TITLE
i18n(zh): improve Chinese localization for fee ratio rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the language localization for Chinese (`zh`)
 - Upgraded `ngx-markdown` from version `21.0.1` to `21.1.0`
 
 ## 2.239.0 - 2026-02-15

--- a/apps/client/src/locales/messages.zh.xlf
+++ b/apps/client/src/locales/messages.zh.xlf
@@ -7883,7 +7883,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioInitialInvestment" datatype="html">
         <source>Fee Ratio (legacy)</source>
-        <target state="new">费率</target>
+        <target state="translated">费率（历史）</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">152</context>
@@ -7907,7 +7907,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioTotalInvestmentVolume" datatype="html">
         <source>Fee Ratio</source>
-        <target state="new">Fee Ratio</target>
+        <target state="translated">费率</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">161</context>
@@ -7915,7 +7915,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioTotalInvestmentVolume.false" datatype="html">
         <source>The fees do exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</source>
-        <target state="new">The fees do exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</target>
+        <target state="translated">费用超过了您总投资额的 ${thresholdMax}% (${feeRatio}%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">163</context>
@@ -7923,7 +7923,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioTotalInvestmentVolume.true" datatype="html">
         <source>The fees do not exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</source>
-        <target state="new">The fees do not exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</target>
+        <target state="translated">费用未超过您总投资额的 ${thresholdMax}% (${feeRatio}%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">167</context>


### PR DESCRIPTION
## Summary

Translated 4 remaining entries with `state="new"` in the Chinese (`zh`) localization file, as part of the effort tracked in #6202.

### Changes

- `rule.feeRatioInitialInvestment`: Updated translation from `费率` to `费率（历史）` to reflect the "legacy" qualifier, and marked as translated
- `rule.feeRatioTotalInvestmentVolume`: Translated "Fee Ratio" → `费率`
- `rule.feeRatioTotalInvestmentVolume.false`: Translated fee threshold exceeded message
- `rule.feeRatioTotalInvestmentVolume.true`: Translated fee threshold not exceeded message

### Changelog

Added entry under `## Unreleased > ### Changed`:
```
- Improved the language localization for Chinese (`zh`)
```

Closes #6202 (partially — all `state="new"` entries are now translated)