### PR TITLE
Task/improve parsing of integer query parameters in GET api/v1/activities endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the _Privacy Policy_
 - Updated the _Terms of Service_
+- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/activities` endpoint
 - Improved the language localization for German (`de`)
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `nestjs` from version `11.1.21` to `11.1.27`
 
 ### Fixed
 
-- Fixed the validation of the `skip` and `take` query parameters in the activities controller to use `ParseIntPipe`
 - Fixed the validation of the data source field of an asset profile with market data
 - Fixed a recurring issue where single-value fields were incorrectly validated as arrays in various endpoints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the validation of the `skip` and `take` query parameters in the activities controller to use `ParseIntPipe`
 - Fixed the validation of the data source field of an asset profile with market data
 - Fixed a recurring issue where single-value fields were incorrectly validated as arrays in various endpoints
 

--- a/apps/api/src/app/activities/activities.controller.ts
+++ b/apps/api/src/app/activities/activities.controller.ts
@@ -145,14 +145,14 @@ export class ActivitiesController {
     const { activities, count } = await this.activitiesService.getActivities({
       endDate,
       filters,
+      skip,
       sortColumn,
       sortDirection,
       startDate,
+      take,
       types,
       userCurrency,
       includeDrafts: true,
-      skip,
-      take,
       userId: impersonationUserId || this.request.user.id,
       withExcludedAccountsAndActivities: true
     });

--- a/apps/api/src/app/activities/activities.controller.ts
+++ b/apps/api/src/app/activities/activities.controller.ts
@@ -29,6 +29,7 @@ import {
   HttpException,
   Inject,
   Param,
+  ParseIntPipe,
   Post,
   Put,
   Query,
@@ -112,12 +113,12 @@ export class ActivitiesController {
     @Query('assetClasses') filterByAssetClasses?: string,
     @Query('dataSource') filterByDataSource?: string,
     @Query('range') dateRange?: DateRange,
-    @Query('skip') skip?: number,
+    @Query('skip', new ParseIntPipe({ optional: true })) skip?: number,
     @Query('sortColumn') sortColumn?: string,
     @Query('sortDirection') sortDirection?: Prisma.SortOrder,
     @Query('symbol') filterBySymbol?: string,
     @Query('tags') filterByTags?: string,
-    @Query('take') take?: number
+    @Query('take', new ParseIntPipe({ optional: true })) take?: number
   ): Promise<ActivitiesResponse> {
     let endDate: Date;
     let startDate: Date;
@@ -150,8 +151,8 @@ export class ActivitiesController {
       types,
       userCurrency,
       includeDrafts: true,
-      skip: isNaN(skip) ? undefined : skip,
-      take: isNaN(take) ? undefined : take,
+      skip,
+      take,
       userId: impersonationUserId || this.request.user.id,
       withExcludedAccountsAndActivities: true
     });


### PR DESCRIPTION
## Description

Replaced manual `isNaN` validation of the `skip` and `take` query parameters in the activities controller with NestJS's built-in `ParseIntPipe({ optional: true })`.

### Changes

- `apps/api/src/app/activities/activities.controller.ts`
  - Added `ParseIntPipe` to NestJS imports
  - Applied `@Query('skip', new ParseIntPipe({ optional: true }))` and `@Query('take', new ParseIntPipe({ optional: true }))` to delegate validation to the framework
  - Removed the now-unnecessary `isNaN(skip) ? undefined : skip` / `isNaN(take) ? undefined : take` guards

### Behavior

| Scenario | Before | After |
|---|---|---|
| `?skip=10` | `10` | `10` |
| `?skip=abc` | `undefined` (silently ignored) | `400 Bad Request` |
| No param | `undefined` | `undefined` |

`ParseIntPipe` with `optional: true` means the param is validated only when present — missing params pass through as `undefined`, while invalid values throw a proper HTTP error instead of being silently swallowed.

Closes
#7180 