### PR TITLE
Support importing account platforms

### DIFF
--- a/apps/api/src/app/import/import-data.dto.ts
+++ b/apps/api/src/app/import/import-data.dto.ts
@@ -6,9 +6,36 @@ import {
 } from '@ghostfolio/common/dtos';
 
 import { Type } from 'class-transformer';
-import { IsArray, IsOptional, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsOptional,
+  ValidateNested,
+  IsString,
+  IsUrl
+} from 'class-validator';
+
+export class ImportPlatformDto {
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @IsString()
+  name: string;
+
+  @IsUrl({
+    protocols: ['http', 'https'],
+    require_protocol: true
+  })
+  url: string;
+}
 
 export class ImportDataDto {
+  @IsArray()
+  @IsOptional()
+  @Type(() => ImportPlatformDto)
+  @ValidateNested({ each: true })
+  platforms?: ImportPlatformDto[];
+
   @IsArray()
   @IsOptional()
   @Type(() => CreateAccountWithBalancesDto)

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -5,7 +5,7 @@ import { TransformDataSourceInResponseInterceptor } from '@ghostfolio/api/interc
 import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
 import { SubscriptionType } from '@ghostfolio/common/enums';
 import { ImportResponse } from '@ghostfolio/common/interfaces';
-import { hasPermission, permissions } from '@ghostfolio/common/permissions';
+import { permissions } from '@ghostfolio/common/permissions';
 import type { RequestWithUser } from '@ghostfolio/common/types';
 
 import {
@@ -50,15 +50,6 @@ export class ImportController {
   ): Promise<ImportResponse> {
     const isDryRun = isDryRunParam === 'true';
 
-    if (
-      !hasPermission(this.request.user.permissions, permissions.createAccount)
-    ) {
-      throw new HttpException(
-        getReasonPhrase(StatusCodes.FORBIDDEN),
-        StatusCodes.FORBIDDEN
-      );
-    }
-
     let maxActivitiesToImport = this.configurationService.get(
       'MAX_ACTIVITIES_TO_IMPORT'
     );
@@ -77,6 +68,7 @@ export class ImportController {
         accountsWithBalancesDto: importData.accounts ?? [],
         activitiesDto: importData.activities,
         assetProfilesWithMarketDataDto: importData.assetProfiles ?? [],
+        platformsDto: importData.platforms ?? [],
         tagsDto: importData.tags ?? [],
         user: this.request.user
       });

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -179,6 +179,7 @@ export class ImportService {
     assetProfilesWithMarketDataDto,
     isDryRun = false,
     maxActivitiesToImport,
+    platformsDto,
     tagsDto,
     user
   }: {
@@ -187,11 +188,13 @@ export class ImportService {
     assetProfilesWithMarketDataDto: ImportDataDto['assetProfiles'];
     isDryRun?: boolean;
     maxActivitiesToImport: number;
+    platformsDto: ImportDataDto['platforms'];
     tagsDto: ImportDataDto['tags'];
     user: UserWithSettings;
   }): Promise<Activity[]> {
     const accountIdMapping: { [oldAccountId: string]: string } = {};
     const assetProfileSymbolMapping: { [oldSymbol: string]: string } = {};
+    const platformIdMapping: { [oldPlatformId: string]: string } = {};
     const tagIdMapping: { [oldTagId: string]: string } = {};
     const userCurrency = user.settings.settings.baseCurrency;
 
@@ -208,6 +211,37 @@ export class ImportService {
         }),
         this.platformService.getPlatforms()
       ]);
