### PR TITLE
Task/improve language localization for KO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefilled the form in the account balance management with the current cash balance
 - Disabled the selection of future dates in the account balance management
-- Improved the language localization for Korean (ko)
+- Improved the language localization for Korean (`ko`)
 
 ## 3.8.0 - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefilled the form in the account balance management with the current cash balance
 - Disabled the selection of future dates in the account balance management
+- Improved the language localization for Korean (ko)
 
 ## 3.8.0 - 2026-06-07
 

--- a/apps/client/src/locales/messages.ko.xlf
+++ b/apps/client/src/locales/messages.ko.xlf
@@ -6891,7 +6891,7 @@
       </trans-unit>
       <trans-unit id="8375528527939577247" datatype="html">
         <source><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> Change with currency effect <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> Change <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></source>
-        <target state="translated">환율 효과 반영 변동</target>
+        <target state="translated"><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> 환율 효과 반영 변동 <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> 변동 <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html</context>
           <context context-type="linenumber">63</context>

--- a/apps/client/src/locales/messages.ko.xlf
+++ b/apps/client/src/locales/messages.ko.xlf
@@ -585,7 +585,7 @@
       </trans-unit>
       <trans-unit id="8280212421112607879" datatype="html">
         <source>Do you really want to delete this account?</source>
-        <target state="translated">이 계정을 정말 삭제하시겠습니까?</target>
+        <target state="translated">이 계좌를 정말 삭제하시겠습니까?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/accounts-table/accounts-table.component.ts</context>
           <context context-type="linenumber">146</context>
@@ -721,7 +721,7 @@
       </trans-unit>
       <trans-unit id="3973560112150137298" datatype="html">
         <source>Find an account...</source>
-        <target state="new">Find an account...</target>
+        <target state="translated">계좌 검색...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/assistant/assistant.component.ts</context>
           <context context-type="linenumber">471</context>
@@ -809,7 +809,7 @@
       </trans-unit>
       <trans-unit id="6182733719813772142" datatype="html">
         <source>First Activity</source>
-        <target state="translated">첫 활동</target>
+        <target state="translated">첫 거래</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/admin-market-data.html</context>
           <context context-type="linenumber">147</context>
@@ -829,7 +829,7 @@
       </trans-unit>
       <trans-unit id="6424689559488978075" datatype="html">
         <source>Activities Count</source>
-        <target state="translated">활동 수</target>
+        <target state="translated">거래 건수</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/admin-market-data.html</context>
           <context context-type="linenumber">156</context>
@@ -901,7 +901,7 @@
       </trans-unit>
       <trans-unit id="7194017842579795231" datatype="html">
         <source>Healthcare</source>
-        <target state="new">Healthcare</target>
+        <target state="translated">헬스케어</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">92</context>
@@ -1017,7 +1017,7 @@
       </trans-unit>
       <trans-unit id="5765523585863707029" datatype="html">
         <source>Technology</source>
-        <target state="new">Technology</target>
+        <target state="translated">기술</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">96</context>
@@ -1073,7 +1073,7 @@
       </trans-unit>
       <trans-unit id="4581276194280068721" datatype="html">
         <source>Industrials</source>
-        <target state="new">Industrials</target>
+        <target state="translated">산업재</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">93</context>
@@ -1109,7 +1109,7 @@
       </trans-unit>
       <trans-unit id="2691624743109891676" datatype="html">
         <source>Consumer Cyclical</source>
-        <target state="new">Consumer Cyclical</target>
+        <target state="translated">임의소비재</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">88</context>
@@ -1269,7 +1269,7 @@
       </trans-unit>
       <trans-unit id="8319378030525016917" datatype="html">
         <source>Asset profile has been saved</source>
-        <target state="new">Asset profile has been saved</target>
+        <target state="translated">자산 정보가 저장되었습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts</context>
           <context context-type="linenumber">624</context>
@@ -1285,7 +1285,7 @@
       </trans-unit>
       <trans-unit id="7701575534145602925" datatype="html">
         <source>Explore <x id="INTERPOLATION" equiv-text="{{ item.title }}"/></source>
-        <target state="new">Explore <x id="INTERPOLATION" equiv-text="{{ item.title }}"/></target>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ item.title }}"/> 둘러보기</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/resources/overview/resources-overview.component.html</context>
           <context context-type="linenumber">11</context>
@@ -1449,7 +1449,7 @@
       </trans-unit>
       <trans-unit id="7341990227686441824" datatype="html">
         <source>Could not validate form</source>
-        <target state="new">Could not validate form</target>
+        <target state="translated">양식 유효성 검사에 실패했습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts</context>
           <context context-type="linenumber">600</context>
@@ -1573,7 +1573,7 @@
       </trans-unit>
       <trans-unit id="5047379499293213623" datatype="html">
         <source>Manage Activities</source>
-        <target state="translated">활동 관리</target>
+        <target state="translated">거래 내역 관리</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-holdings/home-holdings.html</context>
           <context context-type="linenumber">64</context>
@@ -1649,7 +1649,7 @@
       </trans-unit>
       <trans-unit id="2091702622073737696" datatype="html">
         <source>Setup your accounts</source>
-        <target state="translated">계정 설정</target>
+        <target state="translated">계좌 설정</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-overview/home-overview.html</context>
           <context context-type="linenumber">16</context>
@@ -1665,7 +1665,7 @@
       </trans-unit>
       <trans-unit id="6091364379293533723" datatype="html">
         <source>Capture your activities</source>
