### PR TITLE
Task/improve type safety in HTTP interceptor

### DIFF
--- a/apps/client/src/app/core/auth.guard.ts
+++ b/apps/client/src/app/core/auth.guard.ts
@@ -3,7 +3,7 @@ import { UserService } from '@ghostfolio/client/services/user/user.service';
 import { internalRoutes, publicRoutes } from '@ghostfolio/common/routes/routes';
 import { DataService } from '@ghostfolio/ui/services';
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
   Router,
@@ -14,12 +14,10 @@ import { catchError } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuard {
-  public constructor(
-    private dataService: DataService,
-    private router: Router,
-    private settingsStorageService: SettingsStorageService,
-    private userService: UserService
-  ) {}
+  private readonly dataService = inject(DataService);
+  private readonly router = inject(Router);
+  private readonly settingsStorageService = inject(SettingsStorageService);
+  private readonly userService = inject(UserService);
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     const utmSource = route.queryParams?.utm_source;

--- a/apps/client/src/app/core/auth.interceptor.ts
+++ b/apps/client/src/app/core/auth.interceptor.ts
@@ -13,20 +13,20 @@ import {
   HttpInterceptor,
   HttpRequest
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  public constructor(
-    private impersonationStorageService: ImpersonationStorageService,
-    private tokenStorageService: TokenStorageService
-  ) {}
+  private readonly impersonationStorageService = inject(
+    ImpersonationStorageService
+  );
+  private readonly tokenStorageService = inject(TokenStorageService);
 
-  public intercept(
-    req: HttpRequest<any>,
+  public intercept<T>(
+    req: HttpRequest<T>,
     next: HttpHandler
-  ): Observable<HttpEvent<any>> {
+  ): Observable<HttpEvent<T>> {
     let request = req;
 
     if (request.headers.has(HEADER_KEY_SKIP_INTERCEPTOR)) {

--- a/apps/client/src/app/core/http-response.interceptor.ts
+++ b/apps/client/src/app/core/http-response.interceptor.ts
@@ -12,7 +12,7 @@ import {
   HttpInterceptor,
   HttpRequest
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import {
   MatSnackBar,
   MatSnackBarRef,
@@ -29,13 +29,13 @@ export class HttpResponseInterceptor implements HttpInterceptor {
   public info: InfoItem;
   public snackBarRef: MatSnackBarRef<TextOnlySnackBar> | undefined;
 
-  public constructor(
-    private dataService: DataService,
-    private router: Router,
-    private snackBar: MatSnackBar,
-    private userService: UserService,
-    private webAuthnService: WebAuthnService
-  ) {
+  private readonly dataService = inject(DataService);
+  private readonly router = inject(Router);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly userService = inject(UserService);
+  private readonly webAuthnService = inject(WebAuthnService);
+
+  public constructor() {
     this.info = this.dataService.fetchInfo();
   }
 

--- a/apps/client/src/app/core/http-response.interceptor.ts
+++ b/apps/client/src/app/core/http-response.interceptor.ts
@@ -27,7 +27,7 @@ import { catchError, tap } from 'rxjs/operators';
 @Injectable()
 export class HttpResponseInterceptor implements HttpInterceptor {
   public info: InfoItem;
-  public snackBarRef: MatSnackBarRef<TextOnlySnackBar>;
+  public snackBarRef: MatSnackBarRef<TextOnlySnackBar> | undefined;
 
   public constructor(
     private dataService: DataService,
@@ -61,7 +61,7 @@ export class HttpResponseInterceptor implements HttpInterceptor {
                 }
               );
             } else if (
-              !error.url.includes(internalRoutes.auth.routerLink.join(''))
+              !error.url?.includes(internalRoutes.auth.routerLink.join(''))
             ) {
               this.snackBarRef = this.snackBar.open(
                 $localize`This action is not allowed.`,
@@ -72,11 +72,11 @@ export class HttpResponseInterceptor implements HttpInterceptor {
               );
             }
 
-            this.snackBarRef.afterDismissed().subscribe(() => {
+            this.snackBarRef?.afterDismissed().subscribe(() => {
               this.snackBarRef = undefined;
             });
 
-            this.snackBarRef.onAction().subscribe(() => {
+            this.snackBarRef?.onAction().subscribe(() => {
               this.router.navigate(publicRoutes.pricing.routerLink);
             });
           }
@@ -92,11 +92,11 @@ export class HttpResponseInterceptor implements HttpInterceptor {
               }
             );
 
-            this.snackBarRef.afterDismissed().subscribe(() => {
+            this.snackBarRef?.afterDismissed().subscribe(() => {
               this.snackBarRef = undefined;
             });
 
-            this.snackBarRef.onAction().subscribe(() => {
+            this.snackBarRef?.onAction().subscribe(() => {
               window.location.reload();
             });
           }
@@ -106,12 +106,12 @@ export class HttpResponseInterceptor implements HttpInterceptor {
               $localize`Oops! It looks like you’re making too many requests. Please slow down a bit.`
             );
 
-            this.snackBarRef.afterDismissed().subscribe(() => {
+            this.snackBarRef?.afterDismissed().subscribe(() => {
               this.snackBarRef = undefined;
             });
           }
         } else if (error.status === StatusCodes.UNAUTHORIZED) {
-          if (!error.url.includes('/data-providers/ghostfolio/status')) {
+          if (!error.url?.includes('/data-providers/ghostfolio/status')) {
             if (this.webAuthnService.isEnabled()) {
               this.router.navigate(internalRoutes.webauthn.routerLink);
             } else {

--- a/apps/client/src/app/core/http-response.interceptor.ts
+++ b/apps/client/src/app/core/http-response.interceptor.ts
@@ -22,7 +22,7 @@ import { Router } from '@angular/router';
 import { StatusCodes } from 'http-status-codes';
 import ms from 'ms';
 import { Observable, throwError } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 
 @Injectable()
 export class HttpResponseInterceptor implements HttpInterceptor {
@@ -44,9 +44,6 @@ export class HttpResponseInterceptor implements HttpInterceptor {
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(
-      tap((event: HttpEvent<any>) => {
-        return event;
-      }),
       catchError((error: HttpErrorResponse) => {
         if (error.status === StatusCodes.FORBIDDEN) {
           if (!this.snackBarRef) {

--- a/apps/client/src/app/core/http-response.interceptor.ts
+++ b/apps/client/src/app/core/http-response.interceptor.ts
@@ -26,8 +26,8 @@ import { catchError, tap } from 'rxjs/operators';
 
 @Injectable()
 export class HttpResponseInterceptor implements HttpInterceptor {
-  public info: InfoItem;
-  public snackBarRef: MatSnackBarRef<TextOnlySnackBar> | undefined;
+  private readonly info: InfoItem;
+  private snackBarRef: MatSnackBarRef<TextOnlySnackBar> | undefined;
 
   private readonly dataService = inject(DataService);
   private readonly router = inject(Router);

--- a/apps/client/src/app/core/http-response.interceptor.ts
+++ b/apps/client/src/app/core/http-response.interceptor.ts
@@ -39,10 +39,10 @@ export class HttpResponseInterceptor implements HttpInterceptor {
     this.info = this.dataService.fetchInfo();
   }
 
-  public intercept(
-    request: HttpRequest<any>,
+  public intercept<T>(
+    request: HttpRequest<T>,
     next: HttpHandler
-  ): Observable<HttpEvent<any>> {
+  ): Observable<HttpEvent<T>> {
     return next.handle(request).pipe(
       catchError((error: HttpErrorResponse) => {
         if (error.status === StatusCodes.FORBIDDEN) {


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- **Modernized Dependency Injection**: Refactored `HttpResponseInterceptor` and `AuthInterceptor` to use Angular's modern `inject()` function, removing the constructor parameter boilerplate.
- **Enhanced Type-Safety**: Refactored the signature of the `intercept` method in both interceptors to use generic types (`HttpRequest<T>` and `Observable<HttpEvent<T>>`) instead of `any`.
- **Resolved Null and Undefined Compiler Warnings**: Handled strict compilation issues in `HttpResponseInterceptor` by adding optional chaining for `error.url` (which is nullable) and `snackBarRef` (which can be undefined).
- **Cleaned Up Interception Chain**: Removed the redundant, no-op `tap` operator block and its unused import in `HttpResponseInterceptor` to reduce execution overhead.

## Additional context (if any)

These modernizations align both HTTP interceptors with Angular 21 best practices and eliminate runtime crash risks (such as trying to call `.afterDismissed()` on an uninitialized `snackBarRef` when triggering a forbidden error on the auth page).

## Resolved type errors

8 errors (before: 106, after: 98)