+
+      const canCreatePlatform = hasPermission(
+        user.permissions,
+        permissions.createPlatform
+      );
+
+      for (const platform of platformsDto ?? []) {
+        const existingPlatform = existingPlatforms.find(({ url }) => {
+          return url === platform.url;
+        });
+
+        if (existingPlatform) {
+          if (platform.id && platform.id !== existingPlatform.id) {
+            platformIdMapping[platform.id] = existingPlatform.id;
+          }
+
+          continue;
+        }
+
+        if (!canCreatePlatform) {
+          continue;
+        }
+
+        const newPlatform = await this.platformService.createPlatform({
+          ...(platform.id && { id: platform.id }),
+          name: platform.name,
+          url: platform.url
+        });
+
+        existingPlatforms.push(newPlatform);
+      }
 
       for (const accountWithBalances of accountsWithBalancesDto) {
         // Check if there is any existing account with the same ID
@@ -240,14 +274,19 @@ export class ImportService {
             user: { connect: { id: user.id } }
           };
 
+          const resolvedPlatformId = platformId
+            ? (platformIdMapping[platformId] ?? platformId)
+            : undefined;
+
           if (
+            resolvedPlatformId &&
             existingPlatforms.some(({ id }) => {
-              return id === platformId;
+              return id === resolvedPlatformId;
             })
           ) {
             accountObject = {
               ...accountObject,
-              platform: { connect: { id: platformId } }
+              platform: { connect: { id: resolvedPlatformId } }
             };
           }
 

--- a/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.component.ts
@@ -109,6 +109,7 @@ export class GfImportActivitiesDialogComponent {
   private accounts: CreateAccountWithBalancesDto[] = [];
   private activities: Activity[] = [];
   private assetProfiles: CreateAssetProfileWithMarketDataDto[] = [];
+  private platforms: { id?: string; name: string; url: string }[] = [];
   private tags: CreateTagDto[] = [];
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
@@ -175,6 +176,7 @@ export class GfImportActivitiesDialogComponent {
         accounts: this.accounts,
         activities: this.selectedActivities,
         assetProfiles: this.assetProfiles,
+        platforms: this.platforms,
         tags: this.tags
       });
 
@@ -306,6 +308,7 @@ export class GfImportActivitiesDialogComponent {
 
           this.accounts = content.accounts;
           this.assetProfiles = content.assetProfiles;
+          this.platforms = content.platforms ?? [];
           this.tags = content.tags;
 
           if (!isArray(content.activities)) {
@@ -339,6 +342,7 @@ export class GfImportActivitiesDialogComponent {
                 activities: content.activities,
                 assetProfiles: content.assetProfiles,
                 isDryRun: true,
+                platforms: content.platforms ?? [],
                 tags: content.tags
               });
 

--- a/apps/client/src/app/services/import-activities.service.ts
+++ b/apps/client/src/app/services/import-activities.service.ts
@@ -15,6 +15,12 @@ import { parse as csvToJson } from 'papaparse';
 import { EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
+interface ImportPlatform {
+  id?: string;
+  name: string;
+  url: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -116,12 +122,14 @@ export class ImportActivitiesService {
     activities,
     assetProfiles,
     isDryRun = false,
+    platforms,
     tags
   }: {
     activities: CreateOrderDto[];
     accounts?: CreateAccountWithBalancesDto[];
     assetProfiles?: CreateAssetProfileWithMarketDataDto[];
     isDryRun?: boolean;
+    platforms?: ImportPlatform[];
     tags?: CreateTagDto[];
   }): Promise<{
     activities: Activity[];
@@ -132,6 +140,7 @@ export class ImportActivitiesService {
           accounts,
           activities,
           assetProfiles,
+          platforms,
           tags
         },
         isDryRun
@@ -154,11 +163,13 @@ export class ImportActivitiesService {
     accounts,
     activities,
     assetProfiles,
+    platforms,
     tags
   }: {
     accounts?: CreateAccountWithBalancesDto[];
     activities: Activity[];
     assetProfiles?: CreateAssetProfileWithMarketDataDto[];
+    platforms?: ImportPlatform[];
     tags?: CreateTagDto[];
   }): Promise<{
     activities: Activity[];
@@ -172,6 +183,7 @@ export class ImportActivitiesService {
     return this.importJson({
       accounts,
       assetProfiles,
+      platforms,
       tags,
       activities: importData
     });
@@ -445,6 +457,7 @@ export class ImportActivitiesService {
       accounts?: CreateAccountWithBalancesDto[];
       activities: CreateOrderDto[];
       assetProfiles?: CreateAssetProfileWithMarketDataDto[];
+      platforms?: ImportPlatform[];
       tags?: CreateTagDto[];
     },
     aIsDryRun = false


### PR DESCRIPTION
### Summary

Closes #5372

This PR adds support for importing account platforms from Ghostfolio JSON exports.

Previously, the export response could include platform metadata and accounts with `platformId`, but the import flow did not preserve this relationship end-to-end. The client import dialog did not forward `platforms`, and the API import service only connected accounts to platforms that already existed in the destination database.

### Changes

- Added `platforms` support to the import DTO.
- Forwarded platforms from the JSON import dialog during dry-run and final import.
- Forwarded platforms through `ImportActivitiesService`.
- Removed the old inline `createAccount` permission check from the import controller.
- Added platform processing inside `ImportService.import()`.
- Creates missing platforms when the importing user has `createPlatform` permission.
- Preserves imported platform IDs when creating platforms.
- Maps imported platform IDs to existing platform IDs when a platform with the same URL already exists.
- Connects imported accounts using the resolved platform ID.

### Notes

This applies to Ghostfolio JSON import/export data, where exported account platform metadata is already present. CSV imports continue to resolve activities against existing user accounts and do not create platforms.

If a missing platform is imported by a user without `createPlatform` permission, the platform is not created and the account import keeps the existing behavior of not connecting to that missing platform.

### Demo

The attached video shows a JSON import containing platforms and account platformId data. After import, the platform is created and the imported account is connected to it.

https://github.com/user-attachments/assets/a5896b89-7bc5-4975-9f45-c3db819cc100



### Verification

- `npx nx lint api`
- `npx nx lint client`
- `npx tsc --noEmit --project apps/api/tsconfig.app.json`
- `npx nx build client`
- Manually verified that a JSON export containing `platforms` and account `platformId` imports successfully into a clean database, creates the platform, and connects the imported account to it.

