### PR TITLE
Task/reset background color of paginators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Modernized the layout of the overview tab in the admin control panel
+- Improved the styling of the paginator across various table components
 
 ### Fixed
 

--- a/apps/client/src/app/components/admin-market-data/admin-market-data.html
+++ b/apps/client/src/app/components/admin-market-data/admin-market-data.html
@@ -309,6 +309,7 @@
       </div>
 
       <mat-paginator
+        [hidePageSize]="true"
         [length]="totalItems"
         [ngClass]="{
           'd-none': (isLoading && totalItems === 0) || totalItems <= pageSize

--- a/apps/client/src/app/components/admin-users/admin-users.html
+++ b/apps/client/src/app/components/admin-users/admin-users.html
@@ -273,6 +273,7 @@
       </div>
 
       <mat-paginator
+        [hidePageSize]="true"
         [length]="totalItems"
         [ngClass]="{
           'd-none': (isLoading && totalItems === 0) || totalItems <= pageSize

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -258,10 +258,6 @@ body {
       }
     }
 
-    .mat-mdc-paginator {
-      background-color: rgba(var(--palette-foreground-base-dark), 0.02);
-    }
-
     .mdc-button {
       &.mat-accent,
       &.mat-primary {
@@ -456,15 +452,6 @@ ngx-skeleton-loader {
       align-items: center;
       display: flex;
     }
-  }
-}
-
-.mat-mdc-paginator {
-  background-color: rgba(var(--palette-foreground-base-light), 0.02);
-
-  .mat-mdc-paginator-page-size,
-  .mat-mdc-paginator-page-size {
-    display: none;
   }
 }
 

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -359,6 +359,12 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
     )
   );
 
+  @include mat.paginator-overrides(
+    (
+      container-background-color: transparent
+    )
+  );
+
   @include mat.progress-bar-overrides(
     (
       active-indicator-color: var(--gf-theme-primary-500)

--- a/libs/ui/src/lib/activities-table/activities-table.component.html
+++ b/libs/ui/src/lib/activities-table/activities-table.component.html
@@ -536,6 +536,7 @@
 }
 
 <mat-paginator
+  [hidePageSize]="true"
   [length]="totalItems"
   [ngClass]="{
     'd-none': (isLoading() && !totalItems) || totalItems <= pageSize

--- a/libs/ui/src/lib/holdings-table/holdings-table.component.html
+++ b/libs/ui/src/lib/holdings-table/holdings-table.component.html
@@ -193,7 +193,7 @@
   </table>
 </div>
 
-<mat-paginator class="d-none" [pageSize]="pageSize()" />
+<mat-paginator class="d-none" [hidePageSize]="true" [pageSize]="pageSize()" />
 
 @if (isLoading()) {
   <ngx-skeleton-loader

--- a/libs/ui/src/lib/top-holdings/top-holdings.component.html
+++ b/libs/ui/src/lib/top-holdings/top-holdings.component.html
@@ -155,7 +155,7 @@
   </table>
 </div>
 
-<mat-paginator class="d-none" [pageSize]="pageSize" />
+<mat-paginator class="d-none" [hidePageSize]="true" [pageSize]="pageSize" />
 
 @if (isLoading) {
   <ngx-skeleton-loader


### PR DESCRIPTION
Resolves #6799.

Removes the two `.mat-mdc-paginator` CSS overrides in `apps/client/src/styles.scss`:

- The dark-theme block setting the background to `rgba(var(--palette-foreground-base-dark), 0.02)`
- The global block setting the background to `rgba(var(--palette-foreground-base-light), 0.02)` plus the `.mat-mdc-paginator-page-size { display: none }` rule (the selector was duplicated in the source)

The default Angular Material paginator background is transparent and follows the surface theme, which matches the issue's request. Components that need to hide the page-size selector should use the paginator's `[hidePageSize]` input rather than a CSS override.

Diff: 13 lines removed.