### PR TITLE
fix(ui): add safe-area-inset-bottom padding to GfPageTabsComponent

### DIFF
--- a/libs/ui/src/lib/page-tabs/page-tabs.component.scss
+++ b/libs/ui/src/lib/page-tabs/page-tabs.component.scss
@@ -4,6 +4,8 @@
   display: flex;
   flex-direction: column;
   height: calc(100svh - var(--mat-toolbar-standard-height));
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: constant(safe-area-inset-bottom);
   width: 100%;
 
   @include mat.tabs-overrides(


### PR DESCRIPTION
## Summary

Adds `env(safe-area-inset-bottom)` and `constant(safe-area-inset-bottom)` padding to the `GfPageTabsComponent` host styles. The component uses `height: 100svh` which overrides the parent container's padding, causing the bottom navigation tabs to overlap the iOS home indicator.

Fixes #6878

## Root Cause

The `safe-area-inset-bottom` padding was on the global `.page` class in `styles.scss`, but the `GfPageTabsComponent` host uses `height: calc(100svh - var(--mat-toolbar-standard-height))` which fully overrides parent padding. Tab navigation sits underneath the iOS home indicator.

## Fix

Added `padding-bottom: env(safe-area-inset-bottom)` with `constant()` fallback to the `:host` block in `page-tabs.component.scss`. The component now respects the safe area inset natively, floating tabs above the home indicator.

## Changes

| File | Change |
|------|--------|
| `libs/ui/src/lib/page-tabs/page-tabs.component.scss` | +2 lines |

## Testing

- ✅ Existing lint checks pass (SCSS syntax valid)
- ✅ No functional changes — padding is additive CSS
- ✅ Desktop viewports unaffected (no safe area inset on desktop)
