### PR TITLE
Bugfix/dark mode styling of safe withdrawal rate selector in FIRE section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a chart error on interaction by registering the annotation plugin early
 - Fixed an issue on the allocations page where clicking an account in the _By Account_ chart did not open the detail dialog
+- Fixed the SWR dropdown on the _FIRE_ page in dark mode
 
 ## 3.11.0 - 2026-06-14
 

--- a/apps/client/src/app/pages/portfolio/fire/fire-page.scss
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.scss
@@ -32,7 +32,6 @@
 
     option {
       color: rgb(var(--dark-primary-text));
-      background-color: rgb(var(--light-background));
     }
   }
 }

--- a/apps/client/src/app/pages/portfolio/fire/fire-page.scss
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.scss
@@ -29,5 +29,10 @@
     @include select-arrow(variables.$light-primary-text);
 
     color: rgb(var(--light-primary-text));
+
+    option {
+      color: rgb(var(--dark-primary-text));
+      background-color: rgb(var(--light-background));
+    }
   }
 }


### PR DESCRIPTION
This fixes the SWR dropdown on the FIRE page so the opened options remain legible in dark mode

Before:
<img width="460" height="308" alt="Screenshot From 2026-06-16 20-10-16" src="https://github.com/user-attachments/assets/a40cf24e-0a3e-4299-a798-c002b48ba116" />

After:
<img width="460" height="308" alt="Screenshot From 2026-06-16 19-56-05" src="https://github.com/user-attachments/assets/96840c96-2cac-4158-86c9-698dee48c570" />