### PR TITLE
Bugfix/clamp negative periods in FIRE calculator without interest rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a negative number of periods returned by the _FIRE_ calculator when the goal is already met with no interest rate
 - Fixed an issue with the localization of the country names
 
 ## 3.12.0 - 2026-06-17

--- a/libs/ui/src/lib/fire-calculator/fire-calculator.service.spec.ts
+++ b/libs/ui/src/lib/fire-calculator/fire-calculator.service.spec.ts
@@ -32,6 +32,38 @@ describe('FireCalculatorService', () => {
       expect(periodsToRetire).toBe(9);
     });
 
+    it('should return 0 with no interest rate when the goal is already met', async () => {
+      const r = 0;
+      const P = 2000;
+      const totalAmount = 1900;
+      const PMT = 100;
+
+      const periodsToRetire = fireCalculatorService.calculatePeriodsToRetire({
+        P,
+        r,
+        PMT,
+        totalAmount
+      });
+
+      expect(periodsToRetire).toBe(0);
+    });
+
+    it('should return the correct positive amount of periods to retire with no interest rate', async () => {
+      const r = 0;
+      const P = 1000;
+      const totalAmount = 5000;
+      const PMT = 250;
+
+      const periodsToRetire = fireCalculatorService.calculatePeriodsToRetire({
+        P,
+        r,
+        PMT,
+        totalAmount
+      });
+
+      expect(periodsToRetire).toBe(16);
+    });
+
     it('should return the 0 when total amount is 0', async () => {
       const r = 0.05;
       const P = 100000;

--- a/libs/ui/src/lib/fire-calculator/fire-calculator.service.ts
+++ b/libs/ui/src/lib/fire-calculator/fire-calculator.service.ts
@@ -52,7 +52,7 @@ export class FireCalculatorService {
   }) {
     if (r === 0) {
       // No compound interest
-      return (totalAmount - P) / PMT;
+      return Math.max(0, (totalAmount - P) / PMT);
     } else if (totalAmount <= P) {
       return 0;
     }


### PR DESCRIPTION
## Problem

In the _FIRE_ calculator, `calculatePeriodsToRetire()` in `libs/ui/src/lib/fire-calculator/fire-calculator.service.ts` computes the number of periods needed to reach a goal across two branches: an interest-bearing branch (`r !== 0`) and a zero-interest branch (`r === 0`).

The interest-bearing path guards the already-met case (`totalAmount <= P` → returns `0`), but the **zero-interest branch lacks that guard**. When the goal is already met under zero interest, it returns a **negative** number of periods, which renders a past/invalid retirement date.

### Before / After

For `{ P: 2000, PMT: 100, r: 0, totalAmount: 1900 }` (goal already met):

| | Result |
| --- | --- |
| Before | `-1` (past/invalid retirement date) |
| After | `0` (already past the goal) |

## Root cause

The `else if (totalAmount <= P) { return 0; }` already-met guard is unreachable for `r === 0`, because the `if (r === 0)` branch returns first via `(totalAmount - P) / PMT`, which is negative whenever `totalAmount < P`.

## Fix

Clamp the zero-interest result with `Math.max(0, ...)` so it can never go negative, mirroring the already-met behavior of the other branch. The diff is a single line.

```diff
     if (r === 0) {
       // No compound interest
-      return (totalAmount - P) / PMT;
+      return Math.max(0, (totalAmount - P) / PMT);
     } else if (totalAmount <= P) {
       return 0;
     }
```

## Tests

Added two cases to the existing `fire-calculator.service.spec.ts` (matching its describe/it style):
- zero-interest, goal already met → expect `0` (fails before the fix: returns `-1`).
- a normal zero-interest case that still needs several periods → expect the correct positive count (guards against over-clamping).

**Fails-before** (fix reverted): the already-met case fails with `Expected: 0 / Received: -1`, all others pass.

**Passes-after** (`npx nx test ui --testFile=libs/ui/src/lib/fire-calculator/fire-calculator.service.spec.ts`):

```
 PASS   ui  libs/ui/src/lib/fire-calculator/fire-calculator.service.spec.ts
  FireCalculatorService
    Test periods to retire
      ✓ should return the correct amount of periods to retire with no interst rate
      ✓ should return 0 with no interest rate when the goal is already met
      ✓ should return the correct positive amount of periods to retire with no interest rate
      ✓ should return the 0 when total amount is 0
      ✓ should return the correct amount of periods to retire with interst rate

Tests:       5 passed, 5 total
```

`npx prettier --check` on the changed files and `npx nx lint ui` both pass (lint: 0 errors; the changed service file produces no warnings).

A `CHANGELOG.md` entry was added under `## Unreleased / ### Fixed`.

---

Prepared with AI assistance (Claude Code), reviewed by the author.
