### PR TITLE
Feature/add active or closed toggle to holdings overview on mobile

### DIFF
--- a/apps/client/src/app/components/home-holdings/home-holdings.html
+++ b/apps/client/src/app/components/home-holdings/home-holdings.html
@@ -24,7 +24,6 @@
         </div>
         <div class="align-items-center d-flex flex-grow-1 justify-content-end">
           <gf-toggle
-            class="d-none d-lg-block"
             [defaultValue]="holdingType"
             [isLoading]="false"
             [options]="holdingTypeOptions"


### PR DESCRIPTION
Feature/add active or closed toggle to holdings overview on mobile.

<img width="463" height="979" alt="image" src="https://github.com/user-attachments/assets/809a4211-2159-42d2-9d8a-273cd8787e44" />
