### PR TITLE
Bugfix/reactivate auto calculate for retirement date and projected total amount in FIRE page

### DIFF
--- a/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
@@ -174,7 +174,7 @@ export class GfFirePageComponent implements OnInit {
     this.dataService
       .putUserSetting({
         projectedTotalAmount,
-        retirementDate: undefined
+        retirementDate: null
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
@@ -192,7 +192,7 @@ export class GfFirePageComponent implements OnInit {
   protected onRetirementDateChange(retirementDate: Date) {
     this.dataService
       .putUserSetting({
-        projectedTotalAmount: undefined,
+        projectedTotalAmount: null,
         retirementDate: retirementDate.toISOString()
       })
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/libs/common/src/lib/dtos/update-user-setting.dto.ts
+++ b/libs/common/src/lib/dtos/update-user-setting.dto.ts
@@ -96,13 +96,21 @@ export class UpdateUserSettingDto {
   @IsOptional()
   locale?: string;
 
+  /**
+   * The target financial amount the user aims to reach before retiring.
+   * Can be explicitly set to null to clear the value and calculate it dynamically.
+   */
   @IsNumber()
   @IsOptional()
-  projectedTotalAmount?: number;
+  projectedTotalAmount?: number | null;
 
+  /**
+   * The target date when the user plans to retire.
+   * Can be explicitly set to null to clear the value and calculate it dynamically.
+   */
   @IsISO8601()
   @IsOptional()
-  retirementDate?: string;
+  retirementDate?: string | null;
 
   @IsNumber()
   @IsOptional()


### PR DESCRIPTION
Hi @dtslvr, this PR is a bugfix for #6807. Please take a look :)

## Changes

- Changed `projectedTotalAmount` and `retirementDate` back to `null`.
- Updated `UpdateUserSettingDto` to support `null` type for both variables
- Added JSDoc documentation about the `null` behavior.

## Additional Context

Setting one of the fields as `null` is necessary because of the conditional statement to delete the field from the user settings, which is triggered when the field is `null` but not `undefined`:

https://github.com/ghostfolio/ghostfolio/blob/a04099b12d23e2cbf71274aadd2868ff6826cd32/apps/api/src/app/user/user.controller.ts#L183-L185

Therefore, we should modify the DTO to support `null` instead of changing the input to `undefined`.