### PR TITLE
Task/improve type safety in file drop directive

### DIFF
--- a/apps/client/src/app/directives/file-drop/file-drop.directive.ts
+++ b/apps/client/src/app/directives/file-drop/file-drop.directive.ts
@@ -20,9 +20,10 @@ export class GfFileDropDirective {
     event.preventDefault();
     event.stopPropagation();
 
-    // Prevent the browser's default behavior for handling the file drop
-    event.dataTransfer.dropEffect = 'copy';
-
-    this.filesDropped.emit(event.dataTransfer.files);
+    if (event.dataTransfer) {
+      // Prevent the browser's default behavior for handling the file drop
+      event.dataTransfer.dropEffect = 'copy';
+      this.filesDropped.emit(event.dataTransfer.files);
+    }
   }
 }

--- a/apps/client/src/app/directives/file-drop/file-drop.directive.ts
+++ b/apps/client/src/app/directives/file-drop/file-drop.directive.ts
@@ -1,22 +1,27 @@
-import { Directive, HostListener, output } from '@angular/core';
+import { Directive, output } from '@angular/core';
 
 @Directive({
+  host: {
+    '(dragenter)': 'onDragEnter($event)',
+    '(dragover)': 'onDragOver($event)',
+    '(drop)': 'onDrop($event)'
+  },
   selector: '[gfFileDrop]'
 })
 export class GfFileDropDirective {
   public readonly filesDropped = output<FileList>();
 
-  @HostListener('dragenter', ['$event']) onDragEnter(event: DragEvent) {
+  public onDragEnter(event: DragEvent) {
     event.preventDefault();
     event.stopPropagation();
   }
 
-  @HostListener('dragover', ['$event']) onDragOver(event: DragEvent) {
+  public onDragOver(event: DragEvent) {
     event.preventDefault();
     event.stopPropagation();
   }
 
-  @HostListener('drop', ['$event']) onDrop(event: DragEvent) {
+  public onDrop(event: DragEvent) {
     event.preventDefault();
     event.stopPropagation();
 

--- a/apps/client/src/app/directives/file-drop/file-drop.directive.ts
+++ b/apps/client/src/app/directives/file-drop/file-drop.directive.ts
@@ -1,10 +1,10 @@
-import { Directive, EventEmitter, HostListener, Output } from '@angular/core';
+import { Directive, HostListener, output } from '@angular/core';
 
 @Directive({
   selector: '[gfFileDrop]'
 })
 export class GfFileDropDirective {
-  @Output() filesDropped = new EventEmitter<FileList>();
+  public readonly filesDropped = output<FileList>();
 
   @HostListener('dragenter', ['$event']) onDragEnter(event: DragEvent) {
     event.preventDefault();


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- **Resolved Strict Type Errors**: Guarded the file drop emission to guarantee `event.dataTransfer` and its associated `files` property are present, resolving the strict compilation error where a potentially undefined value was being emitted.
- **Modernized to Angular 21 Standards**:
  - Replaced the legacy `@Output()` decorator and `EventEmitter` class with the modern, functional `output()` API.
  - Refactored `@HostListener` decorators into declarative `host` metadata bindings within the `@Directive` decorator for cleaner, centralized configuration.

## Resolved type errors

2 errors (before: 98, after: 96)
