### PR TITLE
Task/include selected profile count in market data delete action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Added the selected asset profile count to the delete menu item of the historical market data table in the admin control panel
+
 ### Fixed
 
 - Fixed an issue with the localization of the country names
@@ -21,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the last activity display in the users table of the admin control panel
 - Improved the registration display in the users table of the admin control panel
 - Improved the user id display in the users table of the admin control panel
-- Improved the delete menu item in the market data management of the admin control panel
 - Deprecated `SymbolProfile` in favor of `assetProfile` in the endpoint `GET api/v1/portfolio/holding/:dataSource/:symbol`
 - Improved the language localization for German (`de`)
 - Upgraded `svgmap` from version `2.19.3` to `2.21.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the last activity display in the users table of the admin control panel
 - Improved the registration display in the users table of the admin control panel
 - Improved the user id display in the users table of the admin control panel
+- Improved the delete menu item in the market data management of the admin control panel
 - Deprecated `SymbolProfile` in favor of `assetProfile` in the endpoint `GET api/v1/portfolio/holding/:dataSource/:symbol`
 - Improved the language localization for German (`de`)
 - Upgraded `svgmap` from version `2.19.3` to `2.21.0`

--- a/apps/client/src/app/components/admin-market-data/admin-market-data.html
+++ b/apps/client/src/app/components/admin-market-data/admin-market-data.html
@@ -239,7 +239,10 @@
                   [disabled]="!selection.hasValue()"
                   (click)="onDeleteAssetProfiles()"
                 >
-                  <ng-container i18n>Delete Profiles</ng-container>
+                  <ng-container i18n>{selection.selected.length, plural,
+                    =1 {Delete 1 Profile}
+                    other {Delete # Profiles}
+                  }</ng-container>
                 </button>
               </mat-menu>
             </th>

--- a/apps/client/src/app/components/admin-market-data/admin-market-data.html
+++ b/apps/client/src/app/components/admin-market-data/admin-market-data.html
@@ -240,7 +240,12 @@
                   (click)="onDeleteAssetProfiles()"
                 >
                   <ng-container i18n
-                    >Delete {{ selection.selected.length }}
+                    >Delete
+                    {{
+                      selection.selected.length > 1
+                        ? selection.selected.length
+                        : ''
+                    }}
                     {selection.selected.length, plural,
                       =1 {Profile}
                       other {Profiles}

--- a/apps/client/src/app/components/admin-market-data/admin-market-data.html
+++ b/apps/client/src/app/components/admin-market-data/admin-market-data.html
@@ -239,10 +239,13 @@
                   [disabled]="!selection.hasValue()"
                   (click)="onDeleteAssetProfiles()"
                 >
-                  <ng-container i18n>{selection.selected.length, plural,
-                    =1 {Delete 1 Profile}
-                    other {Delete # Profiles}
-                  }</ng-container>
+                  <ng-container i18n
+                    >Delete {{ selection.selected.length }}
+                    {selection.selected.length, plural,
+                      =1 {Profile}
+                      other {Profiles}
+                    }</ng-container
+                  >
                 </button>
               </mat-menu>
             </th>


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #7042, please take a look.

### Summary
- Updated the admin market data delete menu item to include the number of selected profiles.
- Added pluralization so the label shows `Delete 1 Profile` or `Delete # Profiles` depending on the selection count.