### PR TITLE
Task/improve type safety for admin platform component

### DIFF
--- a/apps/client/src/app/components/admin-platform/admin-platform.component.html
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.html
@@ -54,7 +54,7 @@
     <td *matCellDef="let element" class="px-1 text-right" mat-cell>
       <gf-value
         class="d-inline-block justify-content-end"
-        [locale]="locale"
+        [locale]="locale()"
         [value]="element.accountCount"
       />
     </td>

--- a/apps/client/src/app/components/admin-platform/admin-platform.component.ts
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.ts
@@ -15,7 +15,7 @@ import {
   inject,
   Input,
   OnInit,
-  ViewChild
+  viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
@@ -57,12 +57,12 @@ import { CreateOrUpdatePlatformDialogParams } from './create-or-update-platform-
 export class GfAdminPlatformComponent implements OnInit {
   @Input() locale = getLocale();
 
-  @ViewChild(MatSort) sort: MatSort;
-
   public dataSource = new MatTableDataSource<Platform>();
   public deviceType: string;
   public displayedColumns = ['name', 'url', 'accounts', 'actions'];
   public platforms: Platform[];
+
+  private readonly sort = viewChild.required(MatSort);
 
   private readonly adminService = inject(AdminService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
@@ -145,7 +145,7 @@ export class GfAdminPlatformComponent implements OnInit {
         this.platforms = platforms;
 
         this.dataSource = new MatTableDataSource(platforms);
-        this.dataSource.sort = this.sort;
+        this.dataSource.sort = this.sort();
         this.dataSource.sortingDataAccessor = get;
 
         this.dataService.updateInfo();

--- a/apps/client/src/app/components/admin-platform/admin-platform.component.ts
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.ts
@@ -86,7 +86,9 @@ export class GfAdminPlatformComponent implements OnInit {
               return id === params['platformId'];
             });
 
-            this.openUpdatePlatformDialog(platform);
+            if (platform) {
+              this.openUpdatePlatformDialog(platform);
+            }
           } else {
             this.router.navigate(['.'], { relativeTo: this.route });
           }
@@ -156,13 +158,7 @@ export class GfAdminPlatformComponent implements OnInit {
       GfCreateOrUpdatePlatformDialogComponent,
       CreateOrUpdatePlatformDialogParams
     >(GfCreateOrUpdatePlatformDialogComponent, {
-      data: {
-        platform: {
-          id: null,
-          name: null,
-          url: null
-        }
-      },
+      data: {} satisfies CreateOrUpdatePlatformDialogParams,
       height: this.deviceType === 'mobile' ? '98vh' : undefined,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'
     });
@@ -191,15 +187,7 @@ export class GfAdminPlatformComponent implements OnInit {
       });
   }
 
-  private openUpdatePlatformDialog({
-    id,
-    name,
-    url
-  }: {
-    id: string;
-    name: string;
-    url: string;
-  }) {
+  private openUpdatePlatformDialog({ id, name, url }: Platform) {
     const dialogRef = this.dialog.open<
       GfCreateOrUpdatePlatformDialogComponent,
       CreateOrUpdatePlatformDialogParams
@@ -210,7 +198,7 @@ export class GfAdminPlatformComponent implements OnInit {
           name,
           url
         }
-      },
+      } satisfies CreateOrUpdatePlatformDialogParams,
       height: this.deviceType === 'mobile' ? '98vh' : undefined,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'
     });

--- a/apps/client/src/app/components/admin-platform/admin-platform.component.ts
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.ts
@@ -12,6 +12,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  inject,
   Input,
   OnInit,
   ViewChild
