### PR TITLE
Task/improve integer query parameter parsing in various controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restricted the modification of activity tags in the impersonation mode
 - Hardened the endpoint of the public access for portfolio sharing by restricting it to public accesses
+- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/admin/user` endpoint
+- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/asset-profiles` endpoint
 - Improved the language localization by translating various tooltips across the application
 - Improved the language localization for Ukrainian (`uk`)
 - Upgraded `yahoo-finance2` from version `3.14.3` to `3.15.4`
@@ -28,8 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the _Privacy Policy_
 - Updated the _Terms of Service_
 - Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/activities` endpoint
-- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/admin/user` endpoint
-- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/asset-profiles` endpoint
 - Improved the language localization for German (`de`)
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `@ionic/angular` from version `8.8.5` to `8.8.12`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the _Privacy Policy_
 - Updated the _Terms of Service_
 - Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/activities` endpoint
+- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/admin/user` endpoint
+- Improved the parsing of integer query parameters (`skip` and `take`) in the `GET api/v1/asset-profiles` endpoint
 - Improved the language localization for German (`de`)
 - Improved the language localization for Japanese (`ja`)
 - Upgraded `@ionic/angular` from version `8.8.5` to `8.8.12`

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -40,6 +40,7 @@ import {
   Inject,
   Logger,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Put,
@@ -319,12 +320,12 @@ export class AdminController {
   @HasPermission(permissions.accessAdminControl)
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async getUsers(
-    @Query('skip') skip?: number,
-    @Query('take') take?: number
+    @Query('skip', new ParseIntPipe({ optional: true })) skip?: number,
+    @Query('take', new ParseIntPipe({ optional: true })) take?: number
   ): Promise<AdminUsersResponse> {
     return this.adminService.getUsers({
-      skip: isNaN(skip) ? undefined : skip,
-      take: isNaN(take) ? undefined : take
+      skip,
+      take
     });
   }
 

--- a/apps/api/src/app/endpoints/asset-profiles/asset-profiles.controller.ts
+++ b/apps/api/src/app/endpoints/asset-profiles/asset-profiles.controller.ts
@@ -22,6 +22,7 @@ import {
   HttpException,
   Inject,
   Param,
+  ParseIntPipe,
   Patch,
   Query,
   UseGuards,
@@ -51,10 +52,10 @@ export class AssetProfilesController {
     @Query('dataSource') filterByDataSource?: string,
     @Query('presetId') presetId?: MarketDataPreset,
     @Query('query') filterBySearchQuery?: string,
-    @Query('skip') skip?: number,
+    @Query('skip', new ParseIntPipe({ optional: true })) skip?: number,
     @Query('sortColumn') sortColumn?: string,
     @Query('sortDirection') sortDirection?: Prisma.SortOrder,
-    @Query('take') take?: number
+    @Query('take', new ParseIntPipe({ optional: true })) take?: number
   ): Promise<AssetProfilesResponse> {
     const filters = this.apiService.buildFiltersFromQueryParams({
       filterByAssetSubClasses,
@@ -67,8 +68,8 @@ export class AssetProfilesController {
       presetId,
       sortColumn,
       sortDirection,
-      skip: isNaN(skip) ? undefined : skip,
-      take: isNaN(take) ? undefined : take
+      skip,
+      take
     });
   }
 

--- a/apps/api/src/app/endpoints/asset-profiles/asset-profiles.controller.ts
+++ b/apps/api/src/app/endpoints/asset-profiles/asset-profiles.controller.ts
@@ -66,9 +66,9 @@ export class AssetProfilesController {
     return this.assetProfilesService.getAssetProfiles({
       filters,
       presetId,
+      skip,
       sortColumn,
       sortDirection,
-      skip,
       take
     });
   }


### PR DESCRIPTION
Closes #7186
Closes #7187

## Description

Replaced manual `isNaN` validation of the `skip` and `take` query parameters in the `AdminController` and `AssetProfilesController` with NestJS's built-in `ParseIntPipe({ optional: true })`, following the same pattern already applied in the activities controller.

### Changes

- `apps/api/src/app/admin/admin.controller.ts`
  - Added `ParseIntPipe` to NestJS imports
  - Applied `@Query('skip', new ParseIntPipe({ optional: true }))` and `@Query('take', new ParseIntPipe({ optional: true }))` to the `getUsers()` method to delegate validation to the framework
  - Removed the now-unnecessary `isNaN(skip) ? undefined : skip` / `isNaN(take) ? undefined : take` guards

- `apps/api/src/app/endpoints/asset-profiles/asset-profiles.controller.ts`
  - Added `ParseIntPipe` to NestJS imports
  - Applied `@Query('skip', new ParseIntPipe({ optional: true }))` and `@Query('take', new ParseIntPipe({ optional: true }))` to the `getAssetProfiles()` method to delegate validation to the framework
  - Removed the now-unnecessary `isNaN(skip) ? undefined : skip` / `isNaN(take) ? undefined : take` guards

### Behavior

`ParseIntPipe` with `optional: true` means the param is validated only when present — missing params pass through as `undefined`, while invalid values (e.g. `?skip=abc`) now throw a proper `400 Bad Request` instead of being silently swallowed as `undefined`.

### Tested
Tested using api build:
```bash
npx nx run api:build
```

