### PR TITLE
fix(activities): replace isNaN checks with ParseIntPipe for skip/take query params

### DIFF
--- a/apps/api/src/app/activities/activities.controller.ts
+++ b/apps/api/src/app/activities/activities.controller.ts
@@ -29,6 +29,7 @@ import {
   HttpException,
   Inject,
   Param,
+  ParseIntPipe,
   Post,
   Put,
   Query,
@@ -112,12 +113,12 @@ export class ActivitiesController {
     @Query('assetClasses') filterByAssetClasses?: string,
     @Query('dataSource') filterByDataSource?: string,
     @Query('range') dateRange?: DateRange,
-    @Query('skip') skip?: number,
+    @Query('skip', new ParseIntPipe({ optional: true })) skip?: number,
     @Query('sortColumn') sortColumn?: string,
     @Query('sortDirection') sortDirection?: Prisma.SortOrder,
     @Query('symbol') filterBySymbol?: string,
     @Query('tags') filterByTags?: string,
-    @Query('take') take?: number
+    @Query('take', new ParseIntPipe({ optional: true })) take?: number
   ): Promise<ActivitiesResponse> {
     let endDate: Date;
     let startDate: Date;
@@ -150,8 +151,8 @@ export class ActivitiesController {
       types,
       userCurrency,
       includeDrafts: true,
-      skip: isNaN(skip) ? undefined : skip,
-      take: isNaN(take) ? undefined : take,
+      skip,
+      take,
       userId: impersonationUserId || this.request.user.id,
       withExcludedAccountsAndActivities: true
     });


### PR DESCRIPTION
Replace manual isNaN checks on the skip and take query parameters in ActivitiesController with NestJS's built-in ParseIntPipe using { optional: true }, which handles both integer parsing and absent params cleanly.

Before:

@Query('skip') skip?: number
// skip: isNaN(skip) ? undefined : skip


After:

@Query('skip', new ParseIntPipe({ optional: true })) skip?: number
// skip