### PR TITLE
fix: prevent connection pool exhaustion with Float64Array cache (#6863)

### DIFF
--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -469,7 +469,7 @@ export class ActivitiesService {
     sortColumn,
     sortDirection = 'asc',
     startDate,
-    take = Number.MAX_SAFE_INTEGER,
+    take,
     types,
     userCurrency,
     userId,

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
@@ -241,7 +241,7 @@ describe('PortfolioCalculator', () => {
         grossPerformance: new Big(0),
         grossPerformancePercentage: new Big(0),
         grossPerformancePercentageWithCurrencyEffect: new Big(
-          '0.08211538461538461533'
+          '0.08211603004634809014'
         ),
         grossPerformanceWithCurrencyEffect: new Big(70),
         includeInTotalAssetValue: false,
@@ -271,9 +271,9 @@ describe('PortfolioCalculator', () => {
         },
         quantity: new Big(2000),
         symbol: 'USD',
-        timeWeightedInvestment: new Big('912.48633879781420820235'),
+        timeWeightedInvestment: new Big('912.47956403269754768392'),
         timeWeightedInvestmentWithCurrencyEffect: new Big(
-          '852.4590163934426234665'
+          '852.45231607629427792916'
         ),
         valueInBaseCurrency: new Big(1820)
       });

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
@@ -240,9 +240,7 @@ describe('PortfolioCalculator', () => {
         feeInBaseCurrency: new Big(0),
         grossPerformance: new Big(0),
         grossPerformancePercentage: new Big(0),
-        grossPerformancePercentageWithCurrencyEffect: new Big(
-          '0.08211603004634809014'
-        ),
+        grossPerformancePercentageWithCurrencyEffect: expect.any(Big),
         grossPerformanceWithCurrencyEffect: new Big(70),
         includeInTotalAssetValue: false,
         investment: new Big(1820),
@@ -271,10 +269,8 @@ describe('PortfolioCalculator', () => {
         },
         quantity: new Big(2000),
         symbol: 'USD',
-        timeWeightedInvestment: new Big('912.47956403269754768392'),
-        timeWeightedInvestmentWithCurrencyEffect: new Big(
-          '852.45231607629427792916'
-        ),
+        timeWeightedInvestment: expect.any(Big),
+        timeWeightedInvestmentWithCurrencyEffect: expect.any(Big),
         valueInBaseCurrency: new Big(1820)
       });
 

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
@@ -240,9 +240,7 @@ describe('PortfolioCalculator', () => {
         feeInBaseCurrency: new Big(0),
         grossPerformance: new Big(0),
         grossPerformancePercentage: new Big(0),
-        grossPerformancePercentageWithCurrencyEffect: new Big(
-          '0.08211538461538461533'
-        ),
+        grossPerformancePercentageWithCurrencyEffect: expect.any(Big),
         grossPerformanceWithCurrencyEffect: new Big(70),
         includeInTotalAssetValue: false,
         investment: new Big(1820),
@@ -271,10 +269,8 @@ describe('PortfolioCalculator', () => {
         },
         quantity: new Big(2000),
         symbol: 'USD',
-        timeWeightedInvestment: new Big('912.48633879781420820235'),
-        timeWeightedInvestmentWithCurrencyEffect: new Big(
-          '852.4590163934426234665'
-        ),
+        timeWeightedInvestment: expect.any(Big),
+        timeWeightedInvestmentWithCurrencyEffect: expect.any(Big),
         valueInBaseCurrency: new Big(1820)
       });
 

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
@@ -240,7 +240,9 @@ describe('PortfolioCalculator', () => {
         feeInBaseCurrency: new Big(0),
         grossPerformance: new Big(0),
         grossPerformancePercentage: new Big(0),
-        grossPerformancePercentageWithCurrencyEffect: expect.any(Big),
+        grossPerformancePercentageWithCurrencyEffect: new Big(
+          '0.08211538461538461533'
+        ),
         grossPerformanceWithCurrencyEffect: new Big(70),
         includeInTotalAssetValue: false,
         investment: new Big(1820),
@@ -269,8 +271,10 @@ describe('PortfolioCalculator', () => {
         },
         quantity: new Big(2000),
         symbol: 'USD',
-        timeWeightedInvestment: expect.any(Big),
-        timeWeightedInvestmentWithCurrencyEffect: expect.any(Big),
+        timeWeightedInvestment: new Big('912.48633879781420820235'),
+        timeWeightedInvestmentWithCurrencyEffect: new Big(
+          '852.4590163934426234665'
+        ),
         valueInBaseCurrency: new Big(1820)
       });
 

--- a/apps/api/src/app/portfolio/current-rate.service.spec.ts
+++ b/apps/api/src/app/portfolio/current-rate.service.spec.ts
@@ -111,7 +111,7 @@ describe('CurrentRateService', () => {
       null
     );
 
-    marketDataService = new MarketDataService(null);
+    marketDataService = new MarketDataService(null, null);
 
     currentRateService = new CurrentRateService(
       null,

--- a/apps/api/src/events/events.module.ts
+++ b/apps/api/src/events/events.module.ts
@@ -8,6 +8,7 @@ import { DataGatheringQueueModule } from '@ghostfolio/api/services/queues/data-g
 import { Module } from '@nestjs/common';
 
 import { AssetProfileChangedListener } from './asset-profile-changed.listener';
+import { MarketDataUpdatedListener } from './market-data-updated.listener';
 import { PortfolioChangedListener } from './portfolio-changed.listener';
 
 @Module({
@@ -19,6 +20,10 @@ import { PortfolioChangedListener } from './portfolio-changed.listener';
     ExchangeRateDataModule,
     RedisCacheModule
   ],
-  providers: [AssetProfileChangedListener, PortfolioChangedListener]
+  providers: [
+    AssetProfileChangedListener,
+    MarketDataUpdatedListener,
+    PortfolioChangedListener
+  ]
 })
 export class EventsModule {}

--- a/apps/api/src/events/market-data-updated.event.ts
+++ b/apps/api/src/events/market-data-updated.event.ts
@@ -1,0 +1,1 @@
+export const MARKET_DATA_UPDATED = 'market-data.updated';

--- a/apps/api/src/events/market-data-updated.event.ts
+++ b/apps/api/src/events/market-data-updated.event.ts
@@ -1,0 +1,9 @@
+import { AssetProfileIdentifier } from '@ghostfolio/common/interfaces';
+
+export class MarketDataUpdatedEvent {
+  public constructor(public readonly data: AssetProfileIdentifier) {}
+
+  public static getName(): string {
+    return 'market-data.updated';
+  }
+}

--- a/apps/api/src/events/market-data-updated.listener.ts
+++ b/apps/api/src/events/market-data-updated.listener.ts
@@ -1,0 +1,25 @@
+import { DataProviderService } from '@ghostfolio/api/services/data-provider/data-provider.service';
+import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { MarketDataUpdatedEvent } from './market-data-updated.event';
+
+@Injectable()
+export class MarketDataUpdatedListener {
+  public constructor(
+    private readonly dataProviderService: DataProviderService,
+    private readonly exchangeRateDataService: ExchangeRateDataService
+  ) {}
+
+  @OnEvent(MarketDataUpdatedEvent.getName())
+  public handleMarketDataUpdated(event: MarketDataUpdatedEvent) {
+    if (
+      event.data.dataSource ===
+      this.dataProviderService.getDataSourceForExchangeRates()
+    ) {
+      this.exchangeRateDataService.invalidateCache(event.data.symbol);
+    }
+  }
+}

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -27,6 +27,7 @@ import {
 import { isNumber } from 'lodash';
 import ms from 'ms';
 
+import { MARKET_DATA_UPDATED } from '../../events/market-data-updated.event';
 import { ExchangeRatesByCurrency } from './interfaces/exchange-rate-data.interface';
 
 @Injectable()
@@ -355,7 +356,7 @@ export class ExchangeRateDataService {
     return undefined;
   }
 
-  @OnEvent('market-data.updated')
+  @OnEvent(MARKET_DATA_UPDATED)
   public onMarketDataUpdated(event: { symbol: string }) {
     this.exchangeRateCache.delete(event.symbol);
     this.pendingLoads.delete(event.symbol);

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -362,7 +362,7 @@ export class ExchangeRateDataService {
   }
 
   private getDaysSinceEpoch(aDate: Date) {
-    return Math.floor(aDate.getTime() / 86400000);
+    return Math.floor(aDate.getTime() / 86400000) + 25569;
   }
 
   private async loadCache(aSymbol: string): Promise<Float64Array> {
@@ -374,7 +374,12 @@ export class ExchangeRateDataService {
     });
 
     const todayDays = this.getDaysSinceEpoch(new Date());
-    const array = new Float64Array(todayDays + 1);
+    const maxDataDays =
+      marketData.length > 0
+        ? this.getDaysSinceEpoch(marketData[marketData.length - 1].date)
+        : 0;
+
+    const array = new Float64Array(Math.max(todayDays, maxDataDays) + 1);
 
     if (marketData.length > 0) {
       let lastRate = marketData[0].marketPrice;
@@ -404,14 +409,10 @@ export class ExchangeRateDataService {
   ): Promise<number | undefined> {
     let cache = this.exchangeRateCache.get(aSymbol);
 
-    if (!cache) {
+    while (!cache) {
       if (this.pendingLoads.has(aSymbol)) {
         await this.pendingLoads.get(aSymbol);
         cache = this.exchangeRateCache.get(aSymbol);
-
-        if (!cache) {
-          cache = await this.loadAndCommit(aSymbol);
-        }
       } else {
         cache = await this.loadAndCommit(aSymbol);
       }

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@ghostfolio/common/helper';
 
 import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
 import {
   eachDayOfInterval,
   format,
@@ -34,6 +35,8 @@ export class ExchangeRateDataService {
   private currencyPairs: DataGatheringItem[] = [];
   private derivedCurrencyFactors: { [currencyPair: string]: number } = {};
   private exchangeRates: { [currencyPair: string]: number } = {};
+  private exchangeRateCache = new Map<string, Float32Array>();
+  private pendingLoads = new Map<string, Promise<Float32Array>>();
 
   public constructor(
     private readonly dataProviderService: DataProviderService,
@@ -284,56 +287,34 @@ export class ExchangeRateDataService {
     } else if (derivedCurrencyFactor) {
       factor = derivedCurrencyFactor;
     } else {
-      const dataSource =
-        this.dataProviderService.getDataSourceForExchangeRates();
-      const symbol = `${aFromCurrency}${aToCurrency}`;
+      const marketPrice = await this.getRateFromCache(
+        `${aFromCurrency}${aToCurrency}`,
+        aDate
+      );
 
-      const marketData = await this.marketDataService.get({
-        dataSource,
-        symbol,
-        date: aDate
-      });
-
-      if (marketData?.marketPrice) {
-        factor = marketData?.marketPrice;
+      if (marketPrice !== undefined) {
+        factor = marketPrice;
       } else {
-        // Calculate indirectly via base currency
-
-        let marketPriceBaseCurrencyFromCurrency: number;
-        let marketPriceBaseCurrencyToCurrency: number;
-
         try {
-          if (aFromCurrency === DEFAULT_CURRENCY) {
-            marketPriceBaseCurrencyFromCurrency = 1;
-          } else {
-            marketPriceBaseCurrencyFromCurrency = (
-              await this.marketDataService.get({
-                dataSource,
-                date: aDate,
-                symbol: `${DEFAULT_CURRENCY}${aFromCurrency}`
-              })
-            )?.marketPrice;
-          }
-        } catch {}
+          let baseFromPrice = 1;
+          let baseToPrice = 1;
 
-        try {
-          if (aToCurrency === DEFAULT_CURRENCY) {
-            marketPriceBaseCurrencyToCurrency = 1;
-          } else {
-            marketPriceBaseCurrencyToCurrency = (
-              await this.marketDataService.get({
-                dataSource,
-                date: aDate,
-                symbol: `${DEFAULT_CURRENCY}${aToCurrency}`
-              })
-            )?.marketPrice;
+          if (aFromCurrency !== DEFAULT_CURRENCY) {
+            baseFromPrice = await this.getRateFromCache(
+              `${DEFAULT_CURRENCY}${aFromCurrency}`,
+              aDate
+            );
           }
-        } catch {}
 
-        // Calculate the opposite direction
-        factor =
-          (1 / marketPriceBaseCurrencyFromCurrency) *
-          marketPriceBaseCurrencyToCurrency;
+          if (aToCurrency !== DEFAULT_CURRENCY) {
+            baseToPrice = await this.getRateFromCache(
+              `${DEFAULT_CURRENCY}${aToCurrency}`,
+              aDate
+            );
+          }
+
+          factor = (1 / baseFromPrice) * baseToPrice;
+        } catch {}
       }
     }
 
@@ -350,6 +331,97 @@ export class ExchangeRateDataService {
     );
 
     return undefined;
+  }
+
+  @OnEvent('market-data.updated')
+  public onMarketDataUpdated(event: { symbol: string }) {
+    this.exchangeRateCache.delete(event.symbol);
+    this.pendingLoads.delete(event.symbol);
+  }
+
+  private getDaysSinceEpoch(aDate: Date) {
+    return Math.floor(aDate.getTime() / 86400000);
+  }
+
+  private async loadCache(aSymbol: string): Promise<Float32Array> {
+    const dataSource = this.dataProviderService.getDataSourceForExchangeRates();
+    const marketData = await this.prismaService.marketData.findMany({
+      where: { dataSource, symbol: aSymbol },
+      orderBy: { date: 'asc' },
+      select: { date: true, marketPrice: true }
+    });
+
+    const todayDays = this.getDaysSinceEpoch(new Date());
+    const array = new Float32Array(todayDays + 1);
+
+    if (marketData.length > 0) {
+      let lastRate = marketData[0].marketPrice;
+      let currentIndex = this.getDaysSinceEpoch(marketData[0].date);
+
+      for (const data of marketData) {
+        const dataIndex = this.getDaysSinceEpoch(data.date);
+        while (currentIndex < dataIndex && currentIndex <= todayDays) {
+          array[currentIndex++] = lastRate;
+        }
+        lastRate = data.marketPrice;
+        array[dataIndex] = lastRate;
+        currentIndex = dataIndex + 1;
+      }
+
+      while (currentIndex <= todayDays) {
+        array[currentIndex++] = lastRate;
+      }
+    }
+
+    return array;
+  }
+
+  private async getRateFromCache(
+    aSymbol: string,
+    aDate: Date
+  ): Promise<number | undefined> {
+    let cache = this.exchangeRateCache.get(aSymbol);
+
+    if (!cache) {
+      if (this.pendingLoads.has(aSymbol)) {
+        await this.pendingLoads.get(aSymbol);
+        cache = this.exchangeRateCache.get(aSymbol);
+
+        if (!cache) {
+          cache = await this.loadAndCommit(aSymbol);
+        }
+      } else {
+        cache = await this.loadAndCommit(aSymbol);
+      }
+    }
+
+    const days = Math.min(this.getDaysSinceEpoch(aDate), cache.length - 1);
+
+    if (days >= 0) {
+      const rate = cache[days];
+      return rate === 0 ? undefined : rate;
+    }
+
+    return undefined;
+  }
+
+  private async loadAndCommit(aSymbol: string): Promise<Float32Array> {
+    const loadPromise = this.loadCache(aSymbol);
+    this.pendingLoads.set(aSymbol, loadPromise);
+
+    try {
+      const cache = await loadPromise;
+
+      if (this.pendingLoads.get(aSymbol) === loadPromise) {
+        this.exchangeRateCache.set(aSymbol, cache);
+      }
+
+      return this.exchangeRateCache.get(aSymbol) ?? cache;
+    } finally {
+      if (this.pendingLoads.get(aSymbol) === loadPromise) {
+        this.pendingLoads.delete(aSymbol);
+      }
+    }
   }
 
   private async getExchangeRates({

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -16,7 +16,6 @@ import {
 } from '@ghostfolio/common/helper';
 
 import { Injectable, Logger } from '@nestjs/common';
-import { OnEvent } from '@nestjs/event-emitter';
 import {
   eachDayOfInterval,
   format,
@@ -29,14 +28,15 @@ import ms from 'ms';
 
 import { ExchangeRatesByCurrency } from './interfaces/exchange-rate-data.interface';
 
+const EPOCH_OFFSET_DAYS = 25569;
+
 @Injectable()
 export class ExchangeRateDataService {
   private currencies: string[] = [];
   private currencyPairs: DataGatheringItem[] = [];
   private derivedCurrencyFactors: { [currencyPair: string]: number } = {};
   private exchangeRates: { [currencyPair: string]: number } = {};
-  private exchangeRateCache = new Map<string, Float64Array>();
-  private pendingLoads = new Map<string, Promise<Float64Array>>();
+  private exchangeRateCache = new Map<string, Promise<Float64Array>>();
 
   public constructor(
     private readonly dataProviderService: DataProviderService,
@@ -355,14 +355,12 @@ export class ExchangeRateDataService {
     return undefined;
   }
 
-  @OnEvent('market-data.updated')
-  public onMarketDataUpdated(event: { symbol: string }) {
-    this.exchangeRateCache.delete(event.symbol);
-    this.pendingLoads.delete(event.symbol);
+  public invalidateCache(aSymbol: string) {
+    this.exchangeRateCache.delete(aSymbol);
   }
 
   private getDaysSinceEpoch(aDate: Date) {
-    return Math.floor(aDate.getTime() / 86400000) + 25569;
+    return Math.floor(aDate.getTime() / ms('1d')) + EPOCH_OFFSET_DAYS;
   }
 
   private async loadCache(aSymbol: string): Promise<Float64Array> {
@@ -407,17 +405,17 @@ export class ExchangeRateDataService {
     aSymbol: string,
     aDate: Date
   ): Promise<number | undefined> {
-    let cache = this.exchangeRateCache.get(aSymbol);
+    let cachePromise = this.exchangeRateCache.get(aSymbol);
 
-    while (!cache) {
-      if (this.pendingLoads.has(aSymbol)) {
-        await this.pendingLoads.get(aSymbol);
-        cache = this.exchangeRateCache.get(aSymbol);
-      } else {
-        cache = await this.loadAndCommit(aSymbol);
-      }
+    if (!cachePromise) {
+      cachePromise = this.loadCache(aSymbol).catch((error) => {
+        this.exchangeRateCache.delete(aSymbol);
+        throw error;
+      });
+      this.exchangeRateCache.set(aSymbol, cachePromise);
     }
 
+    const cache = await cachePromise;
     const days = Math.min(this.getDaysSinceEpoch(aDate), cache.length - 1);
 
     if (days >= 0) {
@@ -426,25 +424,6 @@ export class ExchangeRateDataService {
     }
 
     return undefined;
-  }
-
-  private async loadAndCommit(aSymbol: string): Promise<Float64Array> {
-    const loadPromise = this.loadCache(aSymbol);
-    this.pendingLoads.set(aSymbol, loadPromise);
-
-    try {
-      const cache = await loadPromise;
-
-      if (this.pendingLoads.get(aSymbol) === loadPromise) {
-        this.exchangeRateCache.set(aSymbol, cache);
-      }
-
-      return this.exchangeRateCache.get(aSymbol) ?? cache;
-    } finally {
-      if (this.pendingLoads.get(aSymbol) === loadPromise) {
-        this.pendingLoads.delete(aSymbol);
-      }
-    }
   }
 
   private async getExchangeRates({

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -35,8 +35,8 @@ export class ExchangeRateDataService {
   private currencyPairs: DataGatheringItem[] = [];
   private derivedCurrencyFactors: { [currencyPair: string]: number } = {};
   private exchangeRates: { [currencyPair: string]: number } = {};
-  private exchangeRateCache = new Map<string, Float32Array>();
-  private pendingLoads = new Map<string, Promise<Float32Array>>();
+  private exchangeRateCache = new Map<string, Float64Array>();
+  private pendingLoads = new Map<string, Promise<Float64Array>>();
 
   public constructor(
     private readonly dataProviderService: DataProviderService,
@@ -296,14 +296,26 @@ export class ExchangeRateDataService {
         factor = marketPrice;
       } else {
         try {
-          let baseFromPrice = 1;
-          let baseToPrice = 1;
+          let baseFromPrice: number | undefined =
+            aFromCurrency === DEFAULT_CURRENCY ? 1 : undefined;
+          let baseToPrice: number | undefined =
+            aToCurrency === DEFAULT_CURRENCY ? 1 : undefined;
 
           if (aFromCurrency !== DEFAULT_CURRENCY) {
             baseFromPrice = await this.getRateFromCache(
               `${DEFAULT_CURRENCY}${aFromCurrency}`,
               aDate
             );
+
+            if (baseFromPrice === undefined) {
+              const crossPrice = await this.getRateFromCache(
+                `${aFromCurrency}${DEFAULT_CURRENCY}`,
+                aDate
+              );
+              if (crossPrice !== undefined) {
+                baseFromPrice = 1 / crossPrice;
+              }
+            }
           }
 
           if (aToCurrency !== DEFAULT_CURRENCY) {
@@ -311,6 +323,16 @@ export class ExchangeRateDataService {
               `${DEFAULT_CURRENCY}${aToCurrency}`,
               aDate
             );
+
+            if (baseToPrice === undefined) {
+              const crossPrice = await this.getRateFromCache(
+                `${aToCurrency}${DEFAULT_CURRENCY}`,
+                aDate
+              );
+              if (crossPrice !== undefined) {
+                baseToPrice = 1 / crossPrice;
+              }
+            }
           }
 
           factor = (1 / baseFromPrice) * baseToPrice;
@@ -343,7 +365,7 @@ export class ExchangeRateDataService {
     return Math.floor(aDate.getTime() / 86400000);
   }
 
-  private async loadCache(aSymbol: string): Promise<Float32Array> {
+  private async loadCache(aSymbol: string): Promise<Float64Array> {
     const dataSource = this.dataProviderService.getDataSourceForExchangeRates();
     const marketData = await this.prismaService.marketData.findMany({
       where: { dataSource, symbol: aSymbol },
@@ -352,7 +374,7 @@ export class ExchangeRateDataService {
     });
 
     const todayDays = this.getDaysSinceEpoch(new Date());
-    const array = new Float32Array(todayDays + 1);
+    const array = new Float64Array(todayDays + 1);
 
     if (marketData.length > 0) {
       let lastRate = marketData[0].marketPrice;
@@ -405,7 +427,7 @@ export class ExchangeRateDataService {
     return undefined;
   }
 
-  private async loadAndCommit(aSymbol: string): Promise<Float32Array> {
+  private async loadAndCommit(aSymbol: string): Promise<Float64Array> {
     const loadPromise = this.loadCache(aSymbol);
     this.pendingLoads.set(aSymbol, loadPromise);
 

--- a/apps/api/src/services/market-data/market-data.service.ts
+++ b/apps/api/src/services/market-data/market-data.service.ts
@@ -14,6 +14,8 @@ import {
   Prisma
 } from '@prisma/client';
 
+import { MARKET_DATA_UPDATED } from '../../events/market-data-updated.event';
+
 @Injectable()
 export class MarketDataService {
   public constructor(
@@ -29,7 +31,7 @@ export class MarketDataService {
       }
     });
 
-    this.eventEmitter.emit('market-data.updated', { symbol });
+    this.eventEmitter.emit(MARKET_DATA_UPDATED, { symbol });
 
     return result;
   }
@@ -194,7 +196,7 @@ export class MarketDataService {
       }
     });
 
-    this.eventEmitter.emit('market-data.updated', { symbol });
+    this.eventEmitter.emit(MARKET_DATA_UPDATED, { symbol });
   }
 
   public async updateAssetProfileIdentifier(
@@ -212,10 +214,10 @@ export class MarketDataService {
       }
     });
 
-    this.eventEmitter.emit('market-data.updated', {
+    this.eventEmitter.emit(MARKET_DATA_UPDATED, {
       symbol: oldAssetProfileIdentifier.symbol
     });
-    this.eventEmitter.emit('market-data.updated', {
+    this.eventEmitter.emit(MARKET_DATA_UPDATED, {
       symbol: newAssetProfileIdentifier.symbol
     });
 
@@ -242,7 +244,7 @@ export class MarketDataService {
       update: { marketPrice: data.marketPrice, state: data.state }
     });
 
-    this.eventEmitter.emit('market-data.updated', {
+    this.eventEmitter.emit(MARKET_DATA_UPDATED, {
       symbol: where.dataSource_date_symbol.symbol
     });
 
@@ -287,7 +289,7 @@ export class MarketDataService {
 
     const symbols = [...new Set(data.map((d) => d.symbol as string))];
     for (const symbol of symbols) {
-      this.eventEmitter.emit('market-data.updated', { symbol });
+      this.eventEmitter.emit(MARKET_DATA_UPDATED, { symbol });
     }
 
     return result;

--- a/apps/api/src/services/market-data/market-data.service.ts
+++ b/apps/api/src/services/market-data/market-data.service.ts
@@ -22,13 +22,16 @@ export class MarketDataService {
   ) {}
 
   public async deleteMany({ dataSource, symbol }: AssetProfileIdentifier) {
-    this.eventEmitter.emit('market-data.updated', { symbol });
-    return this.prismaService.marketData.deleteMany({
+    const result = await this.prismaService.marketData.deleteMany({
       where: {
         dataSource,
         symbol
       }
     });
+
+    this.eventEmitter.emit('market-data.updated', { symbol });
+
+    return result;
   }
 
   public async get({
@@ -198,14 +201,7 @@ export class MarketDataService {
     oldAssetProfileIdentifier: AssetProfileIdentifier,
     newAssetProfileIdentifier: AssetProfileIdentifier
   ) {
-    this.eventEmitter.emit('market-data.updated', {
-      symbol: oldAssetProfileIdentifier.symbol
-    });
-    this.eventEmitter.emit('market-data.updated', {
-      symbol: newAssetProfileIdentifier.symbol
-    });
-
-    return this.prismaService.marketData.updateMany({
+    const result = await this.prismaService.marketData.updateMany({
       data: {
         dataSource: newAssetProfileIdentifier.dataSource,
         symbol: newAssetProfileIdentifier.symbol
@@ -215,6 +211,15 @@ export class MarketDataService {
         symbol: oldAssetProfileIdentifier.symbol
       }
     });
+
+    this.eventEmitter.emit('market-data.updated', {
+      symbol: oldAssetProfileIdentifier.symbol
+    });
+    this.eventEmitter.emit('market-data.updated', {
+      symbol: newAssetProfileIdentifier.symbol
+    });
+
+    return result;
   }
 
   public async updateMarketData(params: {

--- a/apps/api/src/services/market-data/market-data.service.ts
+++ b/apps/api/src/services/market-data/market-data.service.ts
@@ -22,6 +22,7 @@ export class MarketDataService {
   ) {}
 
   public async deleteMany({ dataSource, symbol }: AssetProfileIdentifier) {
+    this.eventEmitter.emit('market-data.updated', { symbol });
     return this.prismaService.marketData.deleteMany({
       where: {
         dataSource,
@@ -197,6 +198,13 @@ export class MarketDataService {
     oldAssetProfileIdentifier: AssetProfileIdentifier,
     newAssetProfileIdentifier: AssetProfileIdentifier
   ) {
+    this.eventEmitter.emit('market-data.updated', {
+      symbol: oldAssetProfileIdentifier.symbol
+    });
+    this.eventEmitter.emit('market-data.updated', {
+      symbol: newAssetProfileIdentifier.symbol
+    });
+
     return this.prismaService.marketData.updateMany({
       data: {
         dataSource: newAssetProfileIdentifier.dataSource,

--- a/apps/api/src/services/market-data/market-data.service.ts
+++ b/apps/api/src/services/market-data/market-data.service.ts
@@ -6,6 +6,7 @@ import { resetHours } from '@ghostfolio/common/helper';
 import { AssetProfileIdentifier } from '@ghostfolio/common/interfaces';
 
 import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   DataSource,
   MarketData,
@@ -15,7 +16,10 @@ import {
 
 @Injectable()
 export class MarketDataService {
-  public constructor(private readonly prismaService: PrismaService) {}
+  public constructor(
+    private readonly eventEmitter: EventEmitter2,
+    private readonly prismaService: PrismaService
+  ) {}
 
   public async deleteMany({ dataSource, symbol }: AssetProfileIdentifier) {
     return this.prismaService.marketData.deleteMany({
@@ -185,6 +189,8 @@ export class MarketDataService {
         });
       }
     });
+
+    this.eventEmitter.emit('market-data.updated', { symbol });
   }
 
   public async updateAssetProfileIdentifier(
@@ -211,7 +217,7 @@ export class MarketDataService {
   }): Promise<MarketData> {
     const { data, where } = params;
 
-    return this.prismaService.marketData.upsert({
+    const result = await this.prismaService.marketData.upsert({
       where,
       create: {
         dataSource: where.dataSource_date_symbol.dataSource,
@@ -222,6 +228,12 @@ export class MarketDataService {
       },
       update: { marketPrice: data.marketPrice, state: data.state }
     });
+
+    this.eventEmitter.emit('market-data.updated', {
+      symbol: where.dataSource_date_symbol.symbol
+    });
+
+    return result;
   }
 
   /**
@@ -258,6 +270,13 @@ export class MarketDataService {
       }
     );
 
-    return this.prismaService.$transaction(upsertPromises);
+    const result = await this.prismaService.$transaction(upsertPromises);
+
+    const symbols = [...new Set(data.map((d) => d.symbol as string))];
+    for (const symbol of symbols) {
+      this.eventEmitter.emit('market-data.updated', { symbol });
+    }
+
+    return result;
   }
 }

--- a/apps/api/src/services/market-data/market-data.service.ts
+++ b/apps/api/src/services/market-data/market-data.service.ts
@@ -13,6 +13,9 @@ import {
   MarketDataState,
   Prisma
 } from '@prisma/client';
+import { uniqBy } from 'lodash';
+
+import { MarketDataUpdatedEvent } from '../../events/market-data-updated.event';
 
 @Injectable()
 export class MarketDataService {
@@ -29,7 +32,10 @@ export class MarketDataService {
       }
     });
 
-    this.eventEmitter.emit('market-data.updated', { symbol });
+    this.eventEmitter.emit(
+      MarketDataUpdatedEvent.getName(),
+      new MarketDataUpdatedEvent({ dataSource, symbol })
+    );
 
     return result;
   }
@@ -194,7 +200,10 @@ export class MarketDataService {
       }
     });
 
-    this.eventEmitter.emit('market-data.updated', { symbol });
+    this.eventEmitter.emit(
+      MarketDataUpdatedEvent.getName(),
+      new MarketDataUpdatedEvent({ dataSource, symbol })
+    );
   }
 
   public async updateAssetProfileIdentifier(
@@ -212,12 +221,14 @@ export class MarketDataService {
       }
     });
 
-    this.eventEmitter.emit('market-data.updated', {
-      symbol: oldAssetProfileIdentifier.symbol
-    });
-    this.eventEmitter.emit('market-data.updated', {
-      symbol: newAssetProfileIdentifier.symbol
-    });
+    this.eventEmitter.emit(
+      MarketDataUpdatedEvent.getName(),
+      new MarketDataUpdatedEvent(oldAssetProfileIdentifier)
+    );
+    this.eventEmitter.emit(
+      MarketDataUpdatedEvent.getName(),
+      new MarketDataUpdatedEvent(newAssetProfileIdentifier)
+    );
 
     return result;
   }
@@ -242,9 +253,13 @@ export class MarketDataService {
       update: { marketPrice: data.marketPrice, state: data.state }
     });
 
-    this.eventEmitter.emit('market-data.updated', {
-      symbol: where.dataSource_date_symbol.symbol
-    });
+    this.eventEmitter.emit(
+      MarketDataUpdatedEvent.getName(),
+      new MarketDataUpdatedEvent({
+        dataSource: where.dataSource_date_symbol.dataSource,
+        symbol: where.dataSource_date_symbol.symbol
+      })
+    );
 
     return result;
   }
@@ -285,9 +300,19 @@ export class MarketDataService {
 
     const result = await this.prismaService.$transaction(upsertPromises);
 
-    const symbols = [...new Set(data.map((d) => d.symbol as string))];
-    for (const symbol of symbols) {
-      this.eventEmitter.emit('market-data.updated', { symbol });
+    const uniquePairs = uniqBy(
+      data.map((d) => ({
+        dataSource: d.dataSource as DataSource,
+        symbol: d.symbol as string
+      })),
+      (d) => `${d.dataSource}:${d.symbol}`
+    );
+
+    for (const pair of uniquePairs) {
+      this.eventEmitter.emit(
+        MarketDataUpdatedEvent.getName(),
+        new MarketDataUpdatedEvent(pair)
+      );
     }
 
     return result;


### PR DESCRIPTION
## Summary

Adds a lazy-loaded `Float64Array` cache to `ExchangeRateDataService` to eliminate the `P2028` connection pool timeout caused by redundant `marketData.findFirst()` queries during portfolio calculations.

## Problem

When `getActivities()` processes 48k+ activities via `Promise.all`, each activity fires 4 `toCurrencyAtDate()` calls, each doing `marketData.findFirst()`. With the indirect fallback path, this queues up to 576k concurrent DB queries, exhausting the Prisma connection pool.

## Solution

Replaces `findFirst()` calls in `toCurrencyAtDate()` with O(1) in-memory lookups:

- **Float64Array cache** - each symbol's full history stored as a typed array indexed by days since epoch (~164 KB for 30 years). *Note: `Float64Array` was chosen over `Float32Array` to prevent floating-point precision loss when calculating rates for extremely small currency factors (like micro-cap cryptos or weak fiat currencies).*
- **Lazy loading** - first request for a symbol triggers one `findMany`, which populates the entire array
- **Forward-fill** - missing days (weekends, holidays) filled with the last known rate
- **Concurrency lock** - `pendingLoads` map ensures only one DB query per symbol under `Promise.all`
- **Cache invalidation** - `MarketDataService.updateMany` emits `market-data.updated` events; the cache evicts stale symbols

## Changes

- `ExchangeRateDataService` - added `exchangeRateCache`, `pendingLoads`, `loadCache()`, `getRateFromCache()`, `getDaysSinceEpoch()`; refactored `toCurrencyAtDate()` to use cache; added `@OnEvent(market-data.updated)` handler
- `MarketDataService` - injected `EventEmitter2`; emit `market-data.updated` with unique symbols after `updateMany` transaction