-        <target state="translated">활동을 캡처하세요</target>
+        <target state="translated">거래를 기록하세요</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-overview/home-overview.html</context>
           <context context-type="linenumber">25</context>
@@ -1673,7 +1673,7 @@
       </trans-unit>
       <trans-unit id="2605131345877419693" datatype="html">
         <source>Record your investment activities to keep your portfolio up to date.</source>
-        <target state="translated">투자 활동을 기록하여 포트폴리오를 최신 상태로 유지하세요.</target>
+        <target state="translated">투자 거래 내역을 기록하여 포트폴리오를 최신 상태로 유지하세요.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-overview/home-overview.html</context>
           <context context-type="linenumber">27</context>
@@ -1697,7 +1697,7 @@
       </trans-unit>
       <trans-unit id="2438928685593158434" datatype="html">
         <source>Setup accounts</source>
-        <target state="translated">계정 설정</target>
+        <target state="translated">계좌 설정</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-overview/home-overview.html</context>
           <context context-type="linenumber">49</context>
@@ -1713,7 +1713,7 @@
       </trans-unit>
       <trans-unit id="6005640251215534178" datatype="html">
         <source>Add activity</source>
-        <target state="translated">활동 추가</target>
+        <target state="translated">거래 추가</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-overview/home-overview.html</context>
           <context context-type="linenumber">57</context>
@@ -1733,7 +1733,7 @@
       </trans-unit>
       <trans-unit id="8186013988289067040" datatype="html">
         <source>Code</source>
-        <target state="new">Code</target>
+        <target state="translated">코드</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-overview/admin-overview.html</context>
           <context context-type="linenumber">159</context>
@@ -1829,7 +1829,7 @@
       </trans-unit>
       <trans-unit id="273949409065292025" datatype="html">
         <source>Energy</source>
-        <target state="new">Energy</target>
+        <target state="translated">에너지</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">90</context>
@@ -2225,7 +2225,7 @@
       </trans-unit>
       <trans-unit id="366169681580494481" datatype="html">
         <source>Performance with currency effect</source>
-        <target state="new">Performance with currency effect</target>
+        <target state="translated">환율 효과 반영 성과</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/analysis/analysis-page.html</context>
           <context context-type="linenumber">134</context>
@@ -2285,7 +2285,7 @@
       </trans-unit>
       <trans-unit id="4432485267082955422" datatype="html">
         <source>Consumer Defensive</source>
-        <target state="new">Consumer Defensive</target>
+        <target state="translated">필수소비재</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">89</context>
@@ -2365,7 +2365,7 @@
       </trans-unit>
       <trans-unit id="3848479214898655176" datatype="html">
         <source>Utilities</source>
-        <target state="new">Utilities</target>
+        <target state="translated">유틸리티</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">97</context>
@@ -2689,7 +2689,7 @@
       </trans-unit>
       <trans-unit id="5016419499983434110" datatype="html">
         <source>Accounts</source>
-        <target state="translated">계정</target>
+        <target state="translated">계좌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-platform/admin-platform.component.html</context>
           <context context-type="linenumber">52</context>
@@ -2737,7 +2737,7 @@
       </trans-unit>
       <trans-unit id="4154970040744792968" datatype="html">
         <source>Update account</source>
-        <target state="translated">계정 업데이트</target>
+        <target state="translated">계좌 수정</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html</context>
           <context context-type="linenumber">8</context>
@@ -2745,7 +2745,7 @@
       </trans-unit>
       <trans-unit id="2305747731597491315" datatype="html">
         <source>Add account</source>
-        <target state="translated">계정 추가</target>
+        <target state="translated">계좌 추가</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html</context>
           <context context-type="linenumber">10</context>
@@ -2753,7 +2753,7 @@
       </trans-unit>
       <trans-unit id="8636086114930438800" datatype="html">
         <source>Account ID</source>
-        <target state="translated">계정 ID</target>
+        <target state="translated">계좌 ID</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/accounts/create-or-update-account-dialog/create-or-update-account-dialog.html</context>
           <context context-type="linenumber">96</context>
@@ -2993,7 +2993,7 @@
       </trans-unit>
       <trans-unit id="5134951682994822188" datatype="html">
         <source>Could not parse scraper configuration</source>
-        <target state="new">Could not parse scraper configuration</target>
+        <target state="translated">스크래퍼 설정을 파싱할 수 없습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts</context>
           <context context-type="linenumber">551</context>
@@ -3021,7 +3021,7 @@
       </trans-unit>
       <trans-unit id="7410432243549869948" datatype="html">
         <source>Duration</source>
-        <target state="new">Duration</target>
+        <target state="translated">기간</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-overview/admin-overview.html</context>
           <context context-type="linenumber">172</context>
@@ -3109,7 +3109,7 @@
       </trans-unit>
       <trans-unit id="6112478554058115975" datatype="html">
         <source>Multi-Accounts</source>
-        <target state="translated">다중 계정</target>
+        <target state="translated">다중 계좌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/features/features-page.html</context>
           <context context-type="linenumber">127</context>
@@ -3421,7 +3421,7 @@
       </trans-unit>
       <trans-unit id="6945194064393203435" datatype="html">
         <source>Basic Materials</source>
-        <target state="new">Basic Materials</target>
+        <target state="translated">기초소재</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">86</context>
@@ -3741,7 +3741,7 @@
       </trans-unit>
       <trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source>
-        <target state="translated">활동</target>
+        <target state="translated">거래 내역</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/account-detail-dialog/account-detail-dialog.html</context>
           <context context-type="linenumber">84</context>
