### PR TITLE
Feature/add active or closed toggle to holdings overview on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added active/closed toggle to holdings overview on mobile
 - Added support for routing selected requests through the _OpenRouter_ `web_fetch` tool in the `FetchService`
 
 ### Changed

--- a/apps/client/src/app/components/home-holdings/home-holdings.html
+++ b/apps/client/src/app/components/home-holdings/home-holdings.html
@@ -24,7 +24,6 @@
         </div>
         <div class="align-items-center d-flex flex-grow-1 justify-content-end">
           <gf-toggle
-            class="d-none d-lg-block"
             [defaultValue]="holdingType"
             [isLoading]="false"
             [options]="holdingTypeOptions"


### PR DESCRIPTION
Feature/add active or closed toggle to holdings overview on mobile.

<img width="463" height="979" alt="image" src="https://github.com/user-attachments/assets/7be4081c-9b4e-4ff0-8a9a-cd0937c2164e" />
