### PR TITLE
Prevent repeated requests for failed entity logos

### DIFF
--- a/libs/ui/src/lib/entity-logo/entity-logo-image-source.service.ts
+++ b/libs/ui/src/lib/entity-logo/entity-logo-image-source.service.ts
@@ -7,6 +7,8 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class EntityLogoImageSourceService {
+  private failedImageSources = new Set<string>();
+
   public getLogoUrlByAssetProfileIdentifier({
     dataSource,
     symbol
@@ -16,5 +18,13 @@ export class EntityLogoImageSourceService {
 
   public getLogoUrlByUrl(url: string) {
     return `../api/v1/logo?url=${url}`;
+  }
+
+  public hasFailed(imageSource: string) {
+    return this.failedImageSources.has(imageSource);
+  }
+
+  public markAsFailed(imageSource: string) {
+    this.failedImageSources.add(imageSource);
   }
 }

--- a/libs/ui/src/lib/entity-logo/entity-logo.component.html
+++ b/libs/ui/src/lib/entity-logo/entity-logo.component.html
@@ -1,8 +1,8 @@
 @if (src) {
   <img
-    onerror="this.style.display = 'none'"
     [class.large]="size === 'large'"
     [src]="src"
     [title]="tooltip ? tooltip : ''"
+    (error)="onLogoError()"
   />
 }

--- a/libs/ui/src/lib/entity-logo/entity-logo.component.ts
+++ b/libs/ui/src/lib/entity-logo/entity-logo.component.ts
@@ -23,7 +23,7 @@ export class GfEntityLogoComponent implements OnChanges {
   @Input() tooltip: string;
   @Input() url: string;
 
-  public src: string;
+  public src: string | undefined;
 
   public constructor(
     private readonly imageSourceService: EntityLogoImageSourceService
@@ -31,12 +31,28 @@ export class GfEntityLogoComponent implements OnChanges {
 
   public ngOnChanges() {
     if (this.dataSource && this.symbol) {
-      this.src = this.imageSourceService.getLogoUrlByAssetProfileIdentifier({
-        dataSource: this.dataSource,
-        symbol: this.symbol
-      });
+      const candidateSrc =
+        this.imageSourceService.getLogoUrlByAssetProfileIdentifier({
+          dataSource: this.dataSource,
+          symbol: this.symbol
+        });
+
+      this.src = this.imageSourceService.hasFailed(candidateSrc)
+        ? undefined
+        : candidateSrc;
     } else if (this.url) {
-      this.src = this.imageSourceService.getLogoUrlByUrl(this.url);
+      const candidateSrc = this.imageSourceService.getLogoUrlByUrl(this.url);
+
+      this.src = this.imageSourceService.hasFailed(candidateSrc)
+        ? undefined
+        : candidateSrc;
+    }
+  }
+
+  public onLogoError() {
+    if (this.src) {
+      this.imageSourceService.markAsFailed(this.src);
+      this.src = undefined;
     }
   }
 }


### PR DESCRIPTION
### Summary

This PR prevents repeated frontend requests for entity logo URLs that have already failed during the current app session.

Previously, failed logo images were hidden using an inline `onerror` handler. However, when logo components were recreated through route navigation, sorting, filtering, adding activities, or table updates, the same missing logo URL could be requested again and return another 404.

### Changes

* Added an in-memory failed image source cache to `EntityLogoImageSourceService`.
* Skips rendering entity logos whose image source already failed during the current app session.
* Replaced inline image error handling with Angular `(error)` handling.
* Kept backend behavior unchanged.

### Notes

The cache is intentionally in-memory and session-scoped. A full browser reload retries failed logo URLs, so this does not permanently suppress logos that may become available later.

### Verification

* `npx nx test ui`
* `npx nx lint ui`
* Manually verified that failed logo URLs are requested once after a full page reload, but are not requested again during normal navigation, sorting, filtering, or adding activities after the first failure.

### Demo

**Before**

The first video shows the same failed logo URL being requested repeatedly after route navigation/table recreation.


https://github.com/user-attachments/assets/90adc999-1307-4894-8b9e-4ee19090e6d3



**After**

The second video shows that after this change, the failed logo URL is requested once after a full reload, then skipped during normal navigation/sorting/filtering in the same app session.


https://github.com/user-attachments/assets/f32e366c-5bc8-4a48-850c-64316bbc86ec