@@ -3793,7 +3793,7 @@
       </trans-unit>
       <trans-unit id="4239552960465242484" datatype="html">
         <source>Do you really want to delete these activities?</source>
-        <target state="translated">정말로 이 활동을 삭제하시겠습니까?</target>
+        <target state="translated">정말로 이 거래들을 삭제하시겠습니까?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/activities-table/activities-table.component.ts</context>
           <context context-type="linenumber">304</context>
@@ -3801,7 +3801,7 @@
       </trans-unit>
       <trans-unit id="1111435290645444471" datatype="html">
         <source>Update activity</source>
-        <target state="translated">활동 업데이트</target>
+        <target state="translated">거래 수정</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.html</context>
           <context context-type="linenumber">10</context>
@@ -3821,7 +3821,7 @@
       </trans-unit>
       <trans-unit id="317298331587354132" datatype="html">
         <source>One-time fee, annual account fees</source>
-        <target state="translated">일회성 수수료, 연간 계정 수수료</target>
+        <target state="translated">일회성 수수료, 연간 계좌 수수료</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.html</context>
           <context context-type="linenumber">33</context>
@@ -3881,7 +3881,7 @@
       </trans-unit>
       <trans-unit id="1817902710689724227" datatype="html">
         <source>Import Activities</source>
-        <target state="translated">활동 가져오기</target>
+        <target state="translated">거래 내역 가져오기</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.component.ts</context>
           <context context-type="linenumber">94</context>
@@ -4005,7 +4005,7 @@
       </trans-unit>
       <trans-unit id="6718675045548890054" datatype="html">
         <source>Select Activities</source>
-        <target state="translated">활동 선택</target>
+        <target state="translated">거래 선택</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.html</context>
           <context context-type="linenumber">115</context>
@@ -4025,7 +4025,7 @@
       </trans-unit>
       <trans-unit id="2666668717343771434" datatype="html">
         <source>Allocations</source>
-        <target state="translated">할당</target>
+        <target state="translated">자산 배분</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">4</context>
@@ -4065,7 +4065,7 @@
       </trans-unit>
       <trans-unit id="5202474511401349610" datatype="html">
         <source>By Asset Class</source>
-        <target state="translated">자산 클래스별</target>
+        <target state="translated">자산군별</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">83</context>
@@ -4141,7 +4141,7 @@
       </trans-unit>
       <trans-unit id="7934616470747135563" datatype="html">
         <source>Latest activities</source>
-        <target state="translated">최신 활동</target>
+        <target state="translated">최신 거래 내역</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/public/public-page.html</context>
           <context context-type="linenumber">210</context>
@@ -4173,7 +4173,7 @@
       </trans-unit>
       <trans-unit id="4632243449121794584" datatype="html">
         <source>By Account</source>
-        <target state="translated">계정별</target>
+        <target state="translated">계좌별</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">282</context>
@@ -4429,7 +4429,7 @@
       </trans-unit>
       <trans-unit id="5488101610658427424" datatype="html">
         <source>Unlimited Accounts</source>
-        <target state="translated">무제한 계정</target>
+        <target state="translated">무제한 계좌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/pricing/pricing-page.html</context>
           <context context-type="linenumber">39</context>
@@ -4553,7 +4553,7 @@
       </trans-unit>
       <trans-unit id="7498591289549626867" datatype="html">
         <source>Could not save asset profile</source>
-        <target state="new">Could not save asset profile</target>
+        <target state="translated">자산 정보를 저장할 수 없습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.component.ts</context>
           <context context-type="linenumber">634</context>
@@ -5038,7 +5038,7 @@
       </trans-unit>
       <trans-unit id="2263595996673750436" datatype="html">
         <source>Do you really want to delete this account balance?</source>
-        <target state="translated">정말로 이 계정 잔액을 삭제하시겠습니까?</target>
+        <target state="translated">정말로 이 계좌 잔액을 삭제하시겠습니까?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/account-balances/account-balances.component.ts</context>
           <context context-type="linenumber">113</context>
@@ -5046,7 +5046,7 @@
       </trans-unit>
       <trans-unit id="5388209493122807655" datatype="html">
         <source>Export Activities</source>
-        <target state="translated">수출 활동</target>
+        <target state="translated">거래 내역 내보내기</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/activities-table/activities-table.component.html</context>
           <context context-type="linenumber">64</context>
@@ -5094,7 +5094,7 @@
       </trans-unit>
       <trans-unit id="670983159637074283" datatype="html">
         <source>Do you really want to delete this activity?</source>
-        <target state="translated">정말로 이 활동을 삭제하시겠습니까?</target>
+        <target state="translated">정말로 이 거래를 삭제하시겠습니까?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/activities-table/activities-table.component.ts</context>
           <context context-type="linenumber">314</context>
@@ -5146,7 +5146,7 @@
       </trans-unit>
       <trans-unit id="5425547984857378790" datatype="html">
         <source>Change from All Time High</source>
-        <target state="translated">역대 최고치에서 변화</target>
+        <target state="translated">역대 최고점 대비 변동</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/benchmark/benchmark.component.html</context>
           <context context-type="linenumber">128</context>
@@ -5170,7 +5170,7 @@
       </trans-unit>
       <trans-unit id="5515771028435710194" datatype="html">
         <source>Loan</source>
-        <target state="new">Loan</target>
+        <target state="translated">대출</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">60</context>
@@ -5246,7 +5246,7 @@
       </trans-unit>
       <trans-unit id="8927080808898221200" datatype="html">
         <source>Allocation</source>
