### PR TITLE
Bugfix/remove bottom border in mobile navbar container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a visual regression in the bottom navigation bar on mobile
+
 ## 3.2.0 - 2026-05-03
 
 ### Added

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -520,14 +520,14 @@ ngx-skeleton-loader {
       padding: 2rem 0;
     }
 
+    @include mat.tabs-overrides(
+      (
+        divider-height: 0
+      )
+    );
+
     @media (min-width: 576px) {
       flex-direction: row-reverse;
-
-      @include mat.tabs-overrides(
-        (
-          divider-height: 0
-        )
-      );
 
       .mat-mdc-tab-header {
         background-color: rgba(var(--palette-foreground-base), 0.02);


### PR DESCRIPTION
Hi @dtslvr, this is a bugfix for bottom border of mobile navbar related to Material 3 upgrade in #6768.

## Changes

* Moved the `tabs-overrides` configuration outside of the desktop-only media query in `styles.scss` to apply it globally for pages with tabs.

## Context

This PR addresses a minor UI issue where a divider line (which was not there in Ghostfolio v2) was appearing below the bottom navigation bar on mobile devices. 

In Angular Material, the `mat-tab-nav-bar` includes a divider line by default. Previously, the override to remove this divider (`divider-height: 0`) was scoped inside a `@media (min-width: 576px)` query, meaning it only successfully hid the line on desktop screens. 

By moving the `@include mat.tabs-overrides` outside of the media query, the divider is now hidden globally, cleaning up the UI for the mobile bottom tab bar.

<img width="517" height="158" alt="Screenshot 2026-05-04 at 03 20 25" src="https://github.com/user-attachments/assets/72ecbe76-1170-46a1-b1c4-84bfa62c03f4" />

## UI Impact

* **Before:** Mobile bottom navbar rendered with a thin separator line directly underneath the icons.
* **After:** Separator line is removed, resulting in a much cleaner bottom navigation experience on mobile.