### PR TITLE
Task/migrate the components from NgStyle to style bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Harmonized the unit styling in the value component
+- Migrated the components from `NgStyle` to style bindings
 - Upgraded `stripe` from version `20.4.1` to `21.0.1`
 
 ### Fixed

--- a/apps/client/src/app/components/benchmark-comparator/benchmark-comparator.component.html
+++ b/apps/client/src/app/components/benchmark-comparator/benchmark-comparator.component.html
@@ -53,6 +53,6 @@
   <canvas
     #chartCanvas
     class="h-100"
-    [ngStyle]="{ display: isLoading ? 'none' : 'block' }"
+    [style.display]="isLoading ? 'none' : 'block'"
   ></canvas>
 </div>

--- a/apps/client/src/app/components/investment-chart/investment-chart.component.html
+++ b/apps/client/src/app/components/investment-chart/investment-chart.component.html
@@ -10,5 +10,5 @@
 <canvas
   #chartCanvas
   class="h-100"
-  [ngStyle]="{ display: isLoading ? 'none' : 'block' }"
+  [style.display]="isLoading ? 'none' : 'block'"
 ></canvas>

--- a/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
@@ -12,7 +12,7 @@ import { GfPremiumIndicatorComponent } from '@ghostfolio/ui/premium-indicator';
 import { DataService } from '@ghostfolio/ui/services';
 import { GfValueComponent } from '@ghostfolio/ui/value';
 
-import { CommonModule, NgStyle } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
@@ -35,7 +35,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
     GfFireCalculatorComponent,
     GfPremiumIndicatorComponent,
     GfValueComponent,
-    NgStyle,
     NgxSkeletonLoaderModule,
     ReactiveFormsModule
   ],

--- a/apps/client/src/app/pages/portfolio/fire/fire-page.html
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.html
@@ -19,11 +19,10 @@
             !hasImpersonationId && hasPermissionToUpdateUserSettings
           "
           [locale]="user?.settings?.locale"
-          [ngStyle]="{
-            opacity: user?.subscription?.type === 'Basic' ? '0.67' : 'initial',
-            'pointer-events':
-              user?.subscription?.type === 'Basic' ? 'none' : 'initial'
-          }"
+          [style.opacity]="user?.subscription?.type === 'Basic' ? '0.67' : 'initial'"
+          [style.pointer-events]="
+            user?.subscription?.type === 'Basic' ? 'none' : 'initial'
+          "
           [projectedTotalAmount]="user?.settings?.projectedTotalAmount"
           [retirementDate]="user?.settings?.retirementDate"
           [savingsRate]="user?.settings?.savingsRate"

--- a/libs/ui/src/lib/fire-calculator/fire-calculator.component.html
+++ b/libs/ui/src/lib/fire-calculator/fire-calculator.component.html
@@ -81,7 +81,7 @@
         <canvas
           #chartCanvas
           class="h-100"
-          [ngStyle]="{ display: isLoading ? 'none' : 'block' }"
+          [style.display]="isLoading ? 'none' : 'block'"
         ></canvas>
       </div>
     </div>

--- a/libs/ui/src/lib/line-chart/line-chart.component.html
+++ b/libs/ui/src/lib/line-chart/line-chart.component.html
@@ -9,5 +9,5 @@
 }
 <canvas
   #chartCanvas
-  [ngStyle]="{ display: isLoading ? 'none' : 'block' }"
+  [style.display]="isLoading ? 'none' : 'block'"
 ></canvas>

--- a/libs/ui/src/lib/portfolio-proportion-chart/portfolio-proportion-chart.component.html
+++ b/libs/ui/src/lib/portfolio-proportion-chart/portfolio-proportion-chart.component.html
@@ -9,5 +9,5 @@
 }
 <canvas
   #chartCanvas
-  [ngStyle]="{ display: isLoading ? 'none' : 'block' }"
+  [style.display]="isLoading ? 'none' : 'block'"
 ></canvas>

--- a/libs/ui/src/lib/premium-indicator/premium-indicator.component.html
+++ b/libs/ui/src/lib/premium-indicator/premium-indicator.component.html
@@ -1,7 +1,7 @@
 <a
   class="align-items-center d-flex"
   title="Upgrade to Ghostfolio Premium"
-  [ngStyle]="{ 'pointer-events': enableLink ? 'initial' : 'none' }"
+  [style.pointer-events]="enableLink ? 'initial' : 'none'"
   [routerLink]="routerLinkPricing"
   ><ion-icon class="text-muted" name="diamond-outline"
 /></a>

--- a/libs/ui/src/lib/treemap-chart/treemap-chart.component.html
+++ b/libs/ui/src/lib/treemap-chart/treemap-chart.component.html
@@ -9,5 +9,5 @@
 }
 <canvas
   #chartCanvas
-  [ngStyle]="{ display: isLoading ? 'none' : 'block' }"
+  [style.display]="isLoading ? 'none' : 'block'"
 ></canvas>


### PR DESCRIPTION
## Summary

Migrates all 8 `[ngStyle]` template usages to native `[style.*]` bindings per the Angular schematic at https://angular.dev/reference/migrations/ngstyle-to-style.

## Files

- `apps/client/src/app/components/investment-chart/investment-chart.component.html`
- `apps/client/src/app/components/benchmark-comparator/benchmark-comparator.component.html`
- `apps/client/src/app/pages/portfolio/fire/fire-page.html`
- `apps/client/src/app/pages/portfolio/fire/fire-page.component.ts` -- drops the now-unused `NgStyle` import
- `libs/ui/src/lib/premium-indicator/premium-indicator.component.html`
- `libs/ui/src/lib/treemap-chart/treemap-chart.component.html`
- `libs/ui/src/lib/fire-calculator/fire-calculator.component.html`
- `libs/ui/src/lib/line-chart/line-chart.component.html`
- `libs/ui/src/lib/portfolio-proportion-chart/portfolio-proportion-chart.component.html`
- `CHANGELOG.md`

13 lines added, 14 removed.

## Patterns

Single-property (7 of 8 sites): `[ngStyle]="{ display: isLoading ? 'none' : 'block' }"` -> `[style.display]="isLoading ? 'none' : 'block'"`. Same for `pointer-events` on `premium-indicator`.

Multi-property (`fire-page.html`): the `opacity` + `pointer-events` block on `<gf-fire-calculator>` splits into two separate `[style.opacity]` / `[style.pointer-events]` attributes. The standalone `fire-page.component.ts` drops the now-unused `NgStyle` from its `imports` array and the `@angular/common` import.

## Verification

- `grep -rn "ngStyle\\|NgStyle" apps/ libs/` -> 0 hits.
- All 8 templates render the same DOM and bind to the same expressions.

Closes #6816

This contribution was developed with AI assistance.