### PR TITLE
Task/improve type safety in user account access component

### DIFF
--- a/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
+++ b/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
@@ -29,6 +29,7 @@ import {
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { AccessPermission } from '@prisma/client';
 import { StatusCodes } from 'http-status-codes';
 import { EMPTY, catchError } from 'rxjs';
 
@@ -83,7 +84,7 @@ export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
         isPublic ? null : Validators.required
       ],
       permissions: [
-        access?.permissions[0] ?? 'READ_RESTRICTED',
+        access?.permissions[0] ?? AccessPermission.READ_RESTRICTED,
         Validators.required
       ],
       type: [
@@ -105,7 +106,7 @@ export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
           granteeUserIdControl?.clearValidators();
           granteeUserIdControl?.setValue(null);
           permissionsControl?.setValue(
-            access?.permissions[0] ?? 'READ_RESTRICTED'
+            access?.permissions[0] ?? AccessPermission.READ_RESTRICTED
           );
         }
 

--- a/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
+++ b/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
@@ -115,11 +115,11 @@ export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
       });
   }
 
-  public onCancel() {
+  protected onCancel() {
     this.dialogRef.close();
   }
 
-  public async onSubmit() {
+  protected async onSubmit() {
     if (this.mode === 'create') {
       await this.createAccess();
     } else {

--- a/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
+++ b/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
@@ -52,7 +52,7 @@ import { CreateOrUpdateAccessDialogParams } from './interfaces/interfaces';
 })
 export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
   protected accessForm: FormGroup;
-  protected mode: 'create' | 'update';
+  protected readonly mode: 'create' | 'update';
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
 

--- a/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
+++ b/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/create-or-update-access-dialog.component.ts
@@ -69,21 +69,25 @@ export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
   private readonly notificationService = inject(NotificationService);
 
   public constructor() {
-    this.mode = this.data.access?.id ? 'update' : 'create';
+    this.mode = this.data.access ? 'update' : 'create';
   }
 
   public ngOnInit() {
-    const isPublic = this.data.access.type === 'PUBLIC';
+    const access = this.data?.access;
+    const isPublic = access?.type === 'PUBLIC';
 
     this.accessForm = this.formBuilder.group({
-      alias: [this.data.access.alias],
+      alias: [access?.alias ?? ''],
       granteeUserId: [
-        this.data.access.grantee,
+        access?.grantee ?? null,
         isPublic ? null : Validators.required
       ],
-      permissions: [this.data.access.permissions[0], Validators.required],
+      permissions: [
+        access?.permissions[0] ?? 'READ_RESTRICTED',
+        Validators.required
+      ],
       type: [
-        { disabled: this.mode === 'update', value: this.data.access.type },
+        { disabled: this.mode === 'update', value: access?.type ?? 'PRIVATE' },
         Validators.required
       ]
     });
@@ -100,7 +104,9 @@ export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
         } else {
           granteeUserIdControl?.clearValidators();
           granteeUserIdControl?.setValue(null);
-          permissionsControl?.setValue(this.data.access.permissions[0]);
+          permissionsControl?.setValue(
+            access?.permissions[0] ?? 'READ_RESTRICTED'
+          );
         }
 
         granteeUserIdControl?.updateValueAndValidity();
@@ -158,10 +164,16 @@ export class GfCreateOrUpdateAccessDialogComponent implements OnInit {
   }
 
   private async updateAccess() {
+    const accessId = this.data.access?.id;
+
+    if (!accessId) {
+      return;
+    }
+
     const access: UpdateAccessDto = {
       alias: this.accessForm.get('alias')?.value,
       granteeUserId: this.accessForm.get('granteeUserId')?.value,
-      id: this.data.access.id,
+      id: accessId,
       permissions: [this.accessForm.get('permissions')?.value]
     };
 

--- a/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/components/user-account-access/create-or-update-access-dialog/interfaces/interfaces.ts
@@ -1,5 +1,5 @@
 import { Access } from '@ghostfolio/common/interfaces';
 
 export interface CreateOrUpdateAccessDialogParams {
-  access: Access;
+  access?: Access;
 }

--- a/apps/client/src/app/components/user-account-access/user-account-access.component.ts
+++ b/apps/client/src/app/components/user-account-access/user-account-access.component.ts
@@ -12,6 +12,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
   inject,
@@ -73,7 +74,9 @@ export class GfUserAccountAccessComponent implements OnInit {
   });
   protected user: User;
 
-  private deviceType: string;
+  private readonly deviceType = computed(
+    () => this.deviceDetectorService.deviceInfo().deviceType
+  );
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly dataService = inject(DataService);
@@ -132,8 +135,6 @@ export class GfUserAccountAccessComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.deviceType = this.deviceDetectorService.getDeviceInfo().deviceType;
-
     this.update();
   }
 
@@ -195,8 +196,8 @@ export class GfUserAccountAccessComponent implements OnInit {
       CreateOrUpdateAccessDialogParams
     >(GfCreateOrUpdateAccessDialogComponent, {
       data: {} satisfies CreateOrUpdateAccessDialogParams,
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+      height: this.deviceType() === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
     });
 
     dialogRef.afterClosed().subscribe((access: CreateAccessDto | null) => {
@@ -230,8 +231,8 @@ export class GfUserAccountAccessComponent implements OnInit {
           type: access.type
         }
       } satisfies CreateOrUpdateAccessDialogParams,
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+      height: this.deviceType() === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType() === 'mobile' ? '100vw' : '50rem'
     });
 
     dialogRef.afterClosed().subscribe((result) => {

--- a/apps/client/src/app/components/user-account-access/user-account-access.component.ts
+++ b/apps/client/src/app/components/user-account-access/user-account-access.component.ts
@@ -14,6 +14,7 @@ import {
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
+  inject,
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -73,17 +74,17 @@ export class GfUserAccountAccessComponent implements OnInit {
   });
   public user: User;
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private deviceDetectorService: DeviceDetectorService,
-    private dialog: MatDialog,
-    private notificationService: NotificationService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService
-  ) {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly dialog = inject(MatDialog);
+  private readonly notificationService = inject(NotificationService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
     const { globalPermissions } = this.dataService.fetchInfo();
 
     this.hasPermissionToDeleteAccess = hasPermission(

--- a/apps/client/src/app/components/user-account-access/user-account-access.component.ts
+++ b/apps/client/src/app/components/user-account-access/user-account-access.component.ts
@@ -59,20 +59,21 @@ import { CreateOrUpdateAccessDialogParams } from './create-or-update-access-dial
   templateUrl: './user-account-access.html'
 })
 export class GfUserAccountAccessComponent implements OnInit {
-  public accessesGet: Access[];
-  public accessesGive: Access[];
-  public deviceType: string;
-  public hasPermissionToCreateAccess: boolean;
-  public hasPermissionToDeleteAccess: boolean;
-  public hasPermissionToUpdateOwnAccessToken: boolean;
-  public isAccessTokenHidden = true;
-  public updateOwnAccessTokenForm = new FormGroup({
+  protected accessesGet: Access[];
+  protected accessesGive: Access[];
+  protected hasPermissionToCreateAccess: boolean;
+  protected hasPermissionToDeleteAccess: boolean;
+  protected hasPermissionToUpdateOwnAccessToken: boolean;
+  protected isAccessTokenHidden = true;
+  protected updateOwnAccessTokenForm = new FormGroup({
     accessToken: new FormControl<string>('', {
       nonNullable: true,
       validators: [Validators.required]
     })
   });
-  public user: User;
+  protected user: User;
+
+  private deviceType: string;
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly dataService = inject(DataService);
@@ -136,7 +137,7 @@ export class GfUserAccountAccessComponent implements OnInit {
     this.update();
   }
 
-  public onDeleteAccess(aId: string) {
+  protected onDeleteAccess(aId: string) {
     this.dataService
       .deleteAccess(aId)
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -147,7 +148,7 @@ export class GfUserAccountAccessComponent implements OnInit {
       });
   }
 
-  public onGenerateAccessToken() {
+  protected onGenerateAccessToken() {
     this.notificationService.confirm({
       confirmFn: () => {
         this.dataService
@@ -182,7 +183,7 @@ export class GfUserAccountAccessComponent implements OnInit {
     });
   }
 
-  public onUpdateAccess(aId: string) {
+  protected onUpdateAccess(aId: string) {
     this.router.navigate([], {
       queryParams: { accessId: aId, editDialog: true }
     });

--- a/apps/client/src/app/components/user-account-access/user-account-access.component.ts
+++ b/apps/client/src/app/components/user-account-access/user-account-access.component.ts
@@ -65,7 +65,7 @@ export class GfUserAccountAccessComponent implements OnInit {
   protected hasPermissionToDeleteAccess: boolean;
   protected hasPermissionToUpdateOwnAccessToken: boolean;
   protected isAccessTokenHidden = true;
-  protected updateOwnAccessTokenForm = new FormGroup({
+  protected readonly updateOwnAccessTokenForm = new FormGroup({
     accessToken: new FormControl<string>('', {
       nonNullable: true,
       validators: [Validators.required]

--- a/apps/client/src/app/components/user-account-access/user-account-access.component.ts
+++ b/apps/client/src/app/components/user-account-access/user-account-access.component.ts
@@ -17,7 +17,12 @@ import {
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -60,8 +65,11 @@ export class GfUserAccountAccessComponent implements OnInit {
   public hasPermissionToDeleteAccess: boolean;
   public hasPermissionToUpdateOwnAccessToken: boolean;
   public isAccessTokenHidden = true;
-  public updateOwnAccessTokenForm = this.formBuilder.group({
-    accessToken: ['', Validators.required]
+  public updateOwnAccessTokenForm = new FormGroup({
+    accessToken: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.required]
+    })
   });
   public user: User;
 
@@ -71,7 +79,6 @@ export class GfUserAccountAccessComponent implements OnInit {
     private destroyRef: DestroyRef,
     private deviceDetectorService: DeviceDetectorService,
     private dialog: MatDialog,
-    private formBuilder: FormBuilder,
     private notificationService: NotificationService,
     private route: ActivatedRoute,
     private router: Router,
@@ -144,7 +151,8 @@ export class GfUserAccountAccessComponent implements OnInit {
       confirmFn: () => {
         this.dataService
           .updateOwnAccessToken({
-            accessToken: this.updateOwnAccessTokenForm.get('accessToken').value
+            accessToken:
+              this.updateOwnAccessTokenForm.controls.accessToken.value
           })
           .pipe(
             catchError(() => {
@@ -184,15 +192,7 @@ export class GfUserAccountAccessComponent implements OnInit {
       GfCreateOrUpdateAccessDialogComponent,
       CreateOrUpdateAccessDialogParams
     >(GfCreateOrUpdateAccessDialogComponent, {
-      data: {
-        access: {
-          alias: '',
-          grantee: null,
-          id: null,
-          permissions: ['READ_RESTRICTED'],
-          type: 'PRIVATE'
-        }
-      },
+      data: {} satisfies CreateOrUpdateAccessDialogParams,
       height: this.deviceType === 'mobile' ? '98vh' : undefined,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'
     });
@@ -222,12 +222,12 @@ export class GfUserAccountAccessComponent implements OnInit {
       data: {
         access: {
           alias: access.alias,
-          grantee: access.grantee === 'Public' ? null : access.grantee,
+          grantee: access.grantee === 'Public' ? undefined : access.grantee,
           id: access.id,
           permissions: access.permissions,
           type: access.type
         }
-      },
+      } satisfies CreateOrUpdateAccessDialogParams,
       height: this.deviceType === 'mobile' ? '98vh' : undefined,
       width: this.deviceType === 'mobile' ? '100vw' : '50rem'
     });
@@ -244,9 +244,9 @@ export class GfUserAccountAccessComponent implements OnInit {
   private update() {
     this.accessesGet = this.user.access.map(({ alias, id, permissions }) => {
       return {
-        alias,
         id,
         permissions,
+        alias: alias ?? '',
         grantee: $localize`Me`,
         type: 'PRIVATE'
       };


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- Made `access` optional in `CreateOrUpdateAccessDialogParams` to correctly represent dialog creation state.
- Formulated strictly typed reactive form control for token generation, eliminating null-coalescing workarounds.
- Removed mock domain objects (such as fictional empty-string IDs) from parent-to-dialog creation calls.
- Safely normalized database-nullable properties (like `alias` and `grantee`) to `undefined` or default strings.
- Tightened up encapsulation (`protected` and `private` visibilities) and immutability (`readonly` modifiers).
- Replaced constructor-based dependency injection with the `inject` function.
- Replaced deprecated `getDeviceInfo()` method with computed signal.

## Resolved type errors

5 errors (before: 108, after: 103)
