### PR TITLE
Task/set change detection strategy to OnPush in activities page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the user account deletion flow in the user settings of the user account page
+- Set the change detection strategy to `OnPush` in the activities page
 - Set the change detection strategy to `OnPush` in the allocations page
 - Set the change detection strategy to `OnPush` in the portfolio holdings page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
@@ -32,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set the change detection strategy to `OnPush` in the activities page
 - Set the change detection strategy to `OnPush` in the alert dialog component
 - Set the change detection strategy to `OnPush` in the confirmation dialog component
 - Set the change detection strategy to `OnPush` in the prompt dialog component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set the change detection strategy to `OnPush` in the activities page
 - Set the change detection strategy to `OnPush` in the allocations page
 - Set the change detection strategy to `OnPush` in the portfolio holdings page
+- Set the change detection strategy to `OnPush` in the activities page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
 - Set the change detection strategy to `OnPush` in the users section of the admin control panel
 - Renamed the `SymbolProfileOverrides` _Prisma_ data model to `AssetProfileOverrides` while keeping the database table name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Set the change detection strategy to `OnPush` in the activities page
 - Set the change detection strategy to `OnPush` in the alert dialog component
 - Set the change detection strategy to `OnPush` in the confirmation dialog component
 - Set the change detection strategy to `OnPush` in the prompt dialog component

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -39,13 +39,13 @@ import { GfImportActivitiesDialogComponent } from './import-activities-dialog/im
 import { ImportActivitiesDialogParams } from './import-activities-dialog/interfaces/interfaces';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     GfActivitiesTableComponent,
     GfFabComponent,
     MatSnackBarModule,
     RouterModule
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'gf-activities-page',
   styleUrls: ['./activities-page.scss'],
   templateUrl: './activities-page.html'
@@ -114,6 +114,7 @@ export class GfActivitiesPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((impersonationId) => {
         this.hasImpersonationId = !!impersonationId;
+
         this.changeDetectorRef.markForCheck();
       });
 
@@ -134,8 +135,6 @@ export class GfActivitiesPageComponent implements OnInit {
     // Reset dataSource and totalItems to show loading state
     this.dataSource = undefined;
     this.totalItems = undefined;
-
-    this.changeDetectorRef.markForCheck();
 
     const dateRange = this.user?.settings?.dateRange;
     const range = this.isCalendarYear(dateRange) ? dateRange : undefined;
@@ -453,7 +452,5 @@ export class GfActivitiesPageComponent implements OnInit {
     this.hasPermissionToDeleteActivity =
       !this.hasImpersonationId &&
       hasPermission(this.user.permissions, permissions.deleteActivity);
-
-    this.changeDetectorRef.markForCheck();
   }
 }

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -16,6 +16,7 @@ import { GfFabComponent } from '@ghostfolio/ui/fab';
 import { DataService } from '@ghostfolio/ui/services';
 
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -44,6 +45,7 @@ import { ImportActivitiesDialogParams } from './import-activities-dialog/interfa
     MatSnackBarModule,
     RouterModule
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'gf-activities-page',
   styleUrls: ['./activities-page.scss'],
   templateUrl: './activities-page.html'
@@ -112,6 +114,7 @@ export class GfActivitiesPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((impersonationId) => {
         this.hasImpersonationId = !!impersonationId;
+        this.changeDetectorRef.markForCheck();
       });
 
     this.userService.stateChanged
@@ -131,6 +134,8 @@ export class GfActivitiesPageComponent implements OnInit {
     // Reset dataSource and totalItems to show loading state
     this.dataSource = undefined;
     this.totalItems = undefined;
+
+    this.changeDetectorRef.markForCheck();
 
     const dateRange = this.user?.settings?.dateRange;
     const range = this.isCalendarYear(dateRange) ? dateRange : undefined;
@@ -448,5 +453,7 @@ export class GfActivitiesPageComponent implements OnInit {
     this.hasPermissionToDeleteActivity =
       !this.hasImpersonationId &&
       hasPermission(this.user.permissions, permissions.deleteActivity);
+
+    this.changeDetectorRef.markForCheck();
   }
 }


### PR DESCRIPTION
**Title**

feat(client): migrate ActivitiesPageComponent to OnPush

**Description**

This PR migrates `GfActivitiesPageComponent` to `ChangeDetectionStrategy.OnPush` to improve change detection performance.

### Changes

* Configured `GfActivitiesPageComponent` to use `ChangeDetectionStrategy.OnPush`.
* Added explicit `ChangeDetectorRef.markForCheck()` calls in asynchronous update paths to ensure the UI refreshes correctly:

  * Impersonation state changes
  * User state and permission updates
  * Initial loading state reset

### Result

The component now benefits from the performance improvements of the OnPush change detection strategy while continuing to update the UI correctly without requiring a page refresh.
