### PR TITLE
fix: resolve exchange rate initialization errors

### DIFF
--- a/apps/api/src/app/app.controller.ts
+++ b/apps/api/src/app/app.controller.ts
@@ -1,9 +1,11 @@
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 
-import { Controller } from '@nestjs/common';
+import { Controller, Logger } from '@nestjs/common';
 
 @Controller()
 export class AppController {
+  private readonly logger = new Logger(AppController.name);
+
   public constructor(
     private readonly exchangeRateDataService: ExchangeRateDataService
   ) {
@@ -13,6 +15,8 @@ export class AppController {
   private async initialize() {
     try {
       await this.exchangeRateDataService.initialize();
-    } catch {}
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 }

--- a/apps/api/src/services/data-provider/manual/manual.service.ts
+++ b/apps/api/src/services/data-provider/manual/manual.service.ts
@@ -161,7 +161,8 @@ export class ManualService implements DataProviderInterface {
         where: {
           symbol: {
             in: symbols
-          }
+          },
+          dataSource: this.getName()
         }
       });
 

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -203,7 +203,7 @@ export class ExchangeRateDataService {
       }
     }
 
-    const resultExtended = result;
+    const resultExtended = { ...result };
 
     for (const symbol of Object.keys(result)) {
       const [currency1, currency2] = symbol.match(/.{1,3}/g);


### PR DESCRIPTION
## Summary

Three small fixes that resolve exchange rate errors when using MANUAL data source, particularly for multi-currency portfolios with non-standard currency pairs.

## Changes

### 1. Log error in AppController.initialize() catch block

The empty catch {} silently swallows all errors from exchangeRateDataService.initialize(), making exchange rate failures invisible in production logs.

### 2. Use spread copy in loadCurrencies()

const resultExtended = result creates a reference to the same object, not a copy. The subsequent loop that adds reverse-rate entries mutates the original result object, which can cause incorrect or partial exchange rate data.

### 3. Add dataSource filter to ManualService.getQuotes() MarketData query

The DISTINCT ON (symbol) query without a dataSource filter can return the wrong row for symbols with entries from multiple data providers.

## Testing

- Verified with DATA_SOURCE_EXCHANGE_RATES=MANUAL and DATA_SOURCES=["MANUAL"]
- Portfolio with JMD, CAD, USD currencies and 6+ holdings
- Exchange rate data from MarketData table with MANUAL data source in production