### PR TITLE
Fix portfolio calculation crash when an exchange rate is missing

### DIFF
--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -145,10 +145,18 @@ export abstract class PortfolioCalculator {
             tags,
             type,
             date: format(date, DATE_FORMAT),
-            fee: new Big(feeInAssetProfileCurrency),
-            feeInBaseCurrency: new Big(feeInBaseCurrency),
+            fee: this.parseToBig(feeInAssetProfileCurrency, 'fee', SymbolProfile),
+            feeInBaseCurrency: this.parseToBig(
+              feeInBaseCurrency,
+              'feeInBaseCurrency',
+              SymbolProfile
+            ),
             quantity: new Big(quantity),
-            unitPrice: new Big(unitPriceInAssetProfileCurrency)
+            unitPrice: this.parseToBig(
+              unitPriceInAssetProfileCurrency,
+              'unitPrice',
+              SymbolProfile
+            )
           };
         }
       )
@@ -171,6 +179,35 @@ export abstract class PortfolioCalculator {
     this.computeTransactionPoints();
 
     this.snapshotPromise = this.initialize();
+  }
+
+  // Coerce an activity value into a Big, tolerating a missing/non-finite input.
+  // Values that depend on a currency conversion (fee and unit price expressed in
+  // the asset profile or base currency) arrive as null/NaN when no exchange rate
+  // is available for the activity's currency and date. Passing such a value to
+  // `new Big()` throws "[big.js] Invalid number" inside the constructor, which
+  // aborts the whole portfolio calculation — a single unconvertible activity then
+  // fails the entire performance/details response. Default to 0 and warn instead,
+  // so the rest of the portfolio still renders.
+  private parseToBig(
+    value: number,
+    field: string,
+    symbolProfile?: { currency?: string; dataSource?: string; symbol?: string }
+  ): Big {
+    if (value == null || !Number.isFinite(value)) {
+      Logger.warn(
+        `Missing or invalid "${field}" (${value})` +
+          (symbolProfile?.symbol
+            ? ` for ${symbolProfile.dataSource}/${symbolProfile.symbol} (${symbolProfile.currency})`
+            : '') +
+          `; defaulting to 0 (likely an unavailable exchange rate)`,
+        'PortfolioCalculator'
+      );
+
+      return new Big(0);
+    }
+
+    return new Big(value);
   }
 
   protected abstract calculateOverallPerformance(

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-missing-exchange-rate.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-missing-exchange-rate.spec.ts
@@ -1,0 +1,134 @@
+import {
+  activityDummyData,
+  symbolProfileDummyData,
+  userDummyData
+} from '@ghostfolio/api/app/portfolio/calculator/portfolio-calculator-test-utils';
+import { PortfolioCalculatorFactory } from '@ghostfolio/api/app/portfolio/calculator/portfolio-calculator.factory';
+import { CurrentRateService } from '@ghostfolio/api/app/portfolio/current-rate.service';
+import { CurrentRateServiceMock } from '@ghostfolio/api/app/portfolio/current-rate.service.mock';
+import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.service';
+import { RedisCacheServiceMock } from '@ghostfolio/api/app/redis-cache/redis-cache.service.mock';
+import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
+import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { PortfolioSnapshotService } from '@ghostfolio/api/services/queues/portfolio-snapshot/portfolio-snapshot.service';
+import { PortfolioSnapshotServiceMock } from '@ghostfolio/api/services/queues/portfolio-snapshot/portfolio-snapshot.service.mock';
+import { parseDate } from '@ghostfolio/common/helper';
+import { Activity } from '@ghostfolio/common/interfaces';
+import { PerformanceCalculationType } from '@ghostfolio/common/types/performance-calculation-type.type';
+
+import { Logger } from '@nestjs/common';
+import { Big } from 'big.js';
+
+jest.mock('@ghostfolio/api/app/portfolio/current-rate.service', () => {
+  return {
+    CurrentRateService: jest.fn().mockImplementation(() => {
+      return CurrentRateServiceMock;
+    })
+  };
+});
+
+jest.mock(
+  '@ghostfolio/api/services/queues/portfolio-snapshot/portfolio-snapshot.service',
+  () => {
+    return {
+      PortfolioSnapshotService: jest.fn().mockImplementation(() => {
+        return PortfolioSnapshotServiceMock;
+      })
+    };
+  }
+);
+
+jest.mock('@ghostfolio/api/app/redis-cache/redis-cache.service', () => {
+  return {
+    RedisCacheService: jest.fn().mockImplementation(() => {
+      return RedisCacheServiceMock;
+    })
+  };
+});
+
+describe('PortfolioCalculator', () => {
+  let configurationService: ConfigurationService;
+  let currentRateService: CurrentRateService;
+  let exchangeRateDataService: ExchangeRateDataService;
+  let portfolioCalculatorFactory: PortfolioCalculatorFactory;
+  let portfolioSnapshotService: PortfolioSnapshotService;
+  let redisCacheService: RedisCacheService;
+
+  beforeEach(() => {
+    configurationService = new ConfigurationService();
+
+    currentRateService = new CurrentRateService(null, null, null, null);
+
+    exchangeRateDataService = new ExchangeRateDataService(
+      null,
+      null,
+      null,
+      null
+    );
+
+    portfolioSnapshotService = new PortfolioSnapshotService(null);
+
+    redisCacheService = new RedisCacheService(null, null);
+
+    portfolioCalculatorFactory = new PortfolioCalculatorFactory(
+      configurationService,
+      currentRateService,
+      exchangeRateDataService,
+      portfolioSnapshotService,
+      redisCacheService
+    );
+  });
+
+  describe('with a missing exchange rate', () => {
+    it.only('tolerates an unconvertible activity value instead of throwing', async () => {
+      jest.useFakeTimers().setSystemTime(parseDate('2021-12-18').getTime());
+
+      const warnSpy = jest
+        .spyOn(Logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      // When Ghostfolio has no exchange rate for an activity's currency/date, the
+      // currency-converted fields (here the fee, in both the asset profile and base
+      // currency) arrive as NaN. Previously `new Big(NaN)` threw "[big.js] Invalid
+      // number" inside the constructor and aborted the entire calculation; a single
+      // unconvertible activity then failed the whole performance/details response.
+      const activities: Activity[] = [
+        {
+          ...activityDummyData,
+          date: new Date('2021-11-30'),
+          feeInAssetProfileCurrency: NaN,
+          feeInBaseCurrency: NaN,
+          quantity: 2,
+          SymbolProfile: {
+            ...symbolProfileDummyData,
+            currency: 'CHF',
+            dataSource: 'YAHOO',
+            name: 'Bâloise Holding AG',
+            symbol: 'BALN.SW'
+          },
+          type: 'BUY',
+          unitPriceInAssetProfileCurrency: 136.6
+        }
+      ];
+
+      const portfolioCalculator = portfolioCalculatorFactory.createCalculator({
+        activities,
+        calculationType: PerformanceCalculationType.ROAI,
+        currency: 'CHF',
+        userId: userDummyData.id
+      });
+
+      const portfolioSnapshot = await portfolioCalculator.computeSnapshot();
+
+      // The unconvertible values default to 0 rather than crashing the calculation,
+      // and the guard logs a warning.
+      expect(warnSpy).toHaveBeenCalled();
+      expect(portfolioSnapshot.positions[0].fee).toEqual(new Big(0));
+      expect(portfolioSnapshot.positions[0].feeInBaseCurrency).toEqual(
+        new Big(0)
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

If a portfolio holds an activity whose currency Ghostfolio cannot convert to the asset-profile or base currency for the activity's date (no exchange rate available), the portfolio performance/details endpoint crashes with a 500:

```
ERROR [ExchangeRateDataService] No exchange rate has been found for GBPEUR at 2021-09-20
ERROR [ExceptionsHandler] Error: [big.js] Invalid number
    at new Big (.../big.js)
    at new PortfolioCalculator (...)        // Array.map over activities
    at PortfolioCalculatorFactory.createCalculator
    at PortfolioService.getPerformance
```

In the `PortfolioCalculator` constructor, activities are mapped into `new Big(...)` for `fee` (`feeInAssetProfileCurrency`), `feeInBaseCurrency`, and `unitPrice` (`unitPriceInAssetProfileCurrency`). Those three values come from a currency conversion; when no rate exists they are `null`/`NaN`, and `new Big(NaN)` throws `[big.js] Invalid number`. Because it happens during construction, the whole calculation aborts — one unconvertible activity 500s the entire dashboard.

**Reproduction:** hold a security in a currency with incomplete historical FX data (e.g. an LSE `GBp` listing, or a `.SA`/`BRL` symbol with no `USDBRL` history) while the account base currency differs, then open the portfolio.

## Fix

Add a small `parseToBig(value, field, symbolProfile)` guard used for the three currency-converted fields. A `null`/non-finite value defaults to `Big(0)` and logs a `Logger.warn` naming the field and symbol, so the rest of the portfolio renders instead of the request failing. `quantity` keeps a direct `new Big()` because it is never currency-converted.

This is intentionally fail-soft: a missing rate degrades one activity (with a logged warning) rather than taking down the response. The deeper fix — gathering exchange-rate market data for every held currency — is orthogonal.

## Notes

- Opened as a **draft**: I could not run the full monorepo build/test locally, so CI should validate.
- Localized to `apps/api/src/app/portfolio/calculator/portfolio-calculator.ts` (one helper + 3 call sites).
