### PR TITLE
Task/add explicit @prisma/config dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the _Privacy Policy_
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `nestjs` from version `11.1.21` to `11.1.27`
+- Added explicit devDependency import of `@prisma/config`
 
 ## 3.18.0 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for routing outgoing requests through a per-domain proxy via the `PROXY_ROUTES` setting in the `FetchService`
+- Added `@prisma/config` as a development dependency used by the _Prisma Configuration File_
 
 ### Changed
 
 - Updated the _Privacy Policy_
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `nestjs` from version `11.1.21` to `11.1.27`
-- Added explicit devDependency import of `@prisma/config`
 
 ## 3.18.0 - 2026-06-28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
         "@nx/storybook": "23.0.1",
         "@nx/web": "23.0.1",
         "@nx/workspace": "23.0.1",
+        "@prisma/config": "7.8.0",
         "@schematics/angular": "21.2.6",
         "@storybook/addon-docs": "10.1.10",
         "@storybook/addon-themes": "10.1.10",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@nx/storybook": "23.0.1",
     "@nx/web": "23.0.1",
     "@nx/workspace": "23.0.1",
+    "@prisma/config": "7.8.0",
     "@schematics/angular": "21.2.6",
     "@storybook/addon-docs": "10.1.10",
     "@storybook/addon-themes": "10.1.10",


### PR DESCRIPTION
It's used in `.config/prisma.ts` and is coincidentally available for the `postinstall` to run correctly (already present in the lockfile).

However, some tools (that are not npm) might complain that it should either be explicit or hoisted with an `.npmrc` flag.