-        <target state="translated">배당</target>
+        <target state="translated">자산 배분</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/accounts-table/accounts-table.component.html</context>
           <context context-type="linenumber">248</context>
@@ -5274,7 +5274,7 @@
       </trans-unit>
       <trans-unit id="4086606389696938932" datatype="html">
         <source>Account</source>
-        <target state="translated">계정</target>
+        <target state="translated">계좌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.html</context>
           <context context-type="linenumber">86</context>
@@ -5302,7 +5302,7 @@
       </trans-unit>
       <trans-unit id="4574987680940794089" datatype="html">
         <source>Asset Class</source>
-        <target state="translated">자산 클래스</target>
+        <target state="translated">자산군</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/admin-market-data.html</context>
           <context context-type="linenumber">114</context>
@@ -5334,7 +5334,7 @@
       </trans-unit>
       <trans-unit id="7608037008789240367" datatype="html">
         <source>Asset Sub Class</source>
-        <target state="translated">자산 하위 클래스</target>
+        <target state="translated">하위 자산군</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/admin-market-data.html</context>
           <context context-type="linenumber">123</context>
@@ -5474,7 +5474,7 @@
       </trans-unit>
       <trans-unit id="9218541487912911620" datatype="html">
         <source>No Activities</source>
-        <target state="new">No Activities</target>
+        <target state="translated">거래 내역 없음</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-market-data/admin-market-data.component.ts</context>
           <context context-type="linenumber">150</context>
@@ -5490,7 +5490,7 @@
       </trans-unit>
       <trans-unit id="936060984157466006" datatype="html">
         <source>Everything in <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Basic<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, plus</source>
-        <target state="new">Everything in <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Basic<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, plus</target>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Basic<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>의 모든 기능에 더해</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/pricing/pricing-page.html</context>
           <context context-type="linenumber">199</context>
@@ -5594,7 +5594,7 @@
       </trans-unit>
       <trans-unit id="1666887226757993490" datatype="html">
         <source>Fee</source>
-        <target state="translated">요금</target>
+        <target state="translated">수수료</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.html</context>
           <context context-type="linenumber">255</context>
@@ -5770,7 +5770,7 @@
       </trans-unit>
       <trans-unit id="8340410730497371637" datatype="html">
         <source>Communication Services</source>
-        <target state="new">Communication Services</target>
+        <target state="translated">커뮤니케이션 서비스</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">87</context>
@@ -5986,7 +5986,7 @@
       </trans-unit>
       <trans-unit id="1600023202562292052" datatype="html">
         <source>Close Holding</source>
-        <target state="translated">닫기 보유</target>
+        <target state="translated">보유 포지션 종료</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html</context>
           <context context-type="linenumber">447</context>
@@ -6203,7 +6203,7 @@
       </trans-unit>
       <trans-unit id="2839679566742557360" datatype="html">
         <source>Find a holding...</source>
-        <target state="new">Find a holding...</target>
+        <target state="translated">보유 종목 검색...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/assistant/assistant.component.ts</context>
           <context context-type="linenumber">472</context>
@@ -6263,7 +6263,7 @@
       </trans-unit>
       <trans-unit id="5306473977542913614" datatype="html">
         <source>Activity</source>
-        <target state="translated">활동</target>
+        <target state="translated">거래</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html</context>
           <context context-type="linenumber">227</context>
@@ -6319,7 +6319,7 @@
       </trans-unit>
       <trans-unit id="7309206099560156141" datatype="html">
         <source>{VAR_PLURAL, plural, =1 {activity} other {activities}}</source>
-        <target state="translated">{VAR_PLURAL, 복수형, =1 {활동} 기타 {활동}}</target>
+        <target state="translated">{VAR_PLURAL, plural, =1 {거래} other {거래}}</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html</context>
           <context context-type="linenumber">14</context>
@@ -6327,7 +6327,7 @@
       </trans-unit>
       <trans-unit id="7641420101493176397" datatype="html">
         <source>Delete Activities</source>
-        <target state="translated">활동 삭제</target>
+        <target state="translated">거래 삭제</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/activities-table/activities-table.component.html</context>
           <context context-type="linenumber">92</context>
@@ -6359,7 +6359,7 @@
       </trans-unit>
       <trans-unit id="4943376738492797606" datatype="html">
         <source>Jump to a page...</source>
-        <target state="new">Jump to a page...</target>
+        <target state="translated">페이지 이동...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/assistant/assistant.component.ts</context>
           <context context-type="linenumber">473</context>
@@ -6375,7 +6375,7 @@
       </trans-unit>
       <trans-unit id="2678116732907988505" datatype="html">
         <source>Approximation based on the top holdings of each ETF</source>
-        <target state="translated">각 ETF의 상위 보유량을 기준으로 한 근사치</target>
+        <target state="translated">각 ETF의 상위 보유 종목을 기준으로 한 근사치</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">334</context>
@@ -6383,7 +6383,7 @@
       </trans-unit>
       <trans-unit id="4931386094893319473" datatype="html">
         <source>By ETF Holding</source>
-        <target state="translated">ETF 홀딩으로</target>
+        <target state="translated">ETF 보유 종목별</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/allocations/allocations-page.html</context>
           <context context-type="linenumber">327</context>
@@ -6587,7 +6587,7 @@
       </trans-unit>
       <trans-unit id="3477953895055172777" datatype="html">
         <source>View Holding</source>
-        <target state="translated">보유보기</target>
+        <target state="translated">보유 종목 보기</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/activities-table/activities-table.component.html</context>
           <context context-type="linenumber">474</context>
