### PR TITLE
fix (ui): make dividend import load request trigger correctly

### DIFF
--- a/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.html
+++ b/apps/client/src/app/pages/portfolio/activities/import-activities-dialog/import-activities-dialog.html
@@ -32,16 +32,12 @@
               <mat-label i18n>Holding</mat-label>
               <mat-select formControlName="assetProfileIdentifier">
                 <mat-select-trigger>{{
-                  assetProfileForm.get('assetProfileIdentifier')?.value?.name
+		  assetProfileForm.get('assetProfileIdentifier')?.value?.assetProfile?.name
                 }}</mat-select-trigger>
                 @for (holding of holdings; track holding) {
                   <mat-option
                     class="line-height-1"
-                    [value]="{
-                      dataSource: holding.assetProfile.dataSource,
-                      name: holding.assetProfile.name,
-                      symbol: holding.assetProfile.symbol
-                    }"
+		    [value]="holding"
                   >
                     <span
                       ><b>{{ holding.assetProfile.name }}</b></span


### PR DESCRIPTION
- Problem: Imports Dividends from the activities page did not trigger any network request.
- Root cause: selected holding value shape in template did not match handler expectation.
- Fix: pass holding object directly from select option and update select trigger path.
- Verification: clicking Load Dividends now sends the correct request and import works end-to-end.