### PR TITLE
Fix portfolio performance overflow on narrow viewports

### DIFF
--- a/apps/client/src/app/components/home-overview/home-overview.component.ts
+++ b/apps/client/src/app/components/home-overview/home-overview.component.ts
@@ -143,7 +143,7 @@ export class GfHomeOverviewComponent implements OnInit {
         this.precision.set(2);
 
         if (
-          this.deviceType() === 'mobile' &&
+          window.matchMedia('(max-width: 575.98px)').matches &&
           performance.currentValueInBaseCurrency >=
             NUMERICAL_PRECISION_THRESHOLD_6_FIGURES
         ) {

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.scss
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.scss
@@ -20,4 +20,11 @@
       font-variant-numeric: tabular-nums;
     }
   }
+
+  @media (max-width: 575.98px) {
+    .currency-container,
+    .status-container {
+      min-width: 0;
+    }
+  }
 }


### PR DESCRIPTION
## Problem

On narrow viewports, large portfolio values (>= 100,000) overflow horizontally, causing the currency code to wrap and break the layout. This was first reported in #5987, where the `min-width: 2.5rem` on `.currency-container` was identified as contributing to the visual overflow.

### Root Cause

The precision reduction logic in `home-overview.component.ts` uses `deviceType() === 'mobile'` to decide whether to reduce decimal places to 0. However, `ngx-device-detector` determines `deviceType` by **parsing the User-Agent string**, not by checking the viewport width. This means:

- A desktop browser resized to a narrow width still reports `deviceType === 'desktop'`
- Precision stays at 2 decimal places for large values
- Combined with `min-width: 2.5rem`, the formatted number overflows

The maintainer's question on #5987 ("why isn't `deviceType` mobile?") pointed directly at this: the UA string on a desktop browser will never report `'mobile'`, regardless of window size.

## Fix

Two-layer approach:

1. **Viewport-based precision check**: Replace the `deviceType() === 'mobile'` check with `window.matchMedia('(max-width: 575.98px)').matches`, which correctly detects narrow viewports regardless of device type. This matches the Bootstrap `sm` breakpoint already used elsewhere in the codebase (e.g. `theme.scss`, `landing-page.scss`, `webauthn-page.scss`).
2. **CSS safety net**: Add a `@media (max-width: 575.98px)` override that removes `min-width` from `.currency-container` and `.status-container` on narrow viewports, preventing overflow even if the precision logic doesn't fire.

## Note

The same `deviceType === 'mobile'` pattern for precision reduction exists in several other components (`holding-detail-dialog`, `portfolio-summary`, `analysis-page`). Those can be addressed in follow-up PRs if this approach is acceptable.

## Test plan

- [ ] Open app on desktop browser at full width with portfolio value >= 100,000 -- verify currency code displays correctly with 2 decimal places
- [ ] Resize browser below 576px -- verify precision reduces to 0 decimals and currency code does not overflow
- [ ] Open app on mobile device -- verify same behavior as narrow desktop
