### PR TITLE
Bugfix/double scrollbars on feature page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded `@keyv/redis` from version `4.4.0` to `5.1.6`
 
+### Fixed
+
+- Fixed a layout regression that caused a double scrollbar on pages without tabs
+
 ## 3.4.0 - 2026-05-21
 
 ### Added

--- a/apps/client/src/app/pages/about/about-page.component.ts
+++ b/apps/client/src/app/pages/about/about-page.component.ts
@@ -21,7 +21,7 @@ import {
 } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-about-page',
   styleUrls: ['./about-page.scss'],

--- a/apps/client/src/app/pages/admin/admin-page.component.ts
+++ b/apps/client/src/app/pages/admin/admin-page.component.ts
@@ -15,7 +15,7 @@ import {
 } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-admin-page',
   styleUrls: ['./admin-page.scss'],

--- a/apps/client/src/app/pages/faq/faq-page.component.ts
+++ b/apps/client/src/app/pages/faq/faq-page.component.ts
@@ -11,7 +11,7 @@ import { addIcons } from 'ionicons';
 import { cloudyOutline, readerOutline, serverOutline } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-faq-page',
   styleUrls: ['./faq-page.scss'],

--- a/apps/client/src/app/pages/home/home-page.component.ts
+++ b/apps/client/src/app/pages/home/home-page.component.ts
@@ -25,7 +25,7 @@ import {
 } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-home-page',
   styleUrls: ['./home-page.scss'],

--- a/apps/client/src/app/pages/portfolio/portfolio-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/portfolio-page.component.ts
@@ -18,7 +18,7 @@ import {
 } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-portfolio-page',
   styleUrls: ['./portfolio-page.scss'],

--- a/apps/client/src/app/pages/resources/resources-page.component.ts
+++ b/apps/client/src/app/pages/resources/resources-page.component.ts
@@ -14,7 +14,7 @@ import {
 } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-resources-page',
   styleUrls: ['./resources-page.scss'],

--- a/apps/client/src/app/pages/user-account/user-account-page.component.ts
+++ b/apps/client/src/app/pages/user-account/user-account-page.component.ts
@@ -12,7 +12,7 @@ import { addIcons } from 'ionicons';
 import { diamondOutline, keyOutline, settingsOutline } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-user-account-page',
   styleUrls: ['./user-account-page.scss'],

--- a/apps/client/src/app/pages/zen/zen-page.component.ts
+++ b/apps/client/src/app/pages/zen/zen-page.component.ts
@@ -12,7 +12,7 @@ import { addIcons } from 'ionicons';
 import { albumsOutline, analyticsOutline } from 'ionicons/icons';
 
 @Component({
-  host: { class: 'page has-tabs' },
+  host: { class: 'page' },
   imports: [GfPageTabsComponent],
   selector: 'gf-zen-page',
   styleUrls: ['./zen-page.scss'],

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -365,7 +365,7 @@ ngx-skeleton-loader {
 }
 
 .has-info-message {
-  // Restrict viewport height of tabbed views when the live-demo banner or system announcements are displayed
+  // Restrict viewport height of tabbed views when the Live Demo or system announcements banner are displayed
   .page:has(gf-page-tabs) {
     height: calc(100svh - 2 * var(--mat-toolbar-standard-height));
   }

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -365,7 +365,8 @@ ngx-skeleton-loader {
 }
 
 .has-info-message {
-  .page.has-tabs {
+  // Restrict viewport height of tabbed views when the live-demo banner or system announcements are displayed
+  .page:has(gf-page-tabs) {
     height: calc(100svh - 2 * var(--mat-toolbar-standard-height));
   }
 }
@@ -479,7 +480,6 @@ ngx-skeleton-loader {
 
 .page {
   display: flex;
-  height: calc(100svh - var(--mat-toolbar-standard-height));
   overflow-y: auto;
   padding-bottom: env(safe-area-inset-bottom);
   padding-bottom: constant(safe-area-inset-bottom);
@@ -491,7 +491,13 @@ ngx-skeleton-loader {
     z-index: 999;
   }
 
-  &:not(.has-tabs) {
+  // Restrict viewport height and layout boundaries only when the page hosts tab navigation
+  &:has(gf-page-tabs) {
+    height: calc(100svh - var(--mat-toolbar-standard-height));
+  }
+
+  // Apply vertical padding only to standalone or nested content views (tabs handle their own padding)
+  &:not(:has(gf-page-tabs)) {
     @media (min-width: 576px) {
       padding: 2rem 0;
     }


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #6924. Please take a look :)

## Changes

- **Content-aware height bounds**: Restrict viewport height and overflow-y lock styles in global `styles.scss` specifically to `.page` layouts containing `<gf-page-tabs>` using the `:has()` selector.
- **Natural scrolling on standalone views**: Remove global height constraints from the base `.page` layout. This enables fluid standalone pages (like `/features`, `/pricing`, and `/blog`) to expand naturally and scroll via the main browser window with the desktop footer, completely resolving double scrollbars on desktop.
- **Dynamic padding exclusion**: Skip the desktop page padding (`2rem 0`) automatically for tab shells using `:not(:has(gf-page-tabs))` to avoid double-padding since the tab panel handles its own internal content spacing.
- **Manual class cleanup**: Clean up the obsolete `.has-tabs` class from the `host` decorators across all 8 tab parent page components, shifting all layout height and viewport-bound checks to be fully automated and declarative.
- **Code comments**: Added clean, explanatory Sass documentation comments outlining the banner and dynamic tab layout boundaries.


## Additional context

The fixed height restriction was moved globally to `.page` in #6908 to support height adjustments when the `.has-info-message` banner is present. However, this forced all fluid standalone pages showing a desktop footer to scroll internally, leading to double scrollbars. 

Using `:has(gf-page-tabs)` to dynamically target the height constraints solves the banner height problem while perfectly isolating the layout boundaries. This requires zero custom TS configuration on components and lets content-rich pages scroll naturally down to the footer.