@@ -6875,7 +6875,7 @@
       </trans-unit>
       <trans-unit id="6608617124920241143" datatype="html">
         <source><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> Performance with currency effect <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> Performance <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></source>
-        <target state="translated"><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> 환율 효과가 있는 실적 <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> 실적 <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></target>
+        <target state="translated"><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> 환율 효과 반영 수익률 <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> 수익률 <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html</context>
           <context context-type="linenumber">83</context>
@@ -6891,7 +6891,7 @@
       </trans-unit>
       <trans-unit id="8375528527939577247" datatype="html">
         <source><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> Change with currency effect <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> Change <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></source>
-        <target state="translated"><x id="START_BLOCK_IF" equiv-text="@if ( SymbolProfile?.currency &amp;&amp; data.baseCurrency !== SymbolProfile?.currency ) {"/> 통화 효과로 변경 <x id="CLOSE_BLOCK_IF" equiv-text="}"/><x id="START_BLOCK_ELSE" equiv-text="@else {"/> 변경 <x id="CLOSE_BLOCK_ELSE" equiv-text="}"/></target>
+        <target state="translated">환율 효과 반영 변동</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html</context>
           <context context-type="linenumber">63</context>
@@ -6915,7 +6915,7 @@
       </trans-unit>
       <trans-unit id="8466521722895614996" datatype="html">
         <source><x id="PH" equiv-text="codeToCopy"/> has been copied to the clipboard</source>
-        <target state="new"><x id="PH" equiv-text="codeToCopy"/> has been copied to the clipboard</target>
+        <target state="translated"><x id="PH" equiv-text="codeToCopy"/>가 클립보드에 복사되었습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-overview/admin-overview.component.ts</context>
           <context context-type="linenumber">378</context>
@@ -6967,7 +6967,7 @@
       </trans-unit>
       <trans-unit id="7521745345796915891" datatype="html">
         <source>Financial Services</source>
-        <target state="new">Financial Services</target>
+        <target state="translated">금융 서비스</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/i18n.ts</context>
           <context context-type="linenumber">91</context>
@@ -7385,7 +7385,7 @@
       </trans-unit>
       <trans-unit id="7825231215382064101" datatype="html">
         <source>Change with currency effect</source>
-        <target state="new">Change with currency effect</target>
+        <target state="translated">환율 효과 반영 변동</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/analysis/analysis-page.html</context>
           <context context-type="linenumber">115</context>
@@ -7489,7 +7489,7 @@
       </trans-unit>
       <trans-unit id="1230154438678955604" datatype="html">
         <source>Change</source>
-        <target state="translated">변화</target>
+        <target state="translated">변동</target>
         <context-group purpose="location">
           <context context-type="sourcefile">libs/ui/src/lib/holdings-table/holdings-table.component.html</context>
           <context context-type="linenumber">143</context>
@@ -7501,7 +7501,7 @@
       </trans-unit>
       <trans-unit id="1322586333669103999" datatype="html">
         <source>Performance</source>
-        <target state="translated">성능</target>
+        <target state="translated">성과</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/benchmark-comparator/benchmark-comparator.component.html</context>
           <context context-type="linenumber">6</context>
@@ -7541,7 +7541,7 @@
       </trans-unit>
       <trans-unit id="5004550577313573215" datatype="html">
         <source>Total amount</source>
-        <target state="new">Total amount</target>
+        <target state="translated">총액</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/portfolio/analysis/analysis-page.html</context>
           <context context-type="linenumber">94</context>
@@ -7706,7 +7706,7 @@
       </trans-unit>
       <trans-unit id="7588205374923801261" datatype="html">
         <source>Performance Calculation</source>
-        <target state="translated">성능 계산</target>
+        <target state="translated">성과 계산</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/user-account-settings/user-account-settings.html</context>
           <context context-type="linenumber">31</context>
@@ -7811,7 +7811,7 @@
       </trans-unit>
       <trans-unit id="rule.emergencyFundSetup.false" datatype="html">
         <source>No emergency fund has been set up</source>
-        <target state="translated">비상금은 마련되지 않았습니다</target>
+        <target state="translated">비상금이 설정되지 않았습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">147</context>
@@ -7819,7 +7819,7 @@
       </trans-unit>
       <trans-unit id="rule.emergencyFundSetup.true" datatype="html">
         <source>An emergency fund has been set up</source>
-        <target state="translated">비상금이 마련됐어요</target>
+        <target state="translated">비상금이 설정되어 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">150</context>
@@ -7827,7 +7827,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioTotalInvestmentVolume" datatype="html">
         <source>Fee Ratio</source>
-        <target state="new">Fee Ratio</target>
+        <target state="translated">수수료 비율</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">152</context>
@@ -7835,7 +7835,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioTotalInvestmentVolume.false" datatype="html">
         <source>The fees do exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</source>
