### PR TITLE
Make trackinsight URL configurable

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,7 +22,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ vars.DOCKER_REPOSITORY || 'ghostfolio/ghostfolio' }}
+          images: |
+            ${{ vars.DOCKER_REPOSITORY || 'ghostfolio/ghostfolio' }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{major}}
             type=semver,pattern={{version}}
@@ -37,6 +42,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/apps/api/src/services/configuration/configuration.service.ts
+++ b/apps/api/src/services/configuration/configuration.service.ts
@@ -108,6 +108,7 @@ export class ConfigurationService {
         default: environment.rootUrl
       }),
       STRIPE_SECRET_KEY: str({ default: '' }),
+      TRACKINSIGHT_BASE_URL: url({ default: 'https://www.trackinsight.com' }),
       TWITTER_ACCESS_TOKEN: str({ default: 'dummyAccessToken' }),
       TWITTER_ACCESS_TOKEN_SECRET: str({ default: 'dummyAccessTokenSecret' }),
       TWITTER_API_KEY: str({ default: 'dummyApiKey' }),

--- a/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
+++ b/apps/api/src/services/data-provider/data-enhancer/trackinsight/trackinsight.service.ts
@@ -13,7 +13,6 @@ import { SymbolProfile } from '@prisma/client';
 
 @Injectable()
 export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
-  private static baseUrl = 'https://www.trackinsight.com/data-api';
   private static countriesMapping = {
     'Republic of Korea': 'KR',
     'Russian Federation': 'RU',
@@ -37,6 +36,10 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
     private readonly configurationService: ConfigurationService,
     private readonly fetchService: FetchService
   ) {}
+
+  private get baseUrl() {
+    return this.configurationService.get('TRACKINSIGHT_BASE_URL');
+  }
 
   public async enhance({
     requestTimeout = this.configurationService.get('REQUEST_TIMEOUT'),
@@ -74,7 +77,7 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
 
     const profile = await this.fetchService
       .fetch(
-        `${TrackinsightDataEnhancerService.baseUrl}/funds/${trackinsightSymbol}.json`,
+        `${this.baseUrl}/data-api/funds/${trackinsightSymbol}.json`,
         {
           signal: AbortSignal.timeout(requestTimeout)
         }
@@ -98,7 +101,7 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
 
     const holdings = await this.fetchService
       .fetch(
-        `${TrackinsightDataEnhancerService.baseUrl}/holdings/${trackinsightSymbol}.json`,
+        `${this.baseUrl}/data-api/holdings/${trackinsightSymbol}.json`,
         {
           signal: AbortSignal.timeout(requestTimeout)
         }
@@ -191,7 +194,7 @@ export class TrackinsightDataEnhancerService implements DataEnhancerInterface {
   }) {
     return this.fetchService
       .fetch(
-        `https://www.trackinsight.com/search-api/search_v2/${symbol}/_/ticker/default/0/3`,
+        `${this.baseUrl}/search-api/search_v2/${symbol}/_/ticker/default/0/3`,
         {
           signal: AbortSignal.timeout(requestTimeout)
         }

--- a/apps/api/src/services/interfaces/environment.interface.ts
+++ b/apps/api/src/services/interfaces/environment.interface.ts
@@ -55,6 +55,7 @@ export interface Environment extends CleanedEnvAccessors {
   REQUEST_TIMEOUT: number;
   ROOT_URL: string;
   STRIPE_SECRET_KEY: string;
+  TRACKINSIGHT_BASE_URL: string;
   TWITTER_ACCESS_TOKEN: string;
   TWITTER_ACCESS_TOKEN_SECRET: string;
   TWITTER_API_KEY: string;


### PR DESCRIPTION
This PR makes the trackinsight URL configurable. This allows to run a puppeteering proxy to pass trackinsights AWS WAF protection (e.g. via [this project](https://github.com/SeineEloquenz/trackinsight-proxy). Together with #7145 this fixes the Trackinsight gathering flow for Manual (and likely Yahoo as well?) assets