### PR TITLE
Task/improve type safety for admin tag component

### DIFF
--- a/apps/client/src/app/components/admin-tag/admin-tag.component.html
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.html
@@ -47,7 +47,7 @@
     <td *matCellDef="let element" class="px-1 text-right" mat-cell>
       <gf-value
         class="d-inline-block justify-content-end"
-        [locale]="locale"
+        [locale]="locale()"
         [value]="element.activityCount"
       />
     </td>

--- a/apps/client/src/app/components/admin-tag/admin-tag.component.ts
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.ts
@@ -13,7 +13,7 @@ import {
   computed,
   DestroyRef,
   inject,
-  Input,
+  input,
   OnInit,
   viewChild
 } from '@angular/core';
@@ -54,7 +54,7 @@ import { CreateOrUpdateTagDialogParams } from './create-or-update-tag-dialog/int
   templateUrl: './admin-tag.component.html'
 })
 export class GfAdminTagComponent implements OnInit {
-  @Input() locale = getLocale();
+  public readonly locale = input(getLocale());
 
   public dataSource = new MatTableDataSource<Tag>();
   public displayedColumns = ['name', 'userId', 'activities', 'actions'];

--- a/apps/client/src/app/components/admin-tag/admin-tag.component.ts
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.ts
@@ -14,7 +14,7 @@ import {
   inject,
   Input,
   OnInit,
-  ViewChild
+  viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
@@ -55,12 +55,12 @@ import { CreateOrUpdateTagDialogParams } from './create-or-update-tag-dialog/int
 export class GfAdminTagComponent implements OnInit {
   @Input() locale = getLocale();
 
-  @ViewChild(MatSort) sort: MatSort;
-
   public dataSource = new MatTableDataSource<Tag>();
   public deviceType: string;
   public displayedColumns = ['name', 'userId', 'activities', 'actions'];
   public tags: Tag[];
+
+  private readonly sort = viewChild.required(MatSort);
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly dataService = inject(DataService);
@@ -142,7 +142,7 @@ export class GfAdminTagComponent implements OnInit {
         this.tags = tags;
 
         this.dataSource = new MatTableDataSource(this.tags);
-        this.dataSource.sort = this.sort;
+        this.dataSource.sort = this.sort();
         this.dataSource.sortingDataAccessor = get;
 
         this.dataService.updateInfo();

--- a/apps/client/src/app/components/admin-tag/admin-tag.component.ts
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.ts
@@ -83,7 +83,9 @@ export class GfAdminTagComponent implements OnInit {
               return id === params['tagId'];
             });
 
-            this.openUpdateTagDialog(tag);
+            if (tag) {
+              this.openUpdateTagDialog(tag);
+            }
           } else {
             this.router.navigate(['.'], { relativeTo: this.route });
           }
@@ -153,12 +155,7 @@ export class GfAdminTagComponent implements OnInit {
       GfCreateOrUpdateTagDialogComponent,
       CreateOrUpdateTagDialogParams
     >(GfCreateOrUpdateTagDialogComponent, {
-      data: {
-        tag: {
-          id: null,
-          name: null
-        }
-      },
+      data: {} satisfies CreateOrUpdateTagDialogParams,
       height: this.deviceType === 'mobile' ? '98vh' : undefined,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'
     });
@@ -197,7 +194,7 @@ export class GfAdminTagComponent implements OnInit {
           id,
           name
         }
-      },
+      } satisfies CreateOrUpdateTagDialogParams,
       height: this.deviceType === 'mobile' ? '98vh' : undefined,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'
     });

--- a/apps/client/src/app/components/admin-tag/admin-tag.component.ts
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  inject,
   Input,
   OnInit,
   ViewChild
