### PR TITLE
Task/set change detection strategy to OnPush in allocations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the user account deletion flow in the user settings of the user account page
+- Set the change detection strategy to `OnPush` in the allocations page
 - Set the change detection strategy to `OnPush` in the portfolio holdings page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
 - Set the change detection strategy to `OnPush` in the users section of the admin control panel

--- a/apps/client/src/app/pages/portfolio/allocations/allocations-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/allocations/allocations-page.component.ts
@@ -22,6 +22,7 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 import { GfWorldMapChartComponent } from '@ghostfolio/ui/world-map-chart';
 
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -48,6 +49,7 @@ import { filter, switchMap, tap } from 'rxjs';
 import { AllocationsPageParams } from './interfaces/interfaces';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     GfPortfolioProportionChartComponent,
     GfPremiumIndicatorComponent,
@@ -161,6 +163,8 @@ export class GfAllocationsPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((impersonationId) => {
         this.hasImpersonationId = !!impersonationId;
+
+        this.changeDetectorRef.markForCheck();
       });
 
     this.userService.stateChanged


### PR DESCRIPTION
Closes #7229.

Migrates the allocations page component to `OnPush` change detection, following the same pattern as the already-merged portfolio holdings (#7264), FIRE (#7252) and portfolio page (#7241) migrations.

- Adds `changeDetection: ChangeDetectionStrategy.OnPush` to the component.
- Adds `markForCheck()` to the impersonation subscription (which sets the template-bound `hasImpersonationId`); the `stateChanged` subscription already calls `markForCheck()`.
- CHANGELOG entry under Unreleased -> Changed.

Verified locally: `nx lint client` passes and the production build succeeds.
