### PR TITLE
Task/upgrade Stripe to version 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgraded `stripe` from version `21.0.1` to `22.2.0`
+- Upgraded `stripe` from version `21.0.1` to `22.2.3`
 
 ## 3.20.0 - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgraded `stripe` from version `21.0.1` to `22.2.0`
+
 ## 3.20.0 - 2026-07-04
 
 ### Changed
@@ -47,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `@ionic/angular` from version `8.8.5` to `8.8.12`
 - Upgraded `nestjs` from version `11.1.21` to `11.1.27`
-- Upgraded `stripe` from version `21.0.1` to `22.2.0`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `@ionic/angular` from version `8.8.5` to `8.8.12`
 - Upgraded `nestjs` from version `11.1.21` to `11.1.27`
+- Upgraded `stripe` from version `21.0.1` to `22.2.0`
 
 ### Fixed
 

--- a/apps/api/src/app/subscription/subscription.service.ts
+++ b/apps/api/src/app/subscription/subscription.service.ts
@@ -21,12 +21,16 @@ import { Prisma, Subscription } from '@prisma/client';
 import { addMilliseconds, isBefore } from 'date-fns';
 import ms, { StringValue } from 'ms';
 import Stripe from 'stripe';
+import type {
+  Stripe as StripeInstance,
+  Checkout as StripeCheckout
+} from 'stripe';
 
 @Injectable()
 export class SubscriptionService {
   private readonly logger = new Logger(SubscriptionService.name);
 
-  private stripe: Stripe;
+  private stripe: StripeInstance;
 
   public constructor(
     private readonly configurationService: ConfigurationService,
@@ -37,7 +41,7 @@ export class SubscriptionService {
       this.stripe = new Stripe(
         this.configurationService.get('STRIPE_SECRET_KEY'),
         {
-          apiVersion: '2026-03-25.dahlia'
+          apiVersion: '2026-05-27.dahlia'
         }
       );
     }
@@ -63,7 +67,7 @@ export class SubscriptionService {
       }
     );
 
-    const stripeCheckoutSessionCreateParams: Stripe.Checkout.SessionCreateParams =
+    const stripeCheckoutSessionCreateParams: StripeCheckout.SessionCreateParams =
       {
         cancel_url: `${this.configurationService.get('ROOT_URL')}/${
           user.settings.settings.language
@@ -77,7 +81,7 @@ export class SubscriptionService {
         ],
         locale:
           (user.settings?.settings
-            ?.language as Stripe.Checkout.SessionCreateParams.Locale) ??
+            ?.language as StripeCheckout.SessionCreateParams.Locale) ??
           DEFAULT_LANGUAGE_CODE,
         metadata: subscriptionOffer
           ? { subscriptionOffer: JSON.stringify(subscriptionOffer) }

--- a/apps/api/src/app/subscription/subscription.service.ts
+++ b/apps/api/src/app/subscription/subscription.service.ts
@@ -21,16 +21,12 @@ import { Prisma, Subscription } from '@prisma/client';
 import { addMilliseconds, isBefore } from 'date-fns';
 import ms, { StringValue } from 'ms';
 import Stripe from 'stripe';
-import type {
-  Stripe as StripeInstance,
-  Checkout as StripeCheckout
-} from 'stripe';
 
 @Injectable()
 export class SubscriptionService {
   private readonly logger = new Logger(SubscriptionService.name);
 
-  private stripe: StripeInstance;
+  private stripe: Stripe;
 
   public constructor(
     private readonly configurationService: ConfigurationService,
@@ -67,7 +63,7 @@ export class SubscriptionService {
       }
     );
 
-    const stripeCheckoutSessionCreateParams: StripeCheckout.SessionCreateParams =
+    const stripeCheckoutSessionCreateParams: Stripe.Checkout.SessionCreateParams =
       {
         cancel_url: `${this.configurationService.get('ROOT_URL')}/${
           user.settings.settings.language
@@ -81,7 +77,7 @@ export class SubscriptionService {
         ],
         locale:
           (user.settings?.settings
-            ?.language as StripeCheckout.SessionCreateParams.Locale) ??
+            ?.language as Stripe.Checkout.SessionCreateParams.Locale) ??
           DEFAULT_LANGUAGE_CODE,
         metadata: subscriptionOffer
           ? { subscriptionOffer: JSON.stringify(subscriptionOffer) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "passport-openidconnect": "0.1.2",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.1",
-        "stripe": "21.0.1",
+        "stripe": "22.2.0",
         "svgmap": "2.21.0",
         "tablemark": "4.1.0",
         "twitter-api-v2": "1.29.0",
@@ -32298,9 +32298,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-21.0.1.tgz",
-      "integrity": "sha512-ocv0j7dWttswDWV2XL/kb6+yiLpDXNXL3RQAOB5OB2kr49z0cEatdQc12+zP/j5nrXk6rAsT4N3y/NUvBbK7Pw==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
+      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "passport-openidconnect": "0.1.2",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.1",
-        "stripe": "22.2.0",
+        "stripe": "22.2.3",
         "svgmap": "2.21.0",
         "tablemark": "4.1.0",
         "twitter-api-v2": "1.29.0",
@@ -32298,9 +32298,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
-      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
+      "version": "22.2.3",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.3.tgz",
+      "integrity": "sha512-9lrggvLtjO4Ef5WXH4t50ckHJcJgTD72xFB+KJgZCSszAH9zMV1BqU6PwmWbRLdcdX7LK6PbErBapiGK7pIb+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "passport-openidconnect": "0.1.2",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.1",
-    "stripe": "21.0.1",
+    "stripe": "22.2.0",
     "svgmap": "2.21.0",
     "tablemark": "4.1.0",
     "twitter-api-v2": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "passport-openidconnect": "0.1.2",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.1",
-    "stripe": "22.2.0",
+    "stripe": "22.2.3",
     "svgmap": "2.21.0",
     "tablemark": "4.1.0",
     "twitter-api-v2": "1.29.0",


### PR DESCRIPTION
## Summary

Fixes #6820

Upgrades the `stripe` Node.js SDK from version `21.0.1` to `22.2.0`.

## Changes

### `package.json`
- Bumped `stripe` from `21.0.1` → `22.2.0`

### `apps/api/src/app/subscription/subscription.service.ts`
Stripe v22 ships with breaking TypeScript type changes that required the following fixes:

1. **Added named type import** — `import Stripe from 'stripe'` now resolves to `StripeConstructor` (the CJS callable wrapper) in v22, not the class type. Added a separate `import type { Stripe as StripeInstance } from 'stripe'` to access the actual class type for annotations.

2. **Updated `apiVersion`** — Changed from `'2026-03-25.dahlia'` to `'2026-05-27.dahlia'` (`'2026-03-25.dahlia'` is no longer a valid value in v22's type definitions — the `apiVersion` field is typed as a strict literal matching only the latest supported version bundled with the SDK).

3. **Updated type references** — `Stripe.Checkout.SessionCreateParams` and `Stripe.Checkout.SessionCreateParams.Locale` were updated to use `StripeInstance.Checkout.*` since the `Checkout` namespace is no longer accessible via the `StripeConstructor` namespace.

### `CHANGELOG.md`
- Added entry: `Upgraded stripe from version 21.0.1 to 22.2.0`

## How It Was Tested

**TypeScript compilation**
```bash
npx tsc -p apps/api/tsconfig.app.json --noEmit
```
**Build the api**
```bash
npx nx run api:build
```
