### PR TITLE
Task/improve type safety in portfolio performance component

### DIFF
--- a/apps/client/src/app/components/home-overview/home-overview.html
+++ b/apps/client/src/app/components/home-overview/home-overview.html
@@ -86,7 +86,6 @@
       <div class="col">
         <gf-portfolio-performance
           class="pb-4"
-          [deviceType]="deviceType()"
           [errors]="errors()"
           [isLoading]="isLoadingPerformance()"
           [locale]="user()?.settings?.locale"

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -32,7 +32,7 @@
       {{ unit }}
     </div>
   </div>
-  @if (showDetails) {
+  @if (showDetails()) {
     <div class="row">
       <div class="d-flex col justify-content-end">
         <gf-value

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -1,7 +1,7 @@
 <div class="container p-0">
   <div class="no-gutters row">
     <div class="status-container text-muted text-right">
-      @if (errors()?.length > 0 && !isLoading) {
+      @if (errors()?.length > 0 && !isLoading()) {
         <ion-icon
           i18n-title
           name="time-outline"
@@ -10,7 +10,7 @@
         />
       }
     </div>
-    @if (isLoading) {
+    @if (isLoading()) {
       <div class="align-items-center d-flex">
         <ngx-skeleton-loader
           animation="pulse"
@@ -24,7 +24,7 @@
     }
     <div
       class="display-4 font-weight-bold m-0 text-center value-container"
-      [hidden]="isLoading"
+      [hidden]="isLoading()"
     >
       <span #value id="value"></span>
     </div>
@@ -40,7 +40,7 @@
           [isCurrency]="true"
           [locale]="locale"
           [value]="
-            isLoading
+            isLoading()
               ? undefined
               : performance?.netPerformanceWithCurrencyEffect
           "
@@ -52,7 +52,7 @@
           [isPercent]="true"
           [locale]="locale"
           [value]="
-            isLoading
+            isLoading()
               ? undefined
               : performance?.netPerformancePercentageWithCurrencyEffect
           "

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -38,7 +38,7 @@
         <gf-value
           [colorizeSign]="true"
           [isCurrency]="true"
-          [locale]="locale"
+          [locale]="locale()"
           [value]="
             isLoading()
               ? undefined
@@ -50,7 +50,7 @@
         <gf-value
           [colorizeSign]="true"
           [isPercent]="true"
-          [locale]="locale"
+          [locale]="locale()"
           [value]="
             isLoading()
               ? undefined

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -42,7 +42,7 @@
           [value]="
             isLoading()
               ? undefined
-              : performance?.netPerformanceWithCurrencyEffect
+              : performance().netPerformanceWithCurrencyEffect
           "
         />
       </div>
@@ -54,7 +54,7 @@
           [value]="
             isLoading()
               ? undefined
-              : performance?.netPerformancePercentageWithCurrencyEffect
+              : performance().netPerformancePercentageWithCurrencyEffect
           "
         />
       </div>

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -29,7 +29,7 @@
       <span #value id="value"></span>
     </div>
     <div class="currency-container flex-grow-1 px-1">
-      {{ unit }}
+      {{ unit() }}
     </div>
   </div>
   @if (showDetails()) {

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.html
@@ -1,7 +1,7 @@
 <div class="container p-0">
   <div class="no-gutters row">
     <div class="status-container text-muted text-right">
-      @if (errors?.length > 0 && !isLoading) {
+      @if (errors()?.length > 0 && !isLoading) {
         <ion-icon
           i18n-title
           name="time-outline"

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -35,7 +35,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() isLoading: boolean;
   @Input() locale = getLocale();
   @Input() performance: PortfolioPerformance;
   @Input() precision: number;
@@ -43,6 +42,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   @Input() unit: string;
 
   public readonly errors = input<ResponseError['errors']>();
+  public readonly isLoading = input<boolean>();
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -56,7 +56,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   public ngOnChanges() {
     this.precision = this.precision >= 0 ? this.precision : 2;
 
-    if (this.isLoading) {
+    if (this.isLoading()) {
       if (this.value().nativeElement) {
         this.value().nativeElement.innerHTML = '';
       }

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -81,7 +81,11 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   }
 
   public onShowErrors() {
-    const errorMessageParts = [];
+    if (!this.errors?.length) {
+      return;
+    }
+
+    const errorMessageParts: string[] = [];
 
     for (const error of this.errors) {
       errorMessageParts.push(`${error.symbol} (${error.dataSource})`);

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -38,9 +38,9 @@ export class GfPortfolioPerformanceComponent {
   public readonly isLoading = input<boolean>();
   public readonly locale = input<string>(getLocale());
   public readonly performance = input.required<PortfolioPerformance>();
-  public readonly precision = input<number, number | undefined>(2, {
+  public readonly precision = input.required<number, number>({
     transform: (value) => {
-      return value !== undefined && value >= 0 ? value : 2;
+      return value >= 0 ? value : 2;
     }
   });
   public readonly showDetails = input<boolean>(false);

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -35,7 +35,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() precision: number;
   @Input() showDetails: boolean;
   @Input() unit: string;
 
@@ -43,6 +42,11 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   public readonly isLoading = input<boolean>();
   public readonly locale = input<string>(getLocale());
   public readonly performance = input.required<PortfolioPerformance>();
+  public readonly precision = input<number, number | undefined>(2, {
+    transform: (value) => {
+      return value !== undefined && value >= 0 ? value : 2;
+    }
+  });
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -54,8 +58,6 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   }
 
   public ngOnChanges() {
-    this.precision = this.precision >= 0 ? this.precision : 2;
-
     if (this.isLoading()) {
       if (this.value().nativeElement) {
         this.value().nativeElement.innerHTML = '';
@@ -64,7 +66,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
       if (isNumber(this.performance().currentValueInBaseCurrency)) {
         new CountUp('value', this.performance().currentValueInBaseCurrency, {
           decimal: getNumberFormatDecimal(this.locale()),
-          decimalPlaces: this.precision,
+          decimalPlaces: this.precision(),
           duration: 1,
           separator: getNumberFormatGroup(this.locale())
         }).start();

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -43,7 +43,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   @Input() showDetails: boolean;
   @Input() unit: string;
 
-  @ViewChild('value') value: ElementRef;
+  @ViewChild('value') private value: ElementRef;
 
   private readonly notificationService = inject(NotificationService);
 
@@ -83,7 +83,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
     }
   }
 
-  public onShowErrors() {
+  protected onShowErrors() {
     if (!this.errors?.length) {
       return;
     }

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -35,7 +35,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() performance: PortfolioPerformance;
   @Input() precision: number;
   @Input() showDetails: boolean;
   @Input() unit: string;
@@ -43,6 +42,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   public readonly errors = input<ResponseError['errors']>();
   public readonly isLoading = input<boolean>();
   public readonly locale = input<string>(getLocale());
+  public readonly performance = input.required<PortfolioPerformance>();
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -61,8 +61,8 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
         this.value().nativeElement.innerHTML = '';
       }
     } else {
-      if (isNumber(this.performance?.currentValueInBaseCurrency)) {
-        new CountUp('value', this.performance?.currentValueInBaseCurrency, {
+      if (isNumber(this.performance().currentValueInBaseCurrency)) {
+        new CountUp('value', this.performance().currentValueInBaseCurrency, {
           decimal: getNumberFormatDecimal(this.locale()),
           decimalPlaces: this.precision,
           duration: 1,
@@ -71,7 +71,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
       } else if (this.showDetails === false) {
         new CountUp(
           'value',
-          this.performance?.netPerformancePercentageWithCurrencyEffect * 100,
+          this.performance().netPerformancePercentageWithCurrencyEffect * 100,
           {
             decimal: getNumberFormatDecimal(this.locale()),
             decimalPlaces: 2,

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -34,7 +34,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() deviceType: string;
   @Input() errors: ResponseError['errors'];
   @Input() isLoading: boolean;
   @Input() locale = getLocale();

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -15,6 +15,7 @@ import {
   Component,
   ElementRef,
   inject,
+  input,
   Input,
   OnChanges,
   viewChild
@@ -34,13 +35,14 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() errors: ResponseError['errors'];
   @Input() isLoading: boolean;
   @Input() locale = getLocale();
   @Input() performance: PortfolioPerformance;
   @Input() precision: number;
   @Input() showDetails: boolean;
   @Input() unit: string;
+
+  public readonly errors = input<ResponseError['errors']>();
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -84,13 +86,14 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   }
 
   protected onShowErrors() {
-    if (!this.errors?.length) {
+    const errors = this.errors();
+    if (!errors?.length) {
       return;
     }
 
     const errorMessageParts: string[] = [];
 
-    for (const error of this.errors) {
+    for (const error of errors) {
       errorMessageParts.push(`${error.symbol} (${error.dataSource})`);
     }
 

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -13,8 +13,8 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   effect,
+  ElementRef,
   inject,
   input,
   viewChild
@@ -87,6 +87,7 @@ export class GfPortfolioPerformanceComponent {
 
   protected onShowErrors() {
     const errors = this.errors();
+
     if (!errors?.length) {
       return;
     }

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -35,7 +35,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() locale = getLocale();
   @Input() performance: PortfolioPerformance;
   @Input() precision: number;
   @Input() showDetails: boolean;
@@ -43,6 +42,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
 
   public readonly errors = input<ResponseError['errors']>();
   public readonly isLoading = input<boolean>();
+  public readonly locale = input<string>(getLocale());
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -63,20 +63,20 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
     } else {
       if (isNumber(this.performance?.currentValueInBaseCurrency)) {
         new CountUp('value', this.performance?.currentValueInBaseCurrency, {
-          decimal: getNumberFormatDecimal(this.locale),
+          decimal: getNumberFormatDecimal(this.locale()),
           decimalPlaces: this.precision,
           duration: 1,
-          separator: getNumberFormatGroup(this.locale)
+          separator: getNumberFormatGroup(this.locale())
         }).start();
       } else if (this.showDetails === false) {
         new CountUp(
           'value',
           this.performance?.netPerformancePercentageWithCurrencyEffect * 100,
           {
-            decimal: getNumberFormatDecimal(this.locale),
+            decimal: getNumberFormatDecimal(this.locale()),
             decimalPlaces: 2,
             duration: 1,
-            separator: getNumberFormatGroup(this.locale)
+            separator: getNumberFormatGroup(this.locale())
           }
         ).start();
       } else {

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -14,10 +14,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  effect,
   inject,
   input,
-  Input,
-  OnChanges,
   viewChild
 } from '@angular/core';
 import { IonIcon } from '@ionic/angular/standalone';
@@ -34,9 +33,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   styleUrls: ['./portfolio-performance.component.scss'],
   templateUrl: './portfolio-performance.component.html'
 })
-export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() unit: string;
-
+export class GfPortfolioPerformanceComponent {
   public readonly errors = input<ResponseError['errors']>();
   public readonly isLoading = input<boolean>();
   public readonly locale = input<string>(getLocale());
@@ -47,6 +44,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
     }
   });
   public readonly showDetails = input<boolean>(false);
+  public readonly unit = input.required<string>();
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -55,36 +53,36 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
 
   public constructor() {
     addIcons({ timeOutline });
-  }
 
-  public ngOnChanges() {
-    if (this.isLoading()) {
-      if (this.value().nativeElement) {
-        this.value().nativeElement.innerHTML = '';
-      }
-    } else {
-      if (isNumber(this.performance().currentValueInBaseCurrency)) {
-        new CountUp('value', this.performance().currentValueInBaseCurrency, {
-          decimal: getNumberFormatDecimal(this.locale()),
-          decimalPlaces: this.precision(),
-          duration: 1,
-          separator: getNumberFormatGroup(this.locale())
-        }).start();
-      } else if (this.showDetails() === false) {
-        new CountUp(
-          'value',
-          this.performance().netPerformancePercentageWithCurrencyEffect * 100,
-          {
+    effect(() => {
+      if (this.isLoading()) {
+        if (this.value().nativeElement) {
+          this.value().nativeElement.innerHTML = '';
+        }
+      } else {
+        if (isNumber(this.performance().currentValueInBaseCurrency)) {
+          new CountUp('value', this.performance().currentValueInBaseCurrency, {
             decimal: getNumberFormatDecimal(this.locale()),
-            decimalPlaces: 2,
+            decimalPlaces: this.precision(),
             duration: 1,
             separator: getNumberFormatGroup(this.locale())
-          }
-        ).start();
-      } else {
-        this.value().nativeElement.innerHTML = '*****';
+          }).start();
+        } else if (this.showDetails() === false) {
+          new CountUp(
+            'value',
+            this.performance().netPerformancePercentageWithCurrencyEffect * 100,
+            {
+              decimal: getNumberFormatDecimal(this.locale()),
+              decimalPlaces: 2,
+              duration: 1,
+              separator: getNumberFormatGroup(this.locale())
+            }
+          ).start();
+        } else {
+          this.value().nativeElement.innerHTML = '*****';
+        }
       }
-    }
+    });
   }
 
   protected onShowErrors() {

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -14,6 +14,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  inject,
   Input,
   OnChanges,
   ViewChild
@@ -44,7 +45,9 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
 
   @ViewChild('value') value: ElementRef;
 
-  public constructor(private notificationService: NotificationService) {
+  private readonly notificationService = inject(NotificationService);
+
+  public constructor() {
     addIcons({ timeOutline });
   }
 

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -35,7 +35,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   templateUrl: './portfolio-performance.component.html'
 })
 export class GfPortfolioPerformanceComponent implements OnChanges {
-  @Input() showDetails: boolean;
   @Input() unit: string;
 
   public readonly errors = input<ResponseError['errors']>();
@@ -47,6 +46,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
       return value !== undefined && value >= 0 ? value : 2;
     }
   });
+  public readonly showDetails = input<boolean>(false);
 
   private readonly value =
     viewChild.required<ElementRef<HTMLSpanElement>>('value');
@@ -70,7 +70,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
           duration: 1,
           separator: getNumberFormatGroup(this.locale())
         }).start();
-      } else if (this.showDetails === false) {
+      } else if (this.showDetails() === false) {
         new CountUp(
           'value',
           this.performance().netPerformancePercentageWithCurrencyEffect * 100,

--- a/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
+++ b/apps/client/src/app/components/portfolio-performance/portfolio-performance.component.ts
@@ -17,7 +17,7 @@ import {
   inject,
   Input,
   OnChanges,
-  ViewChild
+  viewChild
 } from '@angular/core';
 import { IonIcon } from '@ionic/angular/standalone';
 import { CountUp } from 'countup.js';
@@ -43,7 +43,8 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
   @Input() showDetails: boolean;
   @Input() unit: string;
 
-  @ViewChild('value') private value: ElementRef;
+  private readonly value =
+    viewChild.required<ElementRef<HTMLSpanElement>>('value');
 
   private readonly notificationService = inject(NotificationService);
 
@@ -55,8 +56,8 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
     this.precision = this.precision >= 0 ? this.precision : 2;
 
     if (this.isLoading) {
-      if (this.value?.nativeElement) {
-        this.value.nativeElement.innerHTML = '';
+      if (this.value().nativeElement) {
+        this.value().nativeElement.innerHTML = '';
       }
     } else {
       if (isNumber(this.performance?.currentValueInBaseCurrency)) {
@@ -78,7 +79,7 @@ export class GfPortfolioPerformanceComponent implements OnChanges {
           }
         ).start();
       } else {
-        this.value.nativeElement.innerHTML = '*****';
+        this.value().nativeElement.innerHTML = '*****';
       }
     }
   }


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- Resolved type safety compilation errors in `GfPortfolioPerformanceComponent`.
- Migrated inputs to modern Signal inputs (`input` and `input.required`).
- Migrated `@ViewChild` to the modern `viewChild.required` Signal API with strict type generic `HTMLSpanElement`.
- Enforced encapsulation (made `value` private, `onShowErrors` protected).
- Replaced constructor-based dependency injection with `inject` function for `NotificationService`.
- Cleaned up dead code (removed unused `deviceType` input and its parent binding).

## Resolved type errors

2 errors (before: 22, after: 20)