### PR TITLE
Bugfix/improve typography for client app and charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harmonized the unit styling in the value component
 - Upgraded `stripe` from version `20.4.1` to `21.0.1`
 
+### Fixed
+
+- Resolved an issue where charts and components defaulted to _Roboto_ instead of the preconfigured _Inter_ font family
+
 ## 3.1.0 - 2026-04-29
 
 ### Added

--- a/apps/client/src/app/app.component.ts
+++ b/apps/client/src/app/app.component.ts
@@ -28,6 +28,7 @@ import {
   RouterOutlet
 } from '@angular/router';
 import { DataSource } from '@prisma/client';
+import { Chart } from 'chart.js';
 import { addIcons } from 'ionicons';
 import { openOutline } from 'ionicons/icons';
 import { DeviceDetectorService } from 'ngx-device-detector';
@@ -254,6 +255,9 @@ export class GfAppComponent implements OnInit {
       : window.matchMedia('(prefers-color-scheme: dark)').matches;
 
     this.toggleTheme(isDarkTheme);
+
+    // Default chart styles
+    Chart.defaults.font.family = getCssVariable('--font-family-sans-serif');
 
     window.matchMedia('(prefers-color-scheme: dark)').addListener((event) => {
       if (!this.user?.settings.colorScheme) {

--- a/apps/client/src/styles/theme.scss
+++ b/apps/client/src/styles/theme.scss
@@ -139,20 +139,28 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
 @include mat.elevation-classes();
 @include mat.table-density(-1);
 
-// $gf-typography: mat.m2-define-typography-config();
+$gf-typography: (
+  // Font families
+  brand-family: var(--font-family-sans-serif),
+  plain-family: var(--font-family-sans-serif),
+  // Font weights
+  bold-weight: 700,
+  medium-weight: 500,
+  regular-weight: 400
+);
 
 .theme-light {
   $gf-theme-default: mat.define-theme(
     (
       color: (
         primary: $_primary,
-        theme-type: light,
-        tertiary: $_tertiary
+        tertiary: $_tertiary,
+        theme-type: light
       ),
       density: (
         scale: -3
       ),
-      // typography: $gf-typography
+      typography: $gf-typography
     )
   );
 
@@ -229,13 +237,13 @@ $_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
     (
       color: (
         primary: $_primary,
-        theme-type: dark,
-        tertiary: $_tertiary
+        tertiary: $_tertiary,
+        theme-type: dark
       ),
       density: (
         scale: -3
       ),
-      // typography: $gf-typography
+      typography: $gf-typography
     )
   );
 


### PR DESCRIPTION
Hi @dtslvr, this is a bugfix for typography related to Material 3 upgrade in #6768.

## Changes

* Bring back typography config to `theme.scss`.
* Configure default font family for charts.

## Context

This change is made after I discovered that the fonts are mostly using "Roboto" instead of using our preconfigured CSS variable, which should point to "Inter" font.

<img width="1470" height="323" alt="Screenshot 2026-05-03 at 11 16 05" src="https://github.com/user-attachments/assets/98eb16cf-f08b-4922-8706-0fb77243cd57" />

###

However, as the method `mat.m2-define-typography-config()` is now deprecated, we should configure the typography config map manually following the guide here: https://material.angular.dev/guide/theming#typography-map.