-        <target state="new">The fees do exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</target>
+        <target state="translated">수수료가 총 투자 금액의 ${thresholdMax}%를 초과합니다 (${feeRatio}%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">154</context>
@@ -7843,7 +7843,7 @@
       </trans-unit>
       <trans-unit id="rule.feeRatioTotalInvestmentVolume.true" datatype="html">
         <source>The fees do not exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</source>
-        <target state="new">The fees do not exceed ${thresholdMax}% of your total investment volume (${feeRatio}%)</target>
+        <target state="translated">수수료가 총 투자 금액의 ${thresholdMax}%를 초과하지 않습니다 (${feeRatio}%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">158</context>
@@ -7883,7 +7883,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskSingleAccount" datatype="html">
         <source>Single Account</source>
-        <target state="translated">단일 계정</target>
+        <target state="translated">단일 계좌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">28</context>
@@ -7891,7 +7891,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskSingleAccount.false" datatype="html">
         <source>Your net worth is managed by a single account</source>
-        <target state="translated">귀하의 순자산은 단일 계정으로 관리됩니다</target>
+        <target state="translated">귀하의 순자산은 단일 계좌로 관리됩니다</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">30</context>
@@ -7899,7 +7899,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskSingleAccount.true" datatype="html">
         <source>Your net worth is managed by ${accountsLength} accounts</source>
-        <target state="translated">귀하의 순자산은 ${accountsLength} 계정에서 관리됩니다.</target>
+        <target state="translated">귀하의 순자산은 ${accountsLength}개의 계좌에서 관리됩니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">36</context>
@@ -8025,7 +8025,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskCurrentInvestment.false" datatype="html">
         <source>Over ${thresholdMax}% of your current investment is at ${maxAccountName} (${maxInvestmentRatio}%)</source>
-        <target state="translated">현재 투자의 ${thresholdMax}% 이상이 ${maxAccountName} (${maxInvestmentRatio}%)에 있습니다.</target>
+        <target state="translated">현재 투자 자산의 ${thresholdMax}% 이상이 ${maxAccountName} 계좌 (${maxInvestmentRatio}%)에 집중되어 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">17</context>
@@ -8033,7 +8033,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskCurrentInvestment.true" datatype="html">
         <source>The major part of your current investment is at ${maxAccountName} (${maxInvestmentRatio}%) and does not exceed ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 주요 부분은 ${maxAccountName} (${maxInvestmentRatio}%)이며 ${thresholdMax}%를 초과하지 않습니다.</target>
+        <target state="translated">현재 투자 자산의 주요 부분이 ${maxAccountName} 계좌 (${maxInvestmentRatio}%)에 있으며, 설정된 기준(${thresholdMax}%)을 초과하지 않습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">24</context>
@@ -8049,7 +8049,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRiskEquity.false.max" datatype="html">
         <source>The equity contribution of your current investment (${equityValueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 지분 기여도(${equityValueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 주식 비중(${equityValueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">43</context>
@@ -8057,7 +8057,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRiskEquity.false.min" datatype="html">
         <source>The equity contribution of your current investment (${equityValueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 지분 기여도(${equityValueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 주식 비중(${equityValueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">47</context>
@@ -8065,7 +8065,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRiskEquity.true" datatype="html">
         <source>The equity contribution of your current investment (${equityValueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 지분 기여도(${equityValueRatio}%)가 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 주식 비중(${equityValueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">51</context>
@@ -8081,7 +8081,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRiskFixedIncome.false.max" datatype="html">
         <source>The fixed income contribution of your current investment (${fixedIncomeValueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 고정 수입 기여도(${fixedIncomeValueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 채권 비중(${fixedIncomeValueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">57</context>
@@ -8089,7 +8089,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRiskFixedIncome.false.min" datatype="html">
         <source>The fixed income contribution of your current investment (${fixedIncomeValueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 고정 수입 기여도(${fixedIncomeValueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 채권 비중(${fixedIncomeValueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">61</context>
@@ -8097,7 +8097,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRiskFixedIncome.true" datatype="html">
         <source>The fixed income contribution of your current investment (${fixedIncomeValueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 고정 수입 기여도(${fixedIncomeValueRatio}%)가 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 채권 비중(${fixedIncomeValueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">66</context>
@@ -8113,7 +8113,7 @@
       </trans-unit>
       <trans-unit id="rule.currencyClusterRiskBaseCurrencyCurrentInvestment.false" datatype="html">
         <source>The major part of your current investment is not in your base currency (${baseCurrencyValueRatio}% in ${baseCurrency})</source>
-        <target state="translated">현재 투자의 주요 부분이 기본 통화(${baseCurrency}의 ${baseCurrencyValueRatio}%)로 되어 있지 않습니다.</target>
+        <target state="translated">현재 투자 자산의 상당 부분이 기준 통화가 아닙니다 (${baseCurrency} 비중: ${baseCurrencyValueRatio}%).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">88</context>
@@ -8121,7 +8121,7 @@
       </trans-unit>
       <trans-unit id="rule.currencyClusterRiskBaseCurrencyCurrentInvestment.true" datatype="html">
         <source>The major part of your current investment is in your base currency (${baseCurrencyValueRatio}% in ${baseCurrency})</source>
-        <target state="translated">현재 투자의 주요 부분은 기본 통화(${baseCurrency}의 ${baseCurrencyValueRatio}%)입니다.</target>
+        <target state="translated">현재 투자 자산의 주요 부분이 기준 통화로 되어 있습니다 (${baseCurrency} 비중: ${baseCurrencyValueRatio}%).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">92</context>
@@ -8137,7 +8137,7 @@
       </trans-unit>
       <trans-unit id="rule.currencyClusterRiskCurrentInvestment.false" datatype="html">
         <source>Over ${thresholdMax}% of your current investment is in ${currency} (${maxValueRatio}%)</source>
-        <target state="translated">현재 투자의 ${thresholdMax}% 이상이 ${currency}(${maxValueRatio}%)에 있습니다.</target>
+        <target state="translated">현재 투자 자산의 ${thresholdMax}% 이상이 ${currency} 통화 (${maxValueRatio}%)에 집중되어 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">97</context>
@@ -8145,7 +8145,7 @@
       </trans-unit>
       <trans-unit id="rule.currencyClusterRiskCurrentInvestment.true" datatype="html">
         <source>The major part of your current investment is in ${currency} (${maxValueRatio}%) and does not exceed ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 주요 부분은 ${currency} (${maxValueRatio}%)이며 ${thresholdMax}%를 초과하지 않습니다.</target>
+        <target state="translated">현재 투자 자산의 상당 부분이 ${currency} 통화 (${maxValueRatio}%)로 되어 있으며, 설정된 기준(${thresholdMax}%)을 초과하지 않습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">101</context>
@@ -8214,7 +8214,7 @@
       </trans-unit>
       <trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ `Expires ${formatDistanceToNow( element.subscription.expiresAt )} (${ (element.subscription.expiresAt | date: defaultDateFormat) })` }}"/></source>
-        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ `Expires ${formatDistanceToNow( element.subscription.expiresAt )} (${ (element.subscription.expiresAt | date: defaultDateFormat) })` }}"/></target>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ `만료일: ${formatDistanceToNow( element.subscription.expiresAt )} (${ (element.subscription.expiresAt | date: defaultDateFormat) })` }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/admin-users/admin-users.html</context>
           <context context-type="linenumber">35</context>
@@ -8266,7 +8266,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRisk.category" datatype="html">
         <source>Account Cluster Risks</source>
-        <target state="translated">계정 클러스터 위험</target>
+        <target state="translated">계좌 집중 위험</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">14</context>
@@ -8274,7 +8274,7 @@
       </trans-unit>
       <trans-unit id="rule.assetClassClusterRisk.category" datatype="html">
         <source>Asset Class Cluster Risks</source>
-        <target state="translated">자산 클래스 클러스터 위험</target>
+        <target state="translated">자산군 집중 위험</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">39</context>
@@ -8282,7 +8282,7 @@
       </trans-unit>
       <trans-unit id="rule.currencyClusterRisk.category" datatype="html">
         <source>Currency Cluster Risks</source>
-        <target state="translated">통화 클러스터 위험</target>
+        <target state="translated">통화 집중 위험</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">83</context>
@@ -8290,7 +8290,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRisk.category" datatype="html">
         <source>Economic Market Cluster Risks</source>
-        <target state="translated">경제 시장 클러스터 위험</target>
+        <target state="translated">경제 시장 집중 위험</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">106</context>
@@ -8298,7 +8298,7 @@
       </trans-unit>
       <trans-unit id="rule.emergencyFund.category" datatype="html">
         <source>Emergency Fund</source>
-        <target state="translated">비상자금</target>
+        <target state="translated">비상금</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">144</context>
@@ -8330,7 +8330,7 @@
       </trans-unit>
       <trans-unit id="rule.liquidityBuyingPower.false.min" datatype="html">
         <source>Your buying power is below ${thresholdMin} ${baseCurrency}</source>
-        <target state="translated">귀하의 구매력은 ${thresholdMin} ${baseCurrency} 미만입니다.</target>
+        <target state="translated">매수 가능 금액이 ${thresholdMin} ${baseCurrency} 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">73</context>
@@ -8338,7 +8338,7 @@
       </trans-unit>
       <trans-unit id="rule.liquidityBuyingPower.false.zero" datatype="html">
         <source>Your buying power is 0 ${baseCurrency}</source>
-        <target state="translated">귀하의 구매력은 0입니다 ${baseCurrency}</target>
+        <target state="translated">매수 가능 금액이 0 ${baseCurrency}입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">77</context>
@@ -8354,7 +8354,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRisk.category" datatype="html">
         <source>Regional Market Cluster Risks</source>
-        <target state="translated">지역 시장 클러스터 위험</target>
+        <target state="translated">지역 시장 집중 위험</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">163</context>
@@ -8370,7 +8370,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRiskDevelopedMarkets.false.max" datatype="html">
         <source>The developed markets contribution of your current investment (${developedMarketsValueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 선진국 시장 기여도(${개발된MarketsValueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 선진국 시장 비중(${developedMarketsValueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">112</context>
@@ -8378,7 +8378,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRiskDevelopedMarkets.false.min" datatype="html">
         <source>The developed markets contribution of your current investment (${developedMarketsValueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 선진국 시장 기여도(${개발된MarketsValueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 선진국 시장 비중(${developedMarketsValueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">117</context>
@@ -8386,7 +8386,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRiskDevelopedMarkets.true" datatype="html">
         <source>The developed markets contribution of your current investment (${developedMarketsValueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 선진국 시장 기여도(${개발된MarketsValueRatio}%)는 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 선진국 시장 비중(${developedMarketsValueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">122</context>
@@ -8402,7 +8402,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRiskEmergingMarkets.false.max" datatype="html">
         <source>The emerging markets contribution of your current investment (${emergingMarketsValueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 신흥 시장 기여도(${emergingMarketsValueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 신흥국 시장 비중(${emergingMarketsValueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">130</context>
@@ -8410,7 +8410,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRiskEmergingMarkets.false.min" datatype="html">
         <source>The emerging markets contribution of your current investment (${emergingMarketsValueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 신흥 시장 기여도(${emergingMarketsValueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 신흥국 시장 비중(${emergingMarketsValueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">135</context>
@@ -8418,7 +8418,7 @@
       </trans-unit>
       <trans-unit id="rule.economicMarketClusterRiskEmergingMarkets.true" datatype="html">
         <source>The emerging markets contribution of your current investment (${emergingMarketsValueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 신흥 시장 기여도(${emergingMarketsValueRatio}%)가 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 신흥국 시장 비중(${emergingMarketsValueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">140</context>
@@ -8426,7 +8426,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskCurrentInvestment.false.invalid" datatype="html">
         <source>No accounts have been set up</source>
-        <target state="translated">설정된 계정이 없습니다.</target>
+        <target state="translated">설정된 계좌가 없습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">21</context>
@@ -8434,7 +8434,7 @@
       </trans-unit>
       <trans-unit id="rule.accountClusterRiskSingleAccount.false.invalid" datatype="html">
         <source>Your net worth is managed by 0 accounts</source>
-        <target state="translated">귀하의 순자산은 0개의 계정에서 관리됩니다.</target>
+        <target state="translated">귀하의 순자산은 0개의 계좌에서 관리됩니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">33</context>
@@ -8450,7 +8450,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskAsiaPacific.false.max" datatype="html">
         <source>The Asia-Pacific market contribution of your current investment (${valueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 아시아 태평양 시장 기여도(${valueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 아시아 태평양 시장 비중(${valueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">167</context>
@@ -8458,7 +8458,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskAsiaPacific.false.min" datatype="html">
         <source>The Asia-Pacific market contribution of your current investment (${valueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 아시아 태평양 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 아시아 태평양 시장 비중(${valueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">171</context>
@@ -8466,7 +8466,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskAsiaPacific.true" datatype="html">
         <source>The Asia-Pacific market contribution of your current investment (${valueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 아시아 태평양 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 아시아 태평양 시장 비중(${valueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">175</context>
@@ -8482,7 +8482,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskEmergingMarkets.false.max" datatype="html">
         <source>The Emerging Markets contribution of your current investment (${valueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 신흥 시장 기여도(${valueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 신흥국 시장 비중(${valueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">183</context>
@@ -8490,7 +8490,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskEmergingMarkets.false.min" datatype="html">
         <source>The Emerging Markets contribution of your current investment (${valueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 신흥 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 신흥국 시장 비중(${valueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">187</context>
@@ -8498,7 +8498,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskEmergingMarkets.true" datatype="html">
         <source>The Emerging Markets contribution of your current investment (${valueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 신흥 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 신흥국 시장 비중(${valueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">191</context>
@@ -8514,7 +8514,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskEurope.false.max" datatype="html">
         <source>The Europe market contribution of your current investment (${valueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 유럽 시장 기여도(${valueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 유럽 시장 비중(${valueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">197</context>
@@ -8522,7 +8522,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskEurope.false.min" datatype="html">
         <source>The Europe market contribution of your current investment (${valueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 유럽 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 유럽 시장 비중(${valueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">201</context>
@@ -8530,7 +8530,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskEurope.true" datatype="html">
         <source>The Europe market contribution of your current investment (${valueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 유럽 시장 기여도(${valueRatio}%)는 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 유럽 시장 비중(${valueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">205</context>
@@ -8546,7 +8546,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskJapan.false.max" datatype="html">
         <source>The Japan market contribution of your current investment (${valueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 일본 시장 기여도(${valueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 일본 시장 비중(${valueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">211</context>
@@ -8554,7 +8554,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskJapan.false.min" datatype="html">
         <source>The Japan market contribution of your current investment (${valueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 일본 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 일본 시장 비중(${valueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">215</context>
@@ -8562,7 +8562,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskJapan.true" datatype="html">
         <source>The Japan market contribution of your current investment (${valueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 일본 시장 기여도(${valueRatio}%)는 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 일본 시장 비중(${valueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">219</context>
@@ -8578,7 +8578,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskNorthAmerica.false.max" datatype="html">
         <source>The North America market contribution of your current investment (${valueRatio}%) exceeds ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 북미 시장 기여도(${valueRatio}%)가 ${thresholdMax}%를 초과합니다.</target>
+        <target state="translated">현재 투자 자산 중 북미 시장 비중(${valueRatio}%)이 ${thresholdMax}%를 초과합니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">225</context>
@@ -8586,7 +8586,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskNorthAmerica.false.min" datatype="html">
         <source>The North America market contribution of your current investment (${valueRatio}%) is below ${thresholdMin}%</source>
-        <target state="translated">현재 투자의 북미 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 미만입니다.</target>
+        <target state="translated">현재 투자 자산 중 북미 시장 비중(${valueRatio}%)이 ${thresholdMin}% 미만입니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">229</context>
@@ -8594,7 +8594,7 @@
       </trans-unit>
       <trans-unit id="rule.regionalMarketClusterRiskNorthAmerica.true" datatype="html">
         <source>The North America market contribution of your current investment (${valueRatio}%) is within the range of ${thresholdMin}% and ${thresholdMax}%</source>
-        <target state="translated">현재 투자의 북미 시장 기여도(${valueRatio}%)가 ${thresholdMin}% 및 ${thresholdMax}% 범위 내에 있습니다.</target>
+        <target state="translated">현재 투자 자산 중 북미 시장 비중(${valueRatio}%)이 ${thresholdMin}% ~ ${thresholdMax}% 범위 내에 있습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/pages/i18n/i18n-page.html</context>
           <context context-type="linenumber">233</context>


### PR DESCRIPTION
- Fixed awkward Korean translations (e.g., "Allocation" -> "자산 배분", "Performance" -> "성과", "Account" -> "계좌").
- Fixed syntax errors in ICU plural structure for Korean locale.
- Fixed translated interpolation variable name bug under developed markets rules.
- Translated 32 missing Korean units.