### PR TITLE
Bugfix/missing navigation on landing page for unauthenticated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the missing "Sign in" button on the landing page for unauthenticated users
 - Fixed the validation of the data source field of an asset profile with market data
 - Fixed a recurring issue where single-value fields were incorrectly validated as arrays in various endpoints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the missing "Sign in" button on the landing page for unauthenticated users
 - Fixed the validation of the data source field of an asset profile with market data
 - Fixed a recurring issue where single-value fields were incorrectly validated as arrays in various endpoints
 

--- a/apps/client/src/app/components/header/header.component.html
+++ b/apps/client/src/app/components/header/header.component.html
@@ -332,7 +332,7 @@
       </li>
     </ul>
   }
-  @if (user() === null) {
+  @if (!user()) {
     <div class="d-flex h-100 logo-container" [class.filled]="hasTabs()">
       <a
         class="align-items-center h-100 justify-content-start px-2 px-sm-3 rounded-0"


### PR DESCRIPTION
## Description

Fixes a regression from #7175 where the "Sign in" button disappeared from the landing page for unauthenticated users. Fixes #7191.

### Root Cause

PR #7175 changed `UserService.reset()` to set `state.user = undefined` instead of `null`. The header template used `@if (user() === null)` to render the public header, but `undefined === null` evaluates to `false`, causing the entire public header block (including the "Sign in" and "Get Started" buttons) to be hidden.

### Changes

- `apps/client/src/app/components/header/header.component.html`: Changed `@if (user() === null)` to `@if (!user())` to correctly handle both `null` and `undefined` as unauthenticated states, while `@if (user())` continues to handle the logged-in state.

### Related Issues

- Fixes #7191
- Regression introduced in #7175