### PR TITLE
Bugfix/detection of not defined values in nested objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed an issue with the localization of the country names
+- Fixed the detection of not defined values in nested objects of the portfolio details endpoint
 
 ## 3.12.0 - 2026-06-17
 

--- a/apps/api/src/helper/object.helper.spec.ts
+++ b/apps/api/src/helper/object.helper.spec.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_REDACTED_PATHS } from '@ghostfolio/common/config';
 
-import { query, redactPaths } from './object.helper';
+import {
+  hasNotDefinedValuesInObject,
+  query,
+  redactPaths
+} from './object.helper';
 
 describe('query', () => {
   it('should get market price from stock API response', () => {
@@ -19,6 +23,111 @@ describe('query', () => {
     })[0];
 
     expect(result).toBe(271.86);
+  });
+});
+
+describe('hasNotDefinedValuesInObject', () => {
+  it('should return false when all values are defined', () => {
+    const object = {
+      currency: 'USD',
+      market: {
+        previousClose: 273.04,
+        price: 271.86
+      },
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(false);
+  });
+
+  it('should return true when a top-level value is null', () => {
+    const object = {
+      currency: 'USD',
+      marketPrice: null,
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(true);
+  });
+
+  it('should return true when a top-level value is undefined', () => {
+    const object = {
+      currency: 'USD',
+      marketPrice: undefined,
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(true);
+  });
+
+  it('should return true when a value nested in an object is null', () => {
+    const object = {
+      currency: 'USD',
+      market: {
+        previousClose: 273.04,
+        price: null
+      },
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(true);
+  });
+
+  it('should return true when the first nested object is fully defined but a later sibling key is null', () => {
+    const object = {
+      market: {
+        previousClose: 273.04,
+        price: 271.86
+      },
+      marketPrice: null,
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(true);
+  });
+
+  it('should return true when the first nested object is fully defined but a later sibling key is undefined', () => {
+    const object = {
+      market: {
+        previousClose: 273.04,
+        price: 271.86
+      },
+      marketPrice: undefined,
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(true);
+  });
+
+  it('should return true when the first nested object is fully defined but a later nested object holds null', () => {
+    const object = {
+      developedMarkets: {
+        UNKNOWN: 0,
+        weight: 1
+      },
+      emergingMarkets: {
+        UNKNOWN: null,
+        weight: 0
+      }
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(true);
+  });
+
+  it('should return false when a deeply nested object is fully defined and is followed by a defined sibling', () => {
+    const object = {
+      holding: {
+        market: {
+          region: {
+            UNKNOWN: 0,
+            developedMarkets: 1
+          }
+        }
+      },
+      symbol: 'AAPL'
+    };
+
+    expect(hasNotDefinedValuesInObject(object)).toBe(false);
   });
 });
 

--- a/apps/api/src/helper/object.helper.ts
+++ b/apps/api/src/helper/object.helper.ts
@@ -7,7 +7,9 @@ export function hasNotDefinedValuesInObject(aObject: Object): boolean {
     if (aObject[key] === null || aObject[key] === undefined) {
       return true;
     } else if (isObject(aObject[key])) {
-      return hasNotDefinedValuesInObject(aObject[key]);
+      if (hasNotDefinedValuesInObject(aObject[key])) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

`hasNotDefinedValuesInObject` (`apps/api/src/helper/object.helper.ts`) is meant to return `true` if **any** key in an object — including keys in nested objects — holds `null` or `undefined`, and `false` only when every value is defined.

When it encounters a nested object it does:

```ts
} else if (isObject(aObject[key])) {
  return hasNotDefinedValuesInObject(aObject[key]);
}
```

The `return` short-circuits the loop on the **first** nested object. If that first nested object is fully defined, the function returns `false` immediately and **never inspects the sibling keys that follow** — even if a later key (or a later nested object) holds `null`/`undefined`. The function then wrongly reports that the object has no undefined values.

### Impact

The helper is consumed in the portfolio details endpoint at `apps/api/src/app/portfolio/portfolio.controller.ts:129`:

```ts
if (hasErrors || hasNotDefinedValuesInObject(holdings)) {
  hasError = true;
}
```

Because `holdings` is keyed by symbol and each holding is a nested object, a holding with a missing/undefined value that happens to come *after* a fully defined holding is not detected, so `hasError` is left `false` and the response does not flag the incomplete data.

## Fix

Only return early on a **positive** hit; otherwise keep scanning the remaining keys:

```ts
} else if (isObject(aObject[key])) {
  if (hasNotDefinedValuesInObject(aObject[key])) {
    return true;
  }
}
```

The loop now returns `true` as soon as any key (nested or not) is `null`/`undefined`, and only returns `false` after every key has been checked and found defined.

## Tests

Added cases to `apps/api/src/helper/object.helper.spec.ts` covering top-level and nested `null`/`undefined`, the previously-missed "first nested object clean, later sibling undefined" scenario, and a deeply-nested-clean object followed by a defined sibling (to guard against over-reporting).

### Before (bug present, fix reverted)

```
  hasNotDefinedValuesInObject
    ✓ should return false when all values are defined
    ✓ should return true when a top-level value is null
    ✓ should return true when a top-level value is undefined
    ✓ should return true when a value nested in an object is null
    ✕ should return true when the first nested object is fully defined but a later sibling key is null
    ✕ should return true when the first nested object is fully defined but a later sibling key is undefined
    ✕ should return true when the first nested object is fully defined but a later nested object holds null
    ✓ should return false when a deeply nested object is fully defined and is followed by a defined sibling

Tests:       3 failed, 7 passed, 10 total
```

### After (fix applied)

```
  hasNotDefinedValuesInObject
    ✓ should return false when all values are defined
    ✓ should return true when a top-level value is null
    ✓ should return true when a top-level value is undefined
    ✓ should return true when a value nested in an object is null
    ✓ should return true when the first nested object is fully defined but a later sibling key is null
    ✓ should return true when the first nested object is fully defined but a later sibling key is undefined
    ✓ should return true when the first nested object is fully defined but a later nested object holds null
    ✓ should return false when a deeply nested object is fully defined and is followed by a defined sibling

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
```

Command: `npx nx test api --testFile=apps/api/src/helper/object.helper.spec.ts`

`npx prettier --check` and `npx nx lint api` both pass on the changed files.

## Changelog

Added an entry under `## Unreleased` -> `### Fixed`.

---

Prepared with AI assistance (Claude Code), reviewed by the author.
