### PR TITLE
Task/improve type safety in analysis page component

### DIFF
--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -2,7 +2,10 @@ import { GfBenchmarkComparatorComponent } from '@ghostfolio/client/components/be
 import { GfInvestmentChartComponent } from '@ghostfolio/client/components/investment-chart/investment-chart.component';
 import { ImpersonationStorageService } from '@ghostfolio/client/services/impersonation-storage.service';
 import { UserService } from '@ghostfolio/client/services/user/user.service';
-import { NUMERICAL_PRECISION_THRESHOLD_6_FIGURES } from '@ghostfolio/common/config';
+import {
+  DEFAULT_DATE_RANGE,
+  NUMERICAL_PRECISION_THRESHOLD_6_FIGURES
+} from '@ghostfolio/common/config';
 import {
   HistoricalDataItem,
   InvestmentItem,
@@ -66,7 +69,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 export class GfAnalysisPageComponent implements OnInit {
   @ViewChild(MatMenuTrigger) actionsMenuButton!: MatMenuTrigger;
 
-  public benchmark: Partial<SymbolProfile>;
+  public benchmark?: Partial<SymbolProfile>;
   public benchmarkDataItems: HistoricalDataItem[] = [];
   public benchmarks: Partial<SymbolProfile>[];
   public bottom3: PortfolioPosition[];
@@ -122,6 +125,10 @@ export class GfAnalysisPageComponent implements OnInit {
       this.hasImpersonationId || this.user.settings.isRestrictedView
         ? undefined
         : this.user?.settings?.savingsRate;
+
+    if (savingsRatePerMonth === undefined) {
+      return undefined;
+    }
 
     return this.mode === 'year'
       ? savingsRatePerMonth * 12
@@ -228,7 +235,7 @@ export class GfAnalysisPageComponent implements OnInit {
       .fetchDividends({
         filters: this.userService.getFilters(),
         groupBy: this.mode,
-        range: this.user?.settings?.dateRange
+        range: this.user?.settings?.dateRange ?? DEFAULT_DATE_RANGE
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ dividends }) => {
@@ -243,7 +250,7 @@ export class GfAnalysisPageComponent implements OnInit {
       .fetchInvestments({
         filters: this.userService.getFilters(),
         groupBy: this.mode,
-        range: this.user?.settings?.dateRange
+        range: this.user?.settings?.dateRange ?? DEFAULT_DATE_RANGE
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ investments, streaks }) => {
@@ -278,7 +285,7 @@ export class GfAnalysisPageComponent implements OnInit {
     this.dataService
       .fetchPortfolioPerformance({
         filters: this.userService.getFilters(),
-        range: this.user?.settings?.dateRange
+        range: this.user?.settings?.dateRange ?? DEFAULT_DATE_RANGE
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ chart, firstOrderDate, performance }) => {
@@ -298,13 +305,16 @@ export class GfAnalysisPageComponent implements OnInit {
             valueInPercentage,
             valueWithCurrencyEffect
           }
-        ] of chart.entries()) {
+        ] of (chart ?? []).entries()) {
+          // Ignore first item where value is 0
           if (index > 0 || this.user?.settings?.dateRange === 'max') {
-            // Ignore first item where value is 0
-            this.investments.push({
-              date,
-              investment: totalInvestmentValueWithCurrencyEffect
-            });
+            if (totalInvestmentValueWithCurrencyEffect !== undefined) {
+              this.investments.push({
+                date,
+                investment: totalInvestmentValueWithCurrencyEffect
+              });
+            }
+
             this.performanceDataItems.push({
               date,
               value: isNumber(valueWithCurrencyEffect)
@@ -387,7 +397,7 @@ export class GfAnalysisPageComponent implements OnInit {
             dataSource,
             symbol,
             filters: this.userService.getFilters(),
-            range: this.user?.settings?.dateRange,
+            range: this.user?.settings?.dateRange ?? DEFAULT_DATE_RANGE,
             startDate: this.firstOrderDate
           })
           .pipe(takeUntilDestroyed(this.destroyRef))

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -68,42 +68,42 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './analysis-page.html'
 })
 export class GfAnalysisPageComponent implements OnInit {
-  public benchmark?: Partial<SymbolProfile>;
-  public benchmarkDataItems: HistoricalDataItem[] = [];
-  public benchmarks: Partial<SymbolProfile>[];
-  public bottom3: PortfolioPosition[];
-  public deviceType: string;
-  public dividendsByGroup: InvestmentItem[];
-  public dividendTimelineDataLabel = $localize`Dividend`;
-  public firstOrderDate: Date;
-  public hasImpersonationId: boolean;
-  public hasPermissionToReadAiPrompt: boolean;
-  public investments: InvestmentItem[];
-  public investmentTimelineDataLabel = $localize`Investment`;
-  public investmentsByGroup: InvestmentItem[];
-  public isLoadingAnalysisPrompt: boolean;
-  public isLoadingBenchmarkComparator: boolean;
-  public isLoadingDividendTimelineChart: boolean;
-  public isLoadingInvestmentChart: boolean;
-  public isLoadingInvestmentTimelineChart: boolean;
-  public isLoadingPortfolioPrompt: boolean;
-  public mode: GroupBy = 'month';
-  public modeOptions: ToggleOption[] = [
+  protected benchmark?: Partial<SymbolProfile>;
+  protected benchmarkDataItems: HistoricalDataItem[] = [];
+  protected benchmarks: Partial<SymbolProfile>[];
+  protected bottom3: PortfolioPosition[];
+  protected dividendsByGroup: InvestmentItem[];
+  protected dividendTimelineDataLabel = $localize`Dividend`;
+  protected hasImpersonationId: boolean;
+  protected hasPermissionToReadAiPrompt: boolean;
+  protected investments: InvestmentItem[];
+  protected investmentTimelineDataLabel = $localize`Investment`;
+  protected investmentsByGroup: InvestmentItem[];
+  protected isLoadingAnalysisPrompt: boolean;
+  protected isLoadingBenchmarkComparator: boolean;
+  protected isLoadingDividendTimelineChart: boolean;
+  protected isLoadingInvestmentChart: boolean;
+  protected isLoadingInvestmentTimelineChart: boolean;
+  protected isLoadingPortfolioPrompt: boolean;
+  protected mode: GroupBy = 'month';
+  protected modeOptions: ToggleOption[] = [
     { label: $localize`Monthly`, value: 'month' },
     { label: $localize`Yearly`, value: 'year' }
   ];
-  public performance: PortfolioPerformance;
-  public performanceDataItems: HistoricalDataItem[];
-  public performanceDataItemsInPercentage: HistoricalDataItem[];
-  public portfolioEvolutionDataLabel = $localize`Investment`;
-  public precision = 2;
-  public streaks: PortfolioInvestmentsResponse['streaks'];
-  public top3: PortfolioPosition[];
-  public unitCurrentStreak: string;
-  public unitLongestStreak: string;
-  public user: User;
+  protected performance: PortfolioPerformance;
+  protected performanceDataItems: HistoricalDataItem[];
+  protected performanceDataItemsInPercentage: HistoricalDataItem[];
+  protected portfolioEvolutionDataLabel = $localize`Investment`;
+  protected precision = 2;
+  protected streaks: PortfolioInvestmentsResponse['streaks'];
+  protected top3: PortfolioPosition[];
+  protected unitCurrentStreak: string;
+  protected unitLongestStreak: string;
+  protected user: User;
 
   private readonly actionsMenuButton = viewChild.required(MatMenuTrigger);
+  private deviceType: string;
+  private firstOrderDate: Date;
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly clipboard = inject(Clipboard);
@@ -168,7 +168,7 @@ export class GfAnalysisPageComponent implements OnInit {
       });
   }
 
-  public onChangeBenchmark(symbolProfileId: string) {
+  protected onChangeBenchmark(symbolProfileId: string) {
     this.dataService
       .putUserSetting({ benchmark: symbolProfileId })
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -184,12 +184,12 @@ export class GfAnalysisPageComponent implements OnInit {
       });
   }
 
-  public onChangeGroupBy(aMode: GroupBy) {
+  protected onChangeGroupBy(aMode: GroupBy) {
     this.mode = aMode;
     this.fetchDividendsAndInvestments();
   }
 
-  public onCopyPromptToClipboard(mode: AiPromptMode) {
+  protected onCopyPromptToClipboard(mode: AiPromptMode) {
     if (mode === 'analysis') {
       this.isLoadingAnalysisPrompt = true;
     } else if (mode === 'portfolio') {

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -31,6 +31,7 @@ import {
   DestroyRef,
   inject,
   OnInit,
+  signal,
   viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -86,7 +87,7 @@ export class GfAnalysisPageComponent implements OnInit {
   protected isLoadingInvestmentChart: boolean;
   protected isLoadingInvestmentTimelineChart: boolean;
   protected isLoadingPortfolioPrompt: boolean;
-  protected mode: GroupBy = 'month';
+  protected readonly mode = signal<GroupBy>('month');
   protected readonly modeOptions: ToggleOption[] = [
     { label: $localize`Monthly`, value: 'month' },
     { label: $localize`Yearly`, value: 'year' }
@@ -136,7 +137,7 @@ export class GfAnalysisPageComponent implements OnInit {
       return undefined;
     }
 
-    return this.mode === 'year'
+    return this.mode() === 'year'
       ? savingsRatePerMonth * 12
       : savingsRatePerMonth;
   }
@@ -186,7 +187,7 @@ export class GfAnalysisPageComponent implements OnInit {
   }
 
   protected onChangeGroupBy(aMode: GroupBy) {
-    this.mode = aMode;
+    this.mode.set(aMode);
     this.fetchDividendsAndInvestments();
   }
 
@@ -238,7 +239,7 @@ export class GfAnalysisPageComponent implements OnInit {
     this.dataService
       .fetchDividends({
         filters: this.userService.getFilters(),
-        groupBy: this.mode,
+        groupBy: this.mode(),
         range: this.user?.settings?.dateRange ?? DEFAULT_DATE_RANGE
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -253,7 +254,7 @@ export class GfAnalysisPageComponent implements OnInit {
     this.dataService
       .fetchInvestments({
         filters: this.userService.getFilters(),
-        groupBy: this.mode,
+        groupBy: this.mode(),
         range: this.user?.settings?.dateRange ?? DEFAULT_DATE_RANGE
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -261,7 +262,7 @@ export class GfAnalysisPageComponent implements OnInit {
         this.investmentsByGroup = investments;
         this.streaks = streaks;
         this.unitCurrentStreak =
-          this.mode === 'year'
+          this.mode() === 'year'
             ? this.streaks?.currentStreak === 1
               ? translate('YEAR')
               : translate('YEARS')
@@ -269,7 +270,7 @@ export class GfAnalysisPageComponent implements OnInit {
               ? translate('MONTH')
               : translate('MONTHS');
         this.unitLongestStreak =
-          this.mode === 'year'
+          this.mode() === 'year'
             ? this.streaks?.longestStreak === 1
               ? translate('YEAR')
               : translate('YEARS')

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -28,6 +28,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  inject,
   OnInit,
   ViewChild
 } from '@angular/core';
@@ -104,16 +105,18 @@ export class GfAnalysisPageComponent implements OnInit {
   public unitLongestStreak: string;
   public user: User;
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private clipboard: Clipboard,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private deviceDetectorService: DeviceDetectorService,
-    private impersonationStorageService: ImpersonationStorageService,
-    private snackBar: MatSnackBar,
-    private userService: UserService
-  ) {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly clipboard = inject(Clipboard);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly impersonationStorageService = inject(
+    ImpersonationStorageService
+  );
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
     const { benchmarks } = this.dataService.fetchInfo();
     this.benchmarks = benchmarks;
 

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -70,14 +70,14 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 export class GfAnalysisPageComponent implements OnInit {
   protected benchmark?: Partial<SymbolProfile>;
   protected benchmarkDataItems: HistoricalDataItem[] = [];
-  protected benchmarks: Partial<SymbolProfile>[];
+  protected readonly benchmarks: Partial<SymbolProfile>[];
   protected bottom3: PortfolioPosition[];
   protected dividendsByGroup: InvestmentItem[];
-  protected dividendTimelineDataLabel = $localize`Dividend`;
+  protected readonly dividendTimelineDataLabel = $localize`Dividend`;
   protected hasImpersonationId: boolean;
   protected hasPermissionToReadAiPrompt: boolean;
   protected investments: InvestmentItem[];
-  protected investmentTimelineDataLabel = $localize`Investment`;
+  protected readonly investmentTimelineDataLabel = $localize`Investment`;
   protected investmentsByGroup: InvestmentItem[];
   protected isLoadingAnalysisPrompt: boolean;
   protected isLoadingBenchmarkComparator: boolean;
@@ -86,14 +86,14 @@ export class GfAnalysisPageComponent implements OnInit {
   protected isLoadingInvestmentTimelineChart: boolean;
   protected isLoadingPortfolioPrompt: boolean;
   protected mode: GroupBy = 'month';
-  protected modeOptions: ToggleOption[] = [
+  protected readonly modeOptions: ToggleOption[] = [
     { label: $localize`Monthly`, value: 'month' },
     { label: $localize`Yearly`, value: 'year' }
   ];
   protected performance: PortfolioPerformance;
   protected performanceDataItems: HistoricalDataItem[];
   protected performanceDataItemsInPercentage: HistoricalDataItem[];
-  protected portfolioEvolutionDataLabel = $localize`Investment`;
+  protected readonly portfolioEvolutionDataLabel = $localize`Investment`;
   protected precision = 2;
   protected streaks: PortfolioInvestmentsResponse['streaks'];
   protected top3: PortfolioPosition[];

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -27,6 +27,7 @@ import { Clipboard } from '@angular/cdk/clipboard';
 import {
   ChangeDetectorRef,
   Component,
+  computed,
   DestroyRef,
   inject,
   OnInit,
@@ -102,7 +103,9 @@ export class GfAnalysisPageComponent implements OnInit {
   protected user: User;
 
   private readonly actionsMenuButton = viewChild.required(MatMenuTrigger);
-  private deviceType: string;
+  private readonly deviceType = computed(
+    () => this.deviceDetectorService.deviceInfo().deviceType
+  );
   private firstOrderDate: Date;
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
@@ -139,8 +142,6 @@ export class GfAnalysisPageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.deviceType = this.deviceDetectorService.getDeviceInfo().deviceType;
-
     this.impersonationStorageService
       .onChangeHasImpersonation()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -333,7 +334,7 @@ export class GfAnalysisPageComponent implements OnInit {
         }
 
         if (
-          this.deviceType === 'mobile' &&
+          this.deviceType() === 'mobile' &&
           this.performance.currentValueInBaseCurrency >=
             NUMERICAL_PRECISION_THRESHOLD_6_FIGURES
         ) {

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -30,7 +30,7 @@ import {
   DestroyRef,
   inject,
   OnInit,
-  ViewChild
+  viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
@@ -68,8 +68,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './analysis-page.html'
 })
 export class GfAnalysisPageComponent implements OnInit {
-  @ViewChild(MatMenuTrigger) actionsMenuButton!: MatMenuTrigger;
-
   public benchmark?: Partial<SymbolProfile>;
   public benchmarkDataItems: HistoricalDataItem[] = [];
   public benchmarks: Partial<SymbolProfile>[];
@@ -104,6 +102,8 @@ export class GfAnalysisPageComponent implements OnInit {
   public unitCurrentStreak: string;
   public unitLongestStreak: string;
   public user: User;
+
+  private readonly actionsMenuButton = viewChild.required(MatMenuTrigger);
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly clipboard = inject(Clipboard);
@@ -220,7 +220,7 @@ export class GfAnalysisPageComponent implements OnInit {
             window.open('https://duck.ai', '_blank');
           });
 
-        this.actionsMenuButton.closeMenu();
+        this.actionsMenuButton().closeMenu();
 
         if (mode === 'analysis') {
           this.isLoadingAnalysisPrompt = false;

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.html
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.html
@@ -442,7 +442,7 @@
         </div>
         <gf-toggle
           class="d-none d-lg-block"
-          [defaultValue]="mode"
+          [defaultValue]="mode()"
           [isLoading]="false"
           [options]="modeOptions"
           (valueChange)="onChangeGroupBy($event.value)"
@@ -476,7 +476,7 @@
           [benchmarkDataItems]="investmentsByGroup"
           [benchmarkDataLabel]="investmentTimelineDataLabel"
           [currency]="user?.settings?.baseCurrency"
-          [groupBy]="mode"
+          [groupBy]="mode()"
           [isInPercentage]="
             hasImpersonationId || user.settings.isRestrictedView
           "
@@ -501,7 +501,7 @@
         </div>
         <gf-toggle
           class="d-none d-lg-block"
-          [defaultValue]="mode"
+          [defaultValue]="mode()"
           [isLoading]="false"
           [options]="modeOptions"
           (valueChange)="onChangeGroupBy($event.value)"
@@ -513,7 +513,7 @@
           [benchmarkDataItems]="dividendsByGroup"
           [benchmarkDataLabel]="dividendTimelineDataLabel"
           [currency]="user?.settings?.baseCurrency"
-          [groupBy]="mode"
+          [groupBy]="mode()"
           [isInPercentage]="
             hasImpersonationId || user.settings.isRestrictedView
           "


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- **Type Safety**: Resolved all 8 strict type errors in `analysis-page.component.ts` (safe navigation, undefined checks, and list fallback mappings).
- **Modern DI**: Replaced constructor-based dependency injection with the modern `inject()` function.
- **Signal Queries**: Replaced the legacy `@ViewChild` decorator with the modern `viewChild.required()` signal query.
- **Encapsulation**: Enforced `protected` visibility for template-bound members, and `private` for internal helpers.
- **Readability**: Enforced `readonly` on properties that are never reassigned.
- **API Updates**: Replaced the deprecated `getDeviceInfo()` call with a `computed` signal reading `deviceInfo()`.
- **Signal State**: Converted the `mode` property into a writable signal and updated associated template bindings (`mode()`).

## Resolved type errors

8 errors (before: 98, after: 90)