@@ -61,17 +62,17 @@ export class GfAdminTagComponent implements OnInit {
   public displayedColumns = ['name', 'userId', 'activities', 'actions'];
   public tags: Tag[];
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private deviceDetectorService: DeviceDetectorService,
-    private dialog: MatDialog,
-    private notificationService: NotificationService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService
-  ) {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly dialog = inject(MatDialog);
+  private readonly notificationService = inject(NotificationService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
     this.route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((params) => {

--- a/apps/client/src/app/components/admin-tag/admin-tag.component.ts
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.ts
@@ -10,6 +10,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   DestroyRef,
   inject,
   Input,
@@ -56,10 +57,12 @@ export class GfAdminTagComponent implements OnInit {
   @Input() locale = getLocale();
 
   public dataSource = new MatTableDataSource<Tag>();
-  public deviceType: string;
   public displayedColumns = ['name', 'userId', 'activities', 'actions'];
   public tags: Tag[];
 
+  private readonly deviceType = computed(
+    () => this.deviceDetectorService.deviceInfo().deviceType
+  );
   private readonly sort = viewChild.required(MatSort);
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
@@ -97,8 +100,6 @@ export class GfAdminTagComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.deviceType = this.deviceDetectorService.getDeviceInfo().deviceType;
-
     this.fetchTags();
   }
 
@@ -157,8 +158,8 @@ export class GfAdminTagComponent implements OnInit {
       CreateOrUpdateTagDialogParams
     >(GfCreateOrUpdateTagDialogComponent, {
       data: {} satisfies CreateOrUpdateTagDialogParams,
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+      height: this.deviceType() === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
     });
 
     dialogRef
@@ -196,8 +197,8 @@ export class GfAdminTagComponent implements OnInit {
           name
         }
       } satisfies CreateOrUpdateTagDialogParams,
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+      height: this.deviceType() === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
     });
 
     dialogRef

--- a/apps/client/src/app/components/admin-tag/admin-tag.component.ts
+++ b/apps/client/src/app/components/admin-tag/admin-tag.component.ts
@@ -56,9 +56,14 @@ import { CreateOrUpdateTagDialogParams } from './create-or-update-tag-dialog/int
 export class GfAdminTagComponent implements OnInit {
   public readonly locale = input(getLocale());
 
-  public dataSource = new MatTableDataSource<Tag>();
-  public displayedColumns = ['name', 'userId', 'activities', 'actions'];
-  public tags: Tag[];
+  protected dataSource = new MatTableDataSource<Tag>();
+  protected readonly displayedColumns = [
+    'name',
+    'userId',
+    'activities',
+    'actions'
+  ];
+  protected tags: Tag[];
 
   private readonly deviceType = computed(
     () => this.deviceDetectorService.deviceInfo().deviceType
@@ -103,7 +108,7 @@ export class GfAdminTagComponent implements OnInit {
     this.fetchTags();
   }
 
-  public onDeleteTag(aId: string) {
+  protected onDeleteTag(aId: string) {
     this.notificationService.confirm({
       confirmFn: () => {
         this.deleteTag(aId);
@@ -113,7 +118,7 @@ export class GfAdminTagComponent implements OnInit {
     });
   }
 
-  public onUpdateTag({ id }: Tag) {
+  protected onUpdateTag({ id }: Tag) {
     this.router.navigate([], {
       queryParams: { editTagDialog: true, tagId: id }
     });

--- a/apps/client/src/app/components/admin-tag/create-or-update-tag-dialog/create-or-update-tag-dialog.component.ts
+++ b/apps/client/src/app/components/admin-tag/create-or-update-tag-dialog/create-or-update-tag-dialog.component.ts
@@ -43,7 +43,7 @@ export class GfCreateOrUpdateTagDialogComponent {
     private formBuilder: FormBuilder
   ) {
     this.tagForm = this.formBuilder.group({
-      name: [this.data.tag.name]
+      name: [this.data.tag?.name]
     });
   }
 
@@ -57,7 +57,7 @@ export class GfCreateOrUpdateTagDialogComponent {
         name: this.tagForm.get('name')?.value
       };
 
-      if (this.data.tag.id) {
+      if (this.data.tag?.id) {
         (tag as UpdateTagDto).id = this.data.tag.id;
         await validateObjectForForm({
           classDto: UpdateTagDto,

--- a/apps/client/src/app/components/admin-tag/create-or-update-tag-dialog/create-or-update-tag-dialog.html
+++ b/apps/client/src/app/components/admin-tag/create-or-update-tag-dialog/create-or-update-tag-dialog.html
@@ -4,7 +4,7 @@
   (keyup.enter)="tagForm.valid && onSubmit()"
   (ngSubmit)="onSubmit()"
 >
-  @if (data.tag.id) {
+  @if (data.tag?.id) {
     <h1 i18n mat-dialog-title>Update tag</h1>
   } @else {
     <h1 i18n mat-dialog-title>Add tag</h1>

--- a/apps/client/src/app/components/admin-tag/create-or-update-tag-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/components/admin-tag/create-or-update-tag-dialog/interfaces/interfaces.ts
@@ -1,5 +1,5 @@
 import { Tag } from '@prisma/client';
 
 export interface CreateOrUpdateTagDialogParams {
-  tag: Pick<Tag, 'id' | 'name'>;
+  tag?: Pick<Tag, 'id' | 'name'>;
 }


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- Resolve errors.
- Made `tag` as optional in `CreateOrUpdateTagDialogParams` to cover for tag creation use case.
- Tightened up encapsulation and immutability.
- Replaced constructor-based dependency injection with `inject` function.
- Replaced deprecated `getDeviceInfo()` method.
- Implemented view child and input signals.

## Resolved type errors

2 errors (before: 126, after: 124).