### PR TITLE
Task/set change detection strategy to OnPush in overview of admin control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrated the `admin-overview-component` to `OnPush`
+- Set the change detection strategy to `OnPush` in the overview of the admin control panel
 - Upgraded `stripe` from version `21.0.1` to `22.2.3`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrated the `admin-overview-component` to `OnPush`
 - Upgraded `stripe` from version `21.0.1` to `22.2.3`
 
 ### Fixed

--- a/apps/client/src/app/components/admin-overview/admin-overview.component.ts
+++ b/apps/client/src/app/components/admin-overview/admin-overview.component.ts
@@ -84,7 +84,7 @@ import ms, { StringValue } from 'ms';
   ],
   selector: 'gf-admin-overview',
   styleUrls: ['./admin-overview.scss'],
-  templateUrl: './admin-overview.html',
+  templateUrl: './admin-overview.html'
 })
 export class GfAdminOverviewComponent implements OnInit {
   protected activitiesCount: number;

--- a/apps/client/src/app/components/admin-overview/admin-overview.component.ts
+++ b/apps/client/src/app/components/admin-overview/admin-overview.component.ts
@@ -65,6 +65,7 @@ import {
 import ms, { StringValue } from 'ms';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ClipboardModule,
     CommonModule,
@@ -84,7 +85,6 @@ import ms, { StringValue } from 'ms';
   selector: 'gf-admin-overview',
   styleUrls: ['./admin-overview.scss'],
   templateUrl: './admin-overview.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GfAdminOverviewComponent implements OnInit {
   protected activitiesCount: number;

--- a/apps/client/src/app/components/admin-overview/admin-overview.component.ts
+++ b/apps/client/src/app/components/admin-overview/admin-overview.component.ts
@@ -27,6 +27,7 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -82,7 +83,8 @@ import ms, { StringValue } from 'ms';
   ],
   selector: 'gf-admin-overview',
   styleUrls: ['./admin-overview.scss'],
-  templateUrl: './admin-overview.html'
+  templateUrl: './admin-overview.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GfAdminOverviewComponent implements OnInit {
   protected activitiesCount: number;
@@ -140,6 +142,8 @@ export class GfAdminOverviewComponent implements OnInit {
             permissions.toggleReadOnlyMode
           );
         }
+
+        this.changeDetectorRef.markForCheck();
       });
 
     addIcons({


### PR DESCRIPTION
Hi @dtslvr, this PR resolves #7223, please take a look

### Summary

This PR migrates the `GfAdminOverviewComponent` to use the `OnPush` change detection strategy to optimize the application performance by reducing unnecessary change detection cycles.

### Changes

- **admin-overview.component.ts**:
  - Imported `ChangeDetectionStrategy` from `@angular/core`.
  - Configured the component to use `ChangeDetectionStrategy.OnPush`.
  - Added `this.changeDetectorRef.markForCheck()` to the `userService.stateChanged` subscription callback to ensure permissions and user details are updated correctly under `OnPush`.
- **CHANGELOG.md**:
  - Added a entry under the *Unreleased > Changed* section.