### PR TITLE
Task/prefill form with current cash balance value in account details dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevented the floating action button from overlapping the paginator on mobile
 - Fixed an issue where the asset profile override (asset class and asset sub class) was not applied to the data enhancers when gathering asset profiles
 - Fixed a layout issue in the asset profile dialog of the admin control panel by truncating long titles
+- Prefilled the account balance form in the account detail dialog with the current cash balance
 
 ## 3.7.0 - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Prefilled the form in the account balance management with the current cash balance
+
 ## 3.8.0 - 2026-06-07
 
 ### Added
@@ -29,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevented the floating action button from overlapping the paginator on mobile
 - Fixed an issue where the asset profile override (asset class and asset sub class) was not applied to the data enhancers when gathering asset profiles
 - Fixed a layout issue in the asset profile dialog of the admin control panel by truncating long titles
-- Prefilled the account balance form in the account detail dialog with the current cash balance
 
 ## 3.7.0 - 2026-06-02
 

--- a/apps/client/src/app/components/account-detail-dialog/account-detail-dialog.html
+++ b/apps/client/src/app/components/account-detail-dialog/account-detail-dialog.html
@@ -148,6 +148,7 @@
           [accountBalances]="accountBalances"
           [accountCurrency]="currency"
           [accountId]="data.accountId"
+          [currentBalance]="balance"
           [locale]="user?.settings?.locale"
           [showActions]="
             !data.hasImpersonationId &&

--- a/libs/ui/src/lib/account-balances/account-balances.component.ts
+++ b/libs/ui/src/lib/account-balances/account-balances.component.ts
@@ -70,6 +70,7 @@ export class GfAccountBalancesComponent implements OnChanges, OnInit {
     input.required<AccountBalancesResponse['balances']>();
   public readonly accountCurrency = input.required<string>();
   public readonly accountId = input.required<string>();
+  public readonly currentBalance = input<number | null>();
   public readonly displayedColumns: string[] = ['date', 'value', 'actions'];
   public readonly locale = input(getLocale());
   public readonly showActions = input(true);
@@ -102,6 +103,8 @@ export class GfAccountBalancesComponent implements OnChanges, OnInit {
       this.dataSource.sort = this.sort();
       this.dataSource.sortingDataAccessor = get;
     }
+
+    this.prefillAccountBalanceForm();
   }
 
   public onDeleteAccountBalance(aId: string) {
@@ -139,5 +142,18 @@ export class GfAccountBalancesComponent implements OnChanges, OnInit {
     }
 
     this.accountBalanceCreated.emit(accountBalance);
+  }
+
+  private prefillAccountBalanceForm() {
+    const currentBalance = this.currentBalance();
+
+    if (
+      typeof currentBalance !== 'number' ||
+      !this.accountBalanceForm.controls.balance.pristine
+    ) {
+      return;
+    }
+
+    this.accountBalanceForm.patchValue({ balance: currentBalance });
   }
 }

--- a/libs/ui/src/lib/account-balances/account-balances.component.ts
+++ b/libs/ui/src/lib/account-balances/account-balances.component.ts
@@ -13,6 +13,7 @@ import {
   OnChanges,
   OnInit,
   Output,
+  effect,
   inject,
   input,
   viewChild
@@ -90,6 +91,17 @@ export class GfAccountBalancesComponent implements OnChanges, OnInit {
 
   public constructor() {
     addIcons({ calendarClearOutline, ellipsisHorizontal, trashOutline });
+
+    effect(() => {
+      const currentBalance = this.currentBalance();
+
+      if (
+        this.accountBalanceForm.controls.balance.pristine &&
+        typeof currentBalance === 'number'
+      ) {
+        this.accountBalanceForm.controls.balance.setValue(currentBalance);
+      }
+    });
   }
 
   public ngOnInit() {
@@ -103,8 +115,6 @@ export class GfAccountBalancesComponent implements OnChanges, OnInit {
       this.dataSource.sort = this.sort();
       this.dataSource.sortingDataAccessor = get;
     }
-
-    this.prefillAccountBalanceForm();
   }
 
   public onDeleteAccountBalance(aId: string) {
@@ -142,18 +152,5 @@ export class GfAccountBalancesComponent implements OnChanges, OnInit {
     }
 
     this.accountBalanceCreated.emit(accountBalance);
-  }
-
-  private prefillAccountBalanceForm() {
-    const currentBalance = this.currentBalance();
-
-    if (
-      typeof currentBalance !== 'number' ||
-      !this.accountBalanceForm.controls.balance.pristine
-    ) {
-      return;
-    }
-
-    this.accountBalanceForm.patchValue({ balance: currentBalance });
   }
 }


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #6983, please take a look.

### Summary
Prefills the cash balance form in the account details dialog with the account’s current cash balance so users can add a new balance entry without retyping the existing value.

### Changes
- Added a `currentBalance` input to `gf-account-balances`.
- Passed the current account balance from the account details dialog into the cash balances component.
- Prefilled the balance form control with the current balance when the form is first shown, without overwriting user edits.