### PR TITLE
Bugfix/data source validation of create asset profile with market data DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the validation of the `dataSource` field in the `CreateAssetProfileWithMarketDataDto` to use `IsIn`
 - Fixed a recurring issue where single-value fields were incorrectly validated as arrays in various endpoints
 
 ## 3.18.0 - 2026-06-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the validation of the `dataSource` field in the `CreateAssetProfileWithMarketDataDto` to use `IsIn`
+- Fixed the validation of the data source field of an asset profile with market data
 - Fixed a recurring issue where single-value fields were incorrectly validated as arrays in various endpoints
 
 ## 3.18.0 - 2026-06-28

--- a/libs/common/src/lib/dtos/create-asset-profile-with-market-data.dto.ts
+++ b/libs/common/src/lib/dtos/create-asset-profile-with-market-data.dto.ts
@@ -1,12 +1,12 @@
 import { MarketData } from '@ghostfolio/common/interfaces';
 
 import { DataSource } from '@prisma/client';
-import { IsArray, IsEnum, IsOptional } from 'class-validator';
+import { IsArray, IsIn, IsOptional } from 'class-validator';
 
 import { CreateAssetProfileDto } from './create-asset-profile.dto';
 
 export class CreateAssetProfileWithMarketDataDto extends CreateAssetProfileDto {
-  @IsEnum([DataSource.MANUAL], {
+  @IsIn([DataSource.MANUAL], {
     message: `dataSource must be '${DataSource.MANUAL}'`
   })
   dataSource: DataSource;


### PR DESCRIPTION
## Description

Fix incorrect validation in `CreateAssetProfileWithMarketDataDto` where `@IsEnum()` was called with an array literal as the enum entity.

### Problem

`@IsEnum()` expects an enum type (like `DataSource`) but receives an array literal `[DataSource.MANUAL]`. Class-validator internally calls `Object.keys(['MANUAL'])` which returns `['0']` — the array index. This means validation always checks if the input equals `'0'` instead of checking if it's `'MANUAL'`, causing every valid request with `dataSource: 'MANUAL'` to be rejected with a 400 error.

### Fix

Replaced `@IsEnum` with `@IsIn`, which is designed for validating against a literal set of values.

### Changes

| File | Change |
|------|--------|
| `libs/common/src/lib/dtos/create-asset-profile-with-market-data.dto.ts` | Replaced `IsEnum` import with `IsIn` and updated the decorator |
| `CHANGELOG.md` | Added changelog entry |