### PR TITLE
Fix page tab label truncation

### DIFF
--- a/libs/ui/src/lib/page-tabs/page-tabs.component.html
+++ b/libs/ui/src/lib/page-tabs/page-tabs.component.html
@@ -42,8 +42,13 @@
 
 <ng-template #tabContent let-tab>
   <ion-icon
+    class="flex-shrink-0"
     [name]="tab.iconName"
     [size]="deviceType === 'mobile' ? 'large' : 'small'"
   />
-  <div class="d-none d-sm-block ml-1" [innerHTML]="tab.label"></div>
+  <div
+    class="d-none d-sm-block ml-1 text-truncate"
+    style="max-width: 10.5rem"
+    [innerHTML]="tab.label"
+  ></div>
 </ng-template>

--- a/libs/ui/src/lib/page-tabs/page-tabs.component.html
+++ b/libs/ui/src/lib/page-tabs/page-tabs.component.html
@@ -47,8 +47,7 @@
     [size]="deviceType === 'mobile' ? 'large' : 'small'"
   />
   <div
-    class="d-none d-sm-block ml-1 text-truncate"
-    style="max-width: 10.5rem"
+    class="d-none d-sm-block flex-grow-1 ml-1 page-tab-label text-truncate"
     [innerHTML]="tab.label"
   ></div>
 </ng-template>

--- a/libs/ui/src/lib/page-tabs/page-tabs.component.scss
+++ b/libs/ui/src/lib/page-tabs/page-tabs.component.scss
@@ -61,6 +61,16 @@
             justify-content: flex-start;
             margin: 0 0.5rem 0.1rem 0.5rem;
 
+            .mdc-tab__content,
+            .mdc-tab__text-label {
+              min-width: 0;
+              width: 100%;
+            }
+
+            .mdc-tab__text-label {
+              display: flex;
+            }
+
             &.mdc-tab--active {
               background-color: rgba(var(--palette-foreground-base), 0.05);
               font-weight: 500;
@@ -70,6 +80,10 @@
       }
     }
   }
+}
+
+.page-tab-label {
+  min-width: 0;
 }
 
 :host-context(.theme-dark) {


### PR DESCRIPTION
## Description

- Truncates visible page tab labels with Bootstrap utility classes
- Keeps the existing icon layout and avoids adding custom CSS

Closes #7055

## Testing

- npx prettier --check libs/ui/src/lib/page-tabs/page-tabs.component.html
- npx nx lint ui
- npx prisma generate
- npx nx test ui --runInBand