### PR TITLE
Task/upgrade @keyv/redis to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for German (`de`)
 - Improved the language localization for Spanish (`es`)
 - Upgraded `bull-board` from version `7.0.0` to `7.1.5`
+- Upgraded `@keyv/redis` from version `4.4.0` to `5.1.6`
 - Upgraded `Nx` from version `22.7.1` to `22.7.2`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgraded `@keyv/redis` from version `4.4.0` to `5.1.6`
+
 ## 3.4.0 - 2026-05-21
 
 ### Added
@@ -26,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for German (`de`)
 - Improved the language localization for Spanish (`es`)
 - Upgraded `bull-board` from version `7.0.0` to `7.1.5`
-- Upgraded `@keyv/redis` from version `4.4.0` to `5.1.6`
 - Upgraded `Nx` from version `22.7.1` to `22.7.2`
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@date-fns/utc": "2.1.1",
         "@internationalized/number": "3.6.6",
         "@ionic/angular": "8.8.5",
-        "@keyv/redis": "4.4.0",
+        "@keyv/redis": "5.1.6",
         "@nestjs/bull": "11.0.4",
         "@nestjs/cache-manager": "3.1.0",
         "@nestjs/common": "11.1.19",
@@ -7144,19 +7144,20 @@
       }
     },
     "node_modules/@keyv/redis": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-4.4.0.tgz",
-      "integrity": "sha512-n/KEj3S7crVkoykggqsMUtcjNGvjagGPlJYgO/r6m9hhGZfhp1txJElHxcdJ1ANi/LJoBuOSILj15g6HD2ucqQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-5.1.6.tgz",
+      "integrity": "sha512-eKvW6pspvVaU5dxigaIDZr635/Uw6urTXL3gNbY9WTR8d3QigZQT+r8gxYSEOsw4+1cCBsC4s7T2ptR0WC9LfQ==",
       "license": "MIT",
       "dependencies": {
-        "@redis/client": "^1.6.0",
-        "cluster-key-slot": "^1.1.2"
+        "@redis/client": "^5.10.0",
+        "cluster-key-slot": "^1.1.2",
+        "hookified": "^1.13.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "keyv": "^5.3.3"
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@keyv/serialize": {
@@ -11664,17 +11665,27 @@
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
-      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
       "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -23191,15 +23202,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -23818,8 +23820,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@date-fns/utc": "2.1.1",
     "@internationalized/number": "3.6.6",
     "@ionic/angular": "8.8.5",
-    "@keyv/redis": "4.4.0",
+    "@keyv/redis": "5.1.6",
     "@nestjs/bull": "11.0.4",
     "@nestjs/cache-manager": "3.1.0",
     "@nestjs/common": "11.1.19",


### PR DESCRIPTION
## Summary
- Upgrade @keyv/redis from 4.4.0 to 5.1.6
- Update the lockfile for @redis/client v5 and the new hookified dependency
- Remove the stale generic-pool lockfile entry that is no longer required by @redis/client v5

Closes #6900

## Testing
- npm ci
- npm ls @keyv/redis @redis/client hookified
- $env:TZ='UTC'; npm run test:api
- npm install --package-lock-only --ignore-scripts --dry-run
- git diff --check

Also ran $env:TZ='UTC'; npm test. The API, client, and UI targets passed, but the full suite failed in common:test because getNumberFormatGroup('de-CH') receives the current Node/ICU group separator ' while the existing test expects '. That failure is outside the Redis adapter change.