### PR TITLE
Bugfix/account cash balance calculation for SELL activities with fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the cash balance computation for `SELL` activities to subtract the fee instead of adding it (the previous logic inflated the account's cash balance by twice the fee)
+
 ## 3.3.0 - 2026-05-14
 
 ### Added

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -214,19 +214,18 @@ export class ActivitiesService {
     });
 
     if (updateAccountBalance === true) {
-      let amount = new Big(data.unitPrice).mul(data.quantity).toNumber();
+      let amount = new Big(data.unitPrice).mul(data.quantity);
 
       if (['BUY', 'FEE'].includes(data.type)) {
-        amount = new Big(amount).mul(-1).toNumber();
+        amount = amount.mul(-1);
       }
 
-      // Fees always reduce cash regardless of the activity direction
-      amount = new Big(amount).minus(data.fee).toNumber();
+      amount = amount.minus(data.fee);
 
       await this.accountService.updateAccountBalance({
         accountId,
-        amount,
         userId,
+        amount: amount.toNumber(),
         currency: data.SymbolProfile.connectOrCreate.create.currency,
         date: data.date as Date
       });

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -214,14 +214,14 @@ export class ActivitiesService {
     });
 
     if (updateAccountBalance === true) {
-      let amount = new Big(data.unitPrice)
-        .mul(data.quantity)
-        .plus(data.fee)
-        .toNumber();
+      let amount = new Big(data.unitPrice).mul(data.quantity).toNumber();
 
       if (['BUY', 'FEE'].includes(data.type)) {
         amount = new Big(amount).mul(-1).toNumber();
       }
+
+      // Fees always reduce cash regardless of the activity direction
+      amount = new Big(amount).minus(data.fee).toNumber();
 
       await this.accountService.updateAccountBalance({
         accountId,


### PR DESCRIPTION
## Description

When a `SELL` activity is created with a non-zero fee, the cash balance on the account is credited by `(quantity * unitPrice) + fee` instead of `(quantity * unitPrice) - fee`. The fee sign is flipped, inflating the cash balance by exactly `2 * fee`.

The previous logic in `ActivitiesService.createActivity` added the fee to the gross magnitude, then negated the entire amount only for `BUY`/`FEE`. For `SELL` (and `DIVIDEND`/`INTEREST`/`LIABILITY` activities that carry a fee), the cash impact ended up as `+gross + fee` instead of `+gross - fee`.

## Reproduction (before fix)

1. Create an account with seed balance `1000`.
2. Add `BUY 10 × 50` (gross `500`, fee `0`). Cash → `500`. ✓
3. Add `SELL 10 × 60` (gross `600`, fee `5`).
   - **Expected:** cash = `500 + (600 - 5) = 1095`
   - **Actual:** cash = `1106` (= `500 + 600 + 5`)

## Fix

Compute the signed gross amount first (negate for `BUY`/`FEE`), then subtract the fee unconditionally:

```ts
let amount = new Big(data.unitPrice).mul(data.quantity).toNumber();

if (['BUY', 'FEE'].includes(data.type)) {
  amount = new Big(amount).mul(-1).toNumber();
}

// Fees always reduce cash regardless of the activity direction
amount = new Big(amount).minus(data.fee).toNumber();
```

This treats fees consistently across all activity types: they reduce cash, regardless of whether the activity is an inflow (`SELL`/`DIVIDEND`/`INTEREST`) or an outflow (`BUY`).

## Real-world impact

In a personal installation on v3.2.0, a `SELL` of 1,700 shares × 34.00 with fee 228.31 credited 58,028.31 to cash instead of 57,571.69 — an inflation of exactly `2 × 228.31 = 456.62`.

## Notes

- No new test added because there is no existing `activities.service.spec.ts`. Happy to add one in a follow-up if maintainers prefer; this PR keeps the change minimal.
- `FEE` activities still behave correctly because their `unitPrice × quantity` is typically `0`, so the signed gross is `0` and the cash impact reduces only by `data.fee`.