### PR TITLE
fix(activities): preserve existing symbol when cloning a manual asset activity 

### DIFF
--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -500,11 +500,7 @@ export class GfCreateOrUpdateActivityDialogComponent {
       fee: this.activityForm.get('fee')?.value,
       quantity: this.activityForm.get('quantity')?.value,
       symbol:
-        (['FEE', 'INTEREST', 'LIABILITY', 'VALUABLE'].includes(
-          this.activityForm.get('type')?.value
-        )
-          ? undefined
-          : this.activityForm.get('searchSymbol')?.value?.symbol) ??
+        this.activityForm.get('searchSymbol')?.value?.symbol ??
         this.activityForm.get('name')?.value,
       tags: this.activityForm.get('tags')?.value?.map(({ id }) => {
         return id;


### PR DESCRIPTION
fix: preserve existing symbol when cloning a manual asset activity

Update create-or-update-activity-dialog.component.ts

When cloning an activity linked to a manual asset (VALUABLE, FEE, INTEREST, LIABILITY), the symbol field in onSubmit() was explicitly set to undefined for these types, causing the backend to generate a new UUID and create a duplicate SymbolProfile instead of reusing the existing one.

Simplify the symbol assignment to always prefer searchSymbol.value.symbol (which correctly holds the existing asset's identifier when cloning) and fall back to name.value only when no symbol exists (i.e. when creating a brand-new manual asset).

Fixes #5324