### PR TITLE
Task/set change detection strategy to OnPush in FIRE page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Set the change detection strategy to `OnPush` in the _FIRE_ page
+
 ## 3.21.0 - 2026-07-05
 
 ### Added
@@ -16,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set the change detection strategy to `OnPush` in the alert dialog component
 - Set the change detection strategy to `OnPush` in the confirmation dialog component
-- Set the change detection strategy to `OnPush` in the FIRE page component
 - Set the change detection strategy to `OnPush` in the prompt dialog component
 - Set the change detection strategy to `OnPush` in the overview of the admin control panel
 - Set the change detection strategy to `OnPush` in the portfolio page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set the change detection strategy to `OnPush` in the alert dialog component
 - Set the change detection strategy to `OnPush` in the confirmation dialog component
+- Set the change detection strategy to `OnPush` in the FIRE page component
 - Set the change detection strategy to `OnPush` in the prompt dialog component
 - Set the change detection strategy to `OnPush` in the overview of the admin control panel
 - Set the change detection strategy to `OnPush` in the portfolio page

--- a/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
@@ -91,6 +91,7 @@ export class GfFirePageComponent implements OnInit {
               : 0
           }
         };
+
         if (this.user.subscription?.type === SubscriptionType.Basic) {
           this.fireWealth = {
             today: {
@@ -139,9 +140,9 @@ export class GfFirePageComponent implements OnInit {
           );
 
           this.calculateWithdrawalRates();
-
-          this.changeDetectorRef.markForCheck();
         }
+
+        this.changeDetectorRef.markForCheck();
       });
   }
 

--- a/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/fire/fire-page.component.ts
@@ -14,6 +14,7 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 
 import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -29,6 +30,7 @@ import { DeviceDetectorService } from 'ngx-device-detector';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CommonModule,
     FormsModule,
@@ -107,6 +109,8 @@ export class GfFirePageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((impersonationId) => {
         this.hasImpersonationId = !!impersonationId;
+
+        this.changeDetectorRef.markForCheck();
       });
 
     this.safeWithdrawalRateControl.valueChanges


### PR DESCRIPTION
## Summary

Closes #7231.

Migrates `GfFirePageComponent` to `ChangeDetectionStrategy.OnPush`.

## Changes

- Adds `ChangeDetectionStrategy.OnPush` to the FIRE page component metadata.
- Marks the component for check when the impersonation state subscription updates template state, matching the existing async update pattern used elsewhere in the component.

## Validation

- `npx prettier --check apps/client/src/app/pages/portfolio/fire/fire-page.component.ts`
- `npx nx lint client --quiet`
- `npx tsc --noEmit --project apps/client/tsconfig.app.json`
- `npx nx test client --runInBand`
- `CI=1 NX_DAEMON=false npx nx build client --configuration=development-en --verbose`
