### PR TITLE
fix: allow empty URL when saving asset profile (#6811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded `stripe` from version `20.4.1` to `21.0.1`
 
+### Fixed
+
+- Fixed the asset profile validation to allow saving with an empty URL field
+
 ## 3.1.0 - 2026-04-29
 
 ### Added

--- a/libs/common/src/lib/dtos/create-asset-profile.dto.ts
+++ b/libs/common/src/lib/dtos/create-asset-profile.dto.ts
@@ -1,6 +1,7 @@
 import { IsCurrencyCode } from '@ghostfolio/common/validators/is-currency-code';
 
 import { AssetClass, AssetSubClass, DataSource, Prisma } from '@prisma/client';
+import { Transform, TransformFnParams } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -9,6 +10,7 @@ import {
   IsString,
   IsUrl
 } from 'class-validator';
+import { isString } from 'lodash';
 
 export class CreateAssetProfileDto {
   @IsEnum(AssetClass, { each: true })
@@ -77,5 +79,8 @@ export class CreateAssetProfileDto {
     protocols: ['https'],
     require_protocol: true
   })
+  @Transform(({ value }: TransformFnParams) =>
+    isString(value) && value.trim() === '' ? undefined : value
+  )
   url?: string;
 }

--- a/libs/common/src/lib/dtos/update-asset-profile.dto.ts
+++ b/libs/common/src/lib/dtos/update-asset-profile.dto.ts
@@ -1,6 +1,7 @@
 import { IsCurrencyCode } from '@ghostfolio/common/validators/is-currency-code';
 
 import { AssetClass, AssetSubClass, DataSource, Prisma } from '@prisma/client';
+import { Transform, TransformFnParams } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -10,6 +11,7 @@ import {
   IsString,
   IsUrl
 } from 'class-validator';
+import { isString } from 'lodash';
 
 export class UpdateAssetProfileDto {
   @IsEnum(AssetClass, { each: true })
@@ -67,5 +69,8 @@ export class UpdateAssetProfileDto {
     protocols: ['https'],
     require_protocol: true
   })
+  @Transform(({ value }: TransformFnParams) =>
+    isString(value) && value.trim() === '' ? undefined : value
+  )
   url?: string;
 }


### PR DESCRIPTION
## Bug

Closes #6811. The asset profile dialog can't be saved when the optional _URL_ field is left blank — validation fails with `url must be a URL address` even though the field is documented as optional.

## Root cause

In `class-validator`, `@IsOptional()` only short-circuits validation when the value is \`undefined\` or \`null\`. An empty string \`\"\"\` is treated as a present value, so `@IsUrl()` runs against it and fails. The form submits \`url: \"\"\` (not \`undefined\`) when the field is blank, so the optional decorator never kicks in.

This affects:

- \`UpdateAssetProfileDto\` (the path the bug repro hits — \"Set Asset Class to Alternative Investment, leave URL empty, click Save\")
- \`CreateAssetProfileDto\` — same flaw on the create path; not in the original repro but same flow, same fix

`CreatePlatformDto` and `UpdatePlatformDto` also use `@IsUrl()` but their \`url\` field is **required** (no \`@IsOptional()\`), so empty string is intentionally rejected there. Left alone.

## Fix

Add a `@Transform` decorator that coerces empty/whitespace-only strings to \`undefined\`, so \`@IsOptional()\` correctly short-circuits the validation chain:

\`\`\`ts
@IsOptional()
@IsUrl({
  protocols: ['https'],
  require_protocol: true
})
@Transform(({ value }: TransformFnParams) =>
  isString(value) && value.trim() === '' ? undefined : value
)
url?: string;
\`\`\`

This matches the existing pattern used for \`comment\` in \`update-account.dto.ts\` (same \`isString(value)\` lodash check + \`Transform\` + \`TransformFnParams\` import shape). \`transform: true\` is already enabled in the global \`ValidationPipe\` (\`apps/api/src/main.ts\`), so the decorator runs on every request.

Whitespace-only inputs (e.g. \`\" \"\`) are also coerced to \`undefined\`, which prevents users from sneaking past the validator with a bogus space.

## Files changed

- \`libs/common/src/lib/dtos/update-asset-profile.dto.ts\` — fix + imports
- \`libs/common/src/lib/dtos/create-asset-profile.dto.ts\` — fix + imports
- \`CHANGELOG.md\` — added \`### Fixed\` entry under Unreleased

## Testing notes

Verified by syntactic match against the existing \`@Transform\` patterns in \`update-account.dto.ts:19-21\`, \`create-order.dto.ts:34\`, and \`update-order.dto.ts:33\` (all use the same \`isString(value)\` + \`TransformFnParams\` shape). The decorator runs before validation given \`transform: true\` in the global \`ValidationPipe\`.

Happy to add a unit test for the DTO if you'd like — let me know if there's a preferred location for DTO-level tests, I didn't see an existing pattern in `libs/common/src/lib/dtos/`.