### PR TITLE
Task/validate property key in admin settings endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Hardened the endpoint to update a property of the admin control panel by validating the `key` path parameter
+
 ## 3.21.0 - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Hardened the endpoint to update a property of the admin control panel by validating the `key` path parameter
 - Improved the user account deletion flow in the user settings of the user account page
 - Set the change detection strategy to `OnPush` in the portfolio holdings page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
 - Set the change detection strategy to `OnPush` in the users section of the admin control panel
+- Hardened the endpoint to update a property of the admin control panel by validating the `key` path parameter
 - Renamed the `SymbolProfileOverrides` _Prisma_ data model to `AssetProfileOverrides` while keeping the database table name
 - Improved the language localization for Dutch (`nl`)
 - Improved the language localization for French (`fr`)

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -29,7 +29,11 @@ import {
   ScraperConfiguration
 } from '@ghostfolio/common/interfaces';
 import { permissions } from '@ghostfolio/common/permissions';
-import type { DateRange, RequestWithUser } from '@ghostfolio/common/types';
+import type {
+  DateRange,
+  PropertyKey,
+  RequestWithUser
+} from '@ghostfolio/common/types';
 
 import {
   Body,
@@ -55,6 +59,7 @@ import { isDate, parseISO } from 'date-fns';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 
 import { AdminService } from './admin.service';
+import { PropertyKeyPipe } from './pipes/property-key.pipe';
 
 @Controller('admin')
 export class AdminController {
@@ -310,7 +315,7 @@ export class AdminController {
   @Put('settings/:key')
   @UseGuards(AuthGuard('jwt'), HasPermissionGuard)
   public async updateProperty(
-    @Param('key') key: string,
+    @Param('key', PropertyKeyPipe) key: PropertyKey,
     @Body() data: UpdatePropertyDto
   ) {
     return this.adminService.putSetting(key, data.value);

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -344,17 +344,17 @@ export class AdminService {
     }
   }
 
-  public async putSetting(key: string, value: string) {
+  public async putSetting(key: PropertyKey, value: string) {
     let response: Property;
 
     if (value) {
       response = await this.propertyService.put({
         value,
-        key: key as PropertyKey
+        key
       });
     } else {
       response = await this.propertyService.delete({
-        key: key as PropertyKey
+        key
       });
     }
 

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -349,8 +349,8 @@ export class AdminService {
 
     if (value) {
       response = await this.propertyService.put({
-        value,
-        key
+        key,
+        value
       });
     } else {
       response = await this.propertyService.delete({

--- a/apps/api/src/app/admin/pipes/property-key.pipe.ts
+++ b/apps/api/src/app/admin/pipes/property-key.pipe.ts
@@ -1,0 +1,25 @@
+import * as config from '@ghostfolio/common/config';
+import type { PropertyKey } from '@ghostfolio/common/types';
+
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class PropertyKeyPipe implements PipeTransform<string, PropertyKey> {
+  private readonly allowedKeys: Set<string>;
+
+  public constructor() {
+    this.allowedKeys = new Set(
+      Object.entries(config)
+        .filter(([key]) => key.startsWith('PROPERTY_'))
+        .map(([, value]) => value as string)
+    );
+  }
+
+  public transform(value: string): PropertyKey {
+    if (!this.allowedKeys.has(value)) {
+      throw new BadRequestException(`Invalid property key: ${value}`);
+    }
+
+    return value as PropertyKey;
+  }
+}

--- a/apps/api/src/app/admin/pipes/property-key.pipe.ts
+++ b/apps/api/src/app/admin/pipes/property-key.pipe.ts
@@ -8,10 +8,14 @@ export class PropertyKeyPipe implements PipeTransform<string, PropertyKey> {
   private readonly allowedKeys: Set<string>;
 
   public constructor() {
-    this.allowedKeys = new Set(
+    this.allowedKeys = new Set<string>(
       Object.entries(config)
-        .filter(([key]) => key.startsWith('PROPERTY_'))
-        .map(([, value]) => value as string)
+        .filter(([key]) => {
+          return key.startsWith('PROPERTY_');
+        })
+        .map(([, value]) => {
+          return value as string;
+        })
     );
   }
 


### PR DESCRIPTION
Fixes #7243

## Description

The `PUT /api/admin/settings/:key` endpoint accepted any arbitrary string as the
`:key` param with no validation. This PR adds a `PropertyKeyPipe` that rejects
unknown keys with a `400 Bad Request` before reaching the service layer.

## Changes

**Added**
- `apps/api/src/app/admin/pipes/property-key.pipe.ts` — `PropertyKeyPipe`

**Modified**
- `apps/api/src/app/admin/admin.controller.ts` — apply `PropertyKeyPipe` to `:key` param
- `apps/api/src/app/admin/admin.service.ts` — restore strict `PropertyKey` type, remove unsafe casts

## Tested

```bash
npx nx run api:build
```
