### PR TITLE
Task/improve type safety in import activities service

### DIFF
--- a/apps/client/src/app/services/import-activities.service.ts
+++ b/apps/client/src/app/services/import-activities.service.ts
@@ -83,22 +83,22 @@ export class ImportActivitiesService {
         assetProfiles.push({
           currency,
           symbol,
-          assetClass: null,
-          assetSubClass: null,
-          comment: null,
+          assetClass: undefined,
+          assetSubClass: undefined,
+          comment: undefined,
           countries: [],
-          cusip: null,
+          cusip: undefined,
           dataSource: DataSource.MANUAL,
-          figi: null,
-          figiComposite: null,
-          figiShareClass: null,
+          figi: undefined,
+          figiComposite: undefined,
+          figiShareClass: undefined,
           holdings: [],
           isActive: true,
-          isin: null,
+          isin: undefined,
           marketData: [],
           name: symbol,
           sectors: [],
-          url: null
+          url: undefined
         });
       }
     }
@@ -191,14 +191,14 @@ export class ImportActivitiesService {
     updateAccountBalance
   }: Activity): CreateOrderDto {
     return {
-      accountId,
-      comment,
       fee,
       quantity,
       type,
       unitPrice,
       updateAccountBalance,
-      currency: currency ?? SymbolProfile.currency,
+      accountId: accountId ?? undefined,
+      comment: comment ?? undefined,
+      currency: currency ?? SymbolProfile.currency ?? '',
       dataSource: SymbolProfile.dataSource,
       date: date.toString(),
       symbol: SymbolProfile.symbol,
@@ -229,7 +229,7 @@ export class ImportActivitiesService {
         return userAccounts.find((account) => {
           return (
             account.id === item[key] ||
-            account.name.toLowerCase() === item[key].toLowerCase()
+            account.name?.toLowerCase() === item[key]?.toString().toLowerCase()
           );
         })?.id;
       }
@@ -299,7 +299,10 @@ export class ImportActivitiesService {
     for (const key of ImportActivitiesService.DATE_KEYS) {
       if (item[key]) {
         try {
-          return parseDateHelper(item[key].toString()).toISOString();
+          const parsedDate = parseDateHelper(item[key].toString());
+          if (parsedDate) {
+            return parsedDate.toISOString();
+          }
         } catch {}
       }
     }

--- a/apps/client/src/app/services/import-activities.service.ts
+++ b/apps/client/src/app/services/import-activities.service.ts
@@ -198,7 +198,9 @@ export class ImportActivitiesService {
     aObject: Record<string, unknown>
   ): Record<string, unknown> {
     return Object.fromEntries(
-      Object.entries(aObject).map(([key, val]) => [key.toLowerCase(), val])
+      Object.entries(aObject).map(([key, val]) => {
+        return [key.toLowerCase(), val];
+      })
     );
   }
 
@@ -212,12 +214,12 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.ACCOUNT_KEYS) {
-      const val = item[key];
-      if (isString(val) || isNumber(val)) {
-        return userAccounts.find((account) => {
+      const value = item[key];
+
+      if (isNumber(value) || isString(value)) {
+        return userAccounts.find(({ id, name }) => {
           return (
-            account.id === val ||
-            account.name?.toLowerCase() === String(val).toLowerCase()
+            id === value || name?.toLowerCase() === String(value).toLowerCase()
           );
         })?.id;
       }
@@ -230,9 +232,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.COMMENT_KEYS) {
-      const val = item[key];
-      if (isString(val) || isNumber(val)) {
-        return String(val);
+      const value = item[key];
+
+      if (isNumber(value) || isString(value)) {
+        return String(value);
       }
     }
 
@@ -251,9 +254,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.CURRENCY_KEYS) {
-      const val = item[key];
-      if (isString(val)) {
-        return val;
+      const value = item[key];
+
+      if (isString(value)) {
+        return value;
       }
     }
 
@@ -267,9 +271,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.DATA_SOURCE_KEYS) {
-      const val = item[key];
-      if (isString(val)) {
-        return DataSource[val.toUpperCase() as keyof typeof DataSource];
+      const value = item[key];
+
+      if (isString(value)) {
+        return DataSource[value.toUpperCase() as keyof typeof DataSource];
       }
     }
 
@@ -288,10 +293,12 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.DATE_KEYS) {
-      const val = item[key];
-      if (isString(val) || isNumber(val)) {
+      const value = item[key];
+
+      if (isNumber(value) || isString(value)) {
         try {
-          const parsedDate = parseDateHelper(String(val));
+          const parsedDate = parseDateHelper(String(value));
+
           if (parsedDate) {
             return parsedDate.toISOString();
           }
@@ -317,9 +324,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.FEE_KEYS) {
-      const val = item[key];
-      if (isNumber(val) && isFinite(val)) {
-        return Math.abs(val);
+      const value = item[key];
+
+      if (isNumber(value) && isFinite(value)) {
+        return Math.abs(value);
       }
     }
 
@@ -341,9 +349,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.QUANTITY_KEYS) {
-      const val = item[key];
-      if (isNumber(val) && isFinite(val)) {
-        return Math.abs(val);
+      const value = item[key];
+
+      if (isNumber(value) && isFinite(value)) {
+        return Math.abs(value);
       }
     }
 
@@ -365,9 +374,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.SYMBOL_KEYS) {
-      const val = item[key];
-      if (isString(val) || isNumber(val)) {
-        return String(val);
+      const value = item[key];
+
+      if (isNumber(value) || isString(value)) {
+        return String(value);
       }
     }
 
@@ -389,9 +399,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.TYPE_KEYS) {
-      const val = item[key];
-      if (isString(val)) {
-        switch (val.toLowerCase()) {
+      const value = item[key];
+
+      if (isString(value)) {
+        switch (value.toLowerCase()) {
           case 'buy':
             return 'BUY';
           case 'dividend':
@@ -428,9 +439,10 @@ export class ImportActivitiesService {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.UNIT_PRICE_KEYS) {
-      const val = item[key];
-      if (isNumber(val) && isFinite(val)) {
-        return Math.abs(val);
+      const value = item[key];
+
+      if (isNumber(value) && isFinite(value)) {
+        return Math.abs(value);
       }
     }
 

--- a/apps/client/src/app/services/import-activities.service.ts
+++ b/apps/client/src/app/services/import-activities.service.ts
@@ -12,8 +12,7 @@ import { inject, Injectable } from '@angular/core';
 import { Account, DataSource, Type as ActivityType } from '@prisma/client';
 import { isFinite, isNumber, isString } from 'lodash';
 import { parse as csvToJson } from 'papaparse';
-import { EMPTY } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -126,7 +125,7 @@ export class ImportActivitiesService {
   }): Promise<{
     activities: Activity[];
   }> {
-    return new Promise((resolve, reject) => {
+    return firstValueFrom(
       this.postImport(
         {
           accounts,
@@ -136,18 +135,7 @@ export class ImportActivitiesService {
         },
         isDryRun
       )
-        .pipe(
-          catchError((error) => {
-            reject(error);
-            return EMPTY;
-          })
-        )
-        .subscribe({
-          next: (data) => {
-            resolve(data);
-          }
-        });
-    });
+    );
   }
 
   public importSelectedActivities({
@@ -163,11 +151,9 @@ export class ImportActivitiesService {
   }): Promise<{
     activities: Activity[];
   }> {
-    const importData: CreateOrderDto[] = [];
-
-    for (const activity of activities) {
-      importData.push(this.convertToCreateOrderDto(activity));
-    }
+    const importData = activities.map((activity) =>
+      this.convertToCreateOrderDto(activity)
+    );
 
     return this.importJson({
       accounts,
@@ -208,11 +194,12 @@ export class ImportActivitiesService {
     };
   }
 
-  private lowercaseKeys(aObject: Record<string, unknown>) {
-    return Object.keys(aObject).reduce<Record<string, unknown>>((acc, key) => {
-      acc[key.toLowerCase()] = aObject[key];
-      return acc;
-    }, {});
+  private lowercaseKeys(
+    aObject: Record<string, unknown>
+  ): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(aObject).map(([key, val]) => [key.toLowerCase(), val])
+    );
   }
 
   private parseAccount({

--- a/apps/client/src/app/services/import-activities.service.ts
+++ b/apps/client/src/app/services/import-activities.service.ts
@@ -10,7 +10,7 @@ import { Activity } from '@ghostfolio/common/interfaces';
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Account, DataSource, Type as ActivityType } from '@prisma/client';
-import { isFinite } from 'lodash';
+import { isFinite, isNumber, isString } from 'lodash';
 import { parse as csvToJson } from 'papaparse';
 import { EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -49,7 +49,7 @@ export class ImportActivitiesService {
     activities: Activity[];
     assetProfiles: CreateAssetProfileWithMarketDataDto[];
   }> {
-    const content = csvToJson(fileContent, {
+    const content = csvToJson<Record<string, unknown>>(fileContent, {
       dynamicTyping: true,
       header: true,
       skipEmptyLines: true
@@ -208,8 +208,8 @@ export class ImportActivitiesService {
     };
   }
 
-  private lowercaseKeys(aObject: any) {
-    return Object.keys(aObject).reduce((acc, key) => {
+  private lowercaseKeys(aObject: Record<string, unknown>) {
+    return Object.keys(aObject).reduce<Record<string, unknown>>((acc, key) => {
       acc[key.toLowerCase()] = aObject[key];
       return acc;
     }, {});
@@ -219,17 +219,18 @@ export class ImportActivitiesService {
     item,
     userAccounts
   }: {
-    item: any;
+    item: Record<string, unknown>;
     userAccounts: Account[];
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.ACCOUNT_KEYS) {
-      if (item[key]) {
+      const val = item[key];
+      if (isString(val) || isNumber(val)) {
         return userAccounts.find((account) => {
           return (
-            account.id === item[key] ||
-            account.name?.toLowerCase() === item[key]?.toString().toLowerCase()
+            account.id === val ||
+            account.name?.toLowerCase() === String(val).toLowerCase()
           );
         })?.id;
       }
@@ -238,12 +239,13 @@ export class ImportActivitiesService {
     return undefined;
   }
 
-  private parseComment({ item }: { item: any }) {
+  private parseComment({ item }: { item: Record<string, unknown> }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.COMMENT_KEYS) {
-      if (item[key]) {
-        return item[key];
+      const val = item[key];
+      if (isString(val) || isNumber(val)) {
+        return String(val);
       }
     }
 
@@ -255,15 +257,16 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.CURRENCY_KEYS) {
-      if (item[key]) {
-        return item[key];
+      const val = item[key];
+      if (isString(val)) {
+        return val;
       }
     }
 
@@ -273,12 +276,13 @@ export class ImportActivitiesService {
     };
   }
 
-  private parseDataSource({ item }: { item: any }) {
+  private parseDataSource({ item }: { item: Record<string, unknown> }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.DATA_SOURCE_KEYS) {
-      if (item[key]) {
-        return DataSource[item[key].toUpperCase()];
+      const val = item[key];
+      if (isString(val)) {
+        return DataSource[val.toUpperCase() as keyof typeof DataSource];
       }
     }
 
@@ -290,16 +294,17 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.DATE_KEYS) {
-      if (item[key]) {
+      const val = item[key];
+      if (isString(val) || isNumber(val)) {
         try {
-          const parsedDate = parseDateHelper(item[key].toString());
+          const parsedDate = parseDateHelper(String(val));
           if (parsedDate) {
             return parsedDate.toISOString();
           }
@@ -318,15 +323,16 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.FEE_KEYS) {
-      if (isFinite(item[key])) {
-        return Math.abs(item[key]);
+      const val = item[key];
+      if (isNumber(val) && isFinite(val)) {
+        return Math.abs(val);
       }
     }
 
@@ -341,15 +347,16 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.QUANTITY_KEYS) {
-      if (isFinite(item[key])) {
-        return Math.abs(item[key]);
+      const val = item[key];
+      if (isNumber(val) && isFinite(val)) {
+        return Math.abs(val);
       }
     }
 
@@ -364,15 +371,16 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.SYMBOL_KEYS) {
-      if (item[key]) {
-        return item[key];
+      const val = item[key];
+      if (isString(val) || isNumber(val)) {
+        return String(val);
       }
     }
 
@@ -387,15 +395,16 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }): ActivityType {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.TYPE_KEYS) {
-      if (item[key]) {
-        switch (item[key].toLowerCase()) {
+      const val = item[key];
+      if (isString(val)) {
+        switch (val.toLowerCase()) {
           case 'buy':
             return 'BUY';
           case 'dividend':
@@ -425,15 +434,16 @@ export class ImportActivitiesService {
     index,
     item
   }: {
-    content: any[];
+    content: Record<string, unknown>[];
     index: number;
-    item: any;
+    item: Record<string, unknown>;
   }) {
     item = this.lowercaseKeys(item);
 
     for (const key of ImportActivitiesService.UNIT_PRICE_KEYS) {
-      if (isFinite(item[key])) {
-        return Math.abs(item[key]);
+      const val = item[key];
+      if (isNumber(val) && isFinite(val)) {
+        return Math.abs(val);
       }
     }
 

--- a/apps/client/src/app/services/import-activities.service.ts
+++ b/apps/client/src/app/services/import-activities.service.ts
@@ -8,7 +8,7 @@ import { parseDate as parseDateHelper } from '@ghostfolio/common/helper';
 import { Activity } from '@ghostfolio/common/interfaces';
 
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Account, DataSource, Type as ActivityType } from '@prisma/client';
 import { isFinite } from 'lodash';
 import { parse as csvToJson } from 'papaparse';
@@ -35,7 +35,7 @@ export class ImportActivitiesService {
     'value'
   ];
 
-  public constructor(private http: HttpClient) {}
+  private readonly http = inject(HttpClient);
 
   public async importCsv({
     fileContent,


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- **Type Safety**: Resolved all 14 strict type errors in `import-activities.service.ts` by replacing `null` assignments to optional DTO fields with `undefined`, mapping nullable fields with nullish coalescing / empty string fallbacks, adding optional chaining check for `account.name`, and validating helper date parse return values.
- **Modern DI**: Replaced constructor-based dependency injection with the modern `inject()` function.
- **Type Safety / Refactoring**: Removed all `any` types (and `any[]` array signatures) from the service methods in favor of type-safe `Record<string, unknown>` mapping, and introduced Lodash `isString` and `isNumber` checks to guard the parser methods.
- **RxJS Modernization**: Replaced the manual subscription and Promise wrapper in `importJson` with RxJS `firstValueFrom` to modernize Observable-to-Promise conversion.
- **Modern JS/TS**: Simplified object key conversion in `lowercaseKeys` using modern `Object.fromEntries` / `Object.entries`, and refactored loop-push logic to functional `.map()` calls in `importSelectedActivities`.

## Resolved type errors

14 errors (before: 84, after: 70)