### PR TITLE
fix: internal getActivities callers missing take parameter

### DIFF
--- a/apps/api/src/app/activities/activities.controller.ts
+++ b/apps/api/src/app/activities/activities.controller.ts
@@ -177,6 +177,7 @@ export class ActivitiesController {
 
     const { activities } = await this.activitiesService.getActivities({
       userCurrency,
+      take: Number.MAX_SAFE_INTEGER,
       includeDrafts: true,
       userId: impersonationUserId || this.request.user.id,
       withExcludedAccountsAndActivities: true

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -288,6 +288,7 @@ export class ActivitiesService {
       filters,
       userId,
       includeDrafts: true,
+      take: Number.MAX_SAFE_INTEGER,
       userCurrency: undefined,
       withExcludedAccountsAndActivities: true
     });
@@ -470,7 +471,7 @@ export class ActivitiesService {
     sortColumn,
     sortDirection = 'asc',
     startDate,
-    take = Number.MAX_SAFE_INTEGER,
+    take = 100,
     types,
     userCurrency,
     userId,
@@ -766,6 +767,7 @@ export class ActivitiesService {
   }) {
     const activities = await this.getActivities({
       filters,
+      take: Number.MAX_SAFE_INTEGER,
       userCurrency,
       userId,
       withExcludedAccountsAndActivities: false // TODO

--- a/apps/api/src/app/export/export.service.ts
+++ b/apps/api/src/app/export/export.service.ts
@@ -46,6 +46,7 @@ export class ExportService {
       includeDrafts: true,
       sortColumn: 'date',
       sortDirection: 'asc',
+      take: Number.MAX_SAFE_INTEGER,
       types: activityTypes,
       userCurrency: userSettings?.baseCurrency,
       withExcludedAccountsAndActivities: true

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -95,7 +95,8 @@ export class ImportService {
             filters,
             userCurrency,
             userId,
-            startDate: parseDate(dateOfFirstActivity)
+            startDate: parseDate(dateOfFirstActivity),
+            take: Number.MAX_SAFE_INTEGER
           }),
           this.symbolProfileService.getSymbolProfiles([
             {
@@ -649,7 +650,8 @@ export class ImportService {
         userCurrency,
         userId,
         includeDrafts: true,
-        withExcludedAccountsAndActivities: true
+        withExcludedAccountsAndActivities: true,
+        take: Number.MAX_SAFE_INTEGER
       });
 
     return activitiesDto.map(

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -328,6 +328,7 @@ export class PortfolioController {
       endDate,
       filters,
       startDate,
+      take: Number.MAX_SAFE_INTEGER,
       userCurrency,
       userId: impersonationUserId || this.request.user.id,
       types: ['DIVIDEND']

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -1904,6 +1904,7 @@ export class PortfolioService {
     const user = await this.userService.user({ id: userId });
 
     const { activities } = await this.activitiesService.getActivities({
+      take: Number.MAX_SAFE_INTEGER,
       userCurrency,
       userId,
       withExcludedAccountsAndActivities: true


### PR DESCRIPTION
## Summary
* The recent change to add a default `take: 100` limit to `getActivities` missed some internal callers.
* Added `take: Number.MAX_SAFE_INTEGER` to `export.service.ts` to ensure exports include all activities, rather than being truncated to 100.
* Added `take: Number.MAX_SAFE_INTEGER` to `import.service.ts` so duplicate activity checks correctly validate against the entire portfolio instead of just the oldest 100 activities.