@@ -63,18 +64,18 @@ export class GfAdminPlatformComponent implements OnInit {
   public displayedColumns = ['name', 'url', 'accounts', 'actions'];
   public platforms: Platform[];
 
-  public constructor(
-    private adminService: AdminService,
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private deviceDetectorService: DeviceDetectorService,
-    private dialog: MatDialog,
-    private notificationService: NotificationService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService
-  ) {
+  private readonly adminService = inject(AdminService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly dialog = inject(MatDialog);
+  private readonly notificationService = inject(NotificationService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
     this.route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((params) => {

--- a/apps/client/src/app/components/admin-platform/admin-platform.component.ts
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.ts
@@ -58,10 +58,9 @@ import { CreateOrUpdatePlatformDialogParams } from './create-or-update-platform-
 export class GfAdminPlatformComponent implements OnInit {
   @Input() locale = getLocale();
 
-  public dataSource = new MatTableDataSource<Platform>();
-  public platforms: Platform[];
-
+  protected dataSource = new MatTableDataSource<Platform>();
   protected readonly displayedColumns = ['name', 'url', 'accounts', 'actions'];
+  protected platforms: Platform[];
 
   private readonly deviceType = computed(
     () => this.deviceDetectorService.deviceInfo().deviceType
@@ -107,7 +106,7 @@ export class GfAdminPlatformComponent implements OnInit {
     this.fetchPlatforms();
   }
 
-  public onDeletePlatform(aId: string) {
+  protected onDeletePlatform(aId: string) {
     this.notificationService.confirm({
       confirmFn: () => {
         this.deletePlatform(aId);
@@ -117,7 +116,7 @@ export class GfAdminPlatformComponent implements OnInit {
     });
   }
 
-  public onUpdatePlatform({ id }: Platform) {
+  protected onUpdatePlatform({ id }: Platform) {
     this.router.navigate([], {
       queryParams: { editPlatformDialog: true, platformId: id }
     });

--- a/apps/client/src/app/components/admin-platform/admin-platform.component.ts
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   DestroyRef,
   inject,
   Input,
@@ -58,10 +59,13 @@ export class GfAdminPlatformComponent implements OnInit {
   @Input() locale = getLocale();
 
   public dataSource = new MatTableDataSource<Platform>();
-  public deviceType: string;
-  public displayedColumns = ['name', 'url', 'accounts', 'actions'];
   public platforms: Platform[];
 
+  protected readonly displayedColumns = ['name', 'url', 'accounts', 'actions'];
+
+  private readonly deviceType = computed(
+    () => this.deviceDetectorService.deviceInfo().deviceType
+  );
   private readonly sort = viewChild.required(MatSort);
 
   private readonly adminService = inject(AdminService);
@@ -100,8 +104,6 @@ export class GfAdminPlatformComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.deviceType = this.deviceDetectorService.getDeviceInfo().deviceType;
-
     this.fetchPlatforms();
   }
 
@@ -160,8 +162,8 @@ export class GfAdminPlatformComponent implements OnInit {
       CreateOrUpdatePlatformDialogParams
     >(GfCreateOrUpdatePlatformDialogComponent, {
       data: {} satisfies CreateOrUpdatePlatformDialogParams,
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+      height: this.deviceType() === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
     });
 
     dialogRef
@@ -200,8 +202,8 @@ export class GfAdminPlatformComponent implements OnInit {
           url
         }
       } satisfies CreateOrUpdatePlatformDialogParams,
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+      height: this.deviceType() === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
     });
 
     dialogRef

--- a/apps/client/src/app/components/admin-platform/admin-platform.component.ts
+++ b/apps/client/src/app/components/admin-platform/admin-platform.component.ts
@@ -14,7 +14,7 @@ import {
   computed,
   DestroyRef,
   inject,
-  Input,
+  input,
   OnInit,
   viewChild
 } from '@angular/core';
@@ -56,7 +56,7 @@ import { CreateOrUpdatePlatformDialogParams } from './create-or-update-platform-
   templateUrl: './admin-platform.component.html'
 })
 export class GfAdminPlatformComponent implements OnInit {
-  @Input() locale = getLocale();
+  public readonly locale = input(getLocale());
 
   protected dataSource = new MatTableDataSource<Platform>();
   protected readonly displayedColumns = ['name', 'url', 'accounts', 'actions'];

--- a/apps/client/src/app/components/admin-platform/create-or-update-platform-dialog/create-or-update-platform-dialog.component.ts
+++ b/apps/client/src/app/components/admin-platform/create-or-update-platform-dialog/create-or-update-platform-dialog.component.ts
@@ -46,8 +46,8 @@ export class GfCreateOrUpdatePlatformDialogComponent {
     private formBuilder: FormBuilder
   ) {
     this.platformForm = this.formBuilder.group({
-      name: [this.data.platform.name, Validators.required],
-      url: [this.data.platform.url ?? 'https://', Validators.required]
+      name: [this.data.platform?.name, Validators.required],
+      url: [this.data.platform?.url ?? 'https://', Validators.required]
     });
   }
 
@@ -62,7 +62,7 @@ export class GfCreateOrUpdatePlatformDialogComponent {
         url: this.platformForm.get('url')?.value
       };
 
-      if (this.data.platform.id) {
+      if (this.data.platform?.id) {
         (platform as UpdatePlatformDto).id = this.data.platform.id;
         await validateObjectForForm({
           classDto: UpdatePlatformDto,

--- a/apps/client/src/app/components/admin-platform/create-or-update-platform-dialog/create-or-update-platform-dialog.html
+++ b/apps/client/src/app/components/admin-platform/create-or-update-platform-dialog/create-or-update-platform-dialog.html
@@ -4,7 +4,7 @@
   (keyup.enter)="platformForm.valid && onSubmit()"
   (ngSubmit)="onSubmit()"
 >
-  @if (data.platform.id) {
+  @if (data.platform?.id) {
     <h1 i18n mat-dialog-title>Update platform</h1>
   } @else {
     <h1 i18n mat-dialog-title>Add platform</h1>

--- a/apps/client/src/app/components/admin-platform/create-or-update-platform-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/components/admin-platform/create-or-update-platform-dialog/interfaces/interfaces.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@prisma/client';
 
 export interface CreateOrUpdatePlatformDialogParams {
-  platform: Platform;
+  platform?: Platform;
 }


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- Resolve errors.
- Made `platform` as optional in `CreateOrUpdatePlatformDialogParams` to cover for platform creation use case.
- Tightened up encapsulation and immutability.
- Replaced constructor-based dependency injection with `inject` function.
- Replaced deprecated `getDeviceInfo()` method.
- Implemented view child and input signals.

## Resolved type errors

2 errors (before: 126, after: 124).