### PR TITLE
Task/set change detection strategy to OnPush in portfolio holdings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the user account deletion flow in the user settings of the user account page
+- Set the change detection strategy to `OnPush` in the holdings component of the home page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
 - Set the change detection strategy to `OnPush` in the users section of the admin control panel
 - Improved the language localization for Dutch (`nl`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the user account deletion flow in the user settings of the user account page
-- Set the change detection strategy to `OnPush` in the holdings component of the home page
+- Set the change detection strategy to `OnPush` in the portfolio holdings page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
 - Set the change detection strategy to `OnPush` in the users section of the admin control panel
 - Improved the language localization for Dutch (`nl`)

--- a/apps/client/src/app/components/home-holdings/home-holdings.component.ts
+++ b/apps/client/src/app/components/home-holdings/home-holdings.component.ts
@@ -15,6 +15,7 @@ import { GfToggleComponent } from '@ghostfolio/ui/toggle';
 import { GfTreemapChartComponent } from '@ghostfolio/ui/treemap-chart';
 
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
@@ -32,6 +33,7 @@ import { gridOutline, reorderFourOutline } from 'ionicons/icons';
 import { DeviceDetectorService } from 'ngx-device-detector';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormsModule,
     GfHoldingsTableComponent,
@@ -88,6 +90,8 @@ export class GfHomeHoldingsComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((impersonationId) => {
         this.hasImpersonationId = !!impersonationId;
+
+        this.changeDetectorRef.markForCheck();
       });
 
     this.userService.stateChanged
@@ -107,9 +111,9 @@ export class GfHomeHoldingsComponent implements OnInit {
           );
 
           this.initialize();
-
-          this.changeDetectorRef.markForCheck();
         }
+
+        this.changeDetectorRef.markForCheck();
       });
 
     this.viewModeFormControl.valueChanges


### PR DESCRIPTION
Closes #7225.

Migrates the home-holdings component to `OnPush` change detection, following the same pattern as the already-merged FIRE page (#7252) and portfolio page (#7241) migrations.

- Adds `changeDetection: ChangeDetectionStrategy.OnPush` to the component.
- Adds `markForCheck()` to the impersonation subscription (which sets a template-bound `hasImpersonationId`) and moves the `stateChanged` `markForCheck()` out of its `if` block, so the view updates correctly under `OnPush` — mirroring the precedent PRs.
- CHANGELOG entry under Unreleased -> Changed.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). The changes were verified locally before submitting (see the test plan above).*