### PR TITLE
Fix manual asset symbol mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for routing outgoing requests through a per-domain proxy via the `PROXY_ROUTES` setting in the `FetchService`
 
+### Fixed
+
+- Fixed symbol mapping for asset profiles with the `MANUAL` data source
+
 ## 3.18.0 - 2026-06-28
 
 ### Added

--- a/apps/api/src/services/queues/data-gathering/data-gathering.service.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.service.ts
@@ -70,10 +70,8 @@ export class DataGatheringService {
   }
 
   public async gatherAssetProfiles(
-    aAssetProfileIdentifiers?: AssetProfileIdentifier[]
+    assetProfileIdentifiers?: AssetProfileIdentifier[]
   ) {
-    let assetProfileIdentifiers = aAssetProfileIdentifiers;
-
     if (!assetProfileIdentifiers) {
       assetProfileIdentifiers = await this.getActiveAssetProfileIdentifiers();
     }

--- a/apps/api/src/services/queues/data-gathering/data-gathering.service.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.service.ts
@@ -72,11 +72,7 @@ export class DataGatheringService {
   public async gatherAssetProfiles(
     aAssetProfileIdentifiers?: AssetProfileIdentifier[]
   ) {
-    let assetProfileIdentifiers = aAssetProfileIdentifiers?.filter(
-      (dataGatheringItem) => {
-        return dataGatheringItem.dataSource !== 'MANUAL';
-      }
-    );
+    let assetProfileIdentifiers = aAssetProfileIdentifiers;
 
     if (!assetProfileIdentifiers) {
       assetProfileIdentifiers = await this.getActiveAssetProfileIdentifiers();
@@ -86,10 +82,31 @@ export class DataGatheringService {
       return;
     }
 
-    const assetProfiles = await this.dataProviderService.getAssetProfiles(
+    const symbolProfiles = await this.symbolProfileService.getSymbolProfiles(
       assetProfileIdentifiers
     );
-    const symbolProfiles = await this.symbolProfileService.getSymbolProfiles(
+
+    // Exclude MANUAL asset profiles unless they define a symbol mapping that
+    // lets data enhancers gather profile data from another data source
+    assetProfileIdentifiers = assetProfileIdentifiers.filter(
+      ({ dataSource, symbol }) => {
+        if (dataSource !== 'MANUAL') {
+          return true;
+        }
+
+        const symbolProfile = symbolProfiles.find((profile) => {
+          return profile.dataSource === dataSource && profile.symbol === symbol;
+        });
+
+        return !isEmpty(symbolProfile?.symbolMapping);
+      }
+    );
+
+    if (assetProfileIdentifiers.length <= 0) {
+      return;
+    }
+
+    const assetProfiles = await this.dataProviderService.getAssetProfiles(
       assetProfileIdentifiers
     );
 
@@ -372,15 +389,16 @@ export class DataGatheringService {
   }: {
     maxAge?: StringValue;
   } = {}): Promise<AssetProfileIdentifier[]> {
-    return this.prismaService.symbolProfile.findMany({
+    const symbolProfiles = await this.prismaService.symbolProfile.findMany({
       orderBy: [{ symbol: 'asc' }, { dataSource: 'asc' }],
       select: {
         dataSource: true,
-        symbol: true
+        symbol: true,
+        symbolMapping: true
       },
       where: {
         dataSource: {
-          notIn: ['MANUAL', 'RAPID_API']
+          not: 'RAPID_API'
         },
         isActive: true,
         ...(maxAge && {
@@ -390,6 +408,16 @@ export class DataGatheringService {
         })
       }
     });
+
+    return symbolProfiles
+      .filter(({ dataSource, symbolMapping }) => {
+        // Include MANUAL asset profiles only when they define a symbol mapping
+        // that lets data enhancers gather profile data from another data source
+        return dataSource !== 'MANUAL' || !isEmpty(symbolMapping);
+      })
+      .map(({ dataSource, symbol }) => {
+        return { dataSource, symbol };
+      });
   }
 
   private async getAssetProfileIdentifiersWithCompleteMarketData(): Promise<


### PR DESCRIPTION
This PR should hopefully fix #4376.
I've tested the changes locally against an asset with mapping to QQQ and found the correct sector data etc. in the database (after I changed ghostfolio's useragent for the Trackinsight call, as that just returned an empty response with the original one)