### PR TITLE
Task/set change detection strategy to OnPush in analysis page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the user account deletion flow in the user settings of the user account page
+- Set the change detection strategy to `OnPush` in the analysis page
 - Set the change detection strategy to `OnPush` in the portfolio holdings page
 - Set the change detection strategy to `OnPush` in the _FIRE_ page
 - Set the change detection strategy to `OnPush` in the users section of the admin control panel

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -25,6 +25,7 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 
 import { Clipboard } from '@angular/cdk/clipboard';
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -51,6 +52,7 @@ import { DeviceDetectorService } from 'ngx-device-detector';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     GfBenchmarkComparatorComponent,
     GfInvestmentChartComponent,
@@ -148,6 +150,8 @@ export class GfAnalysisPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((impersonationId) => {
         this.hasImpersonationId = !!impersonationId;
+
+        this.changeDetectorRef.markForCheck();
       });
 
     this.userService.stateChanged
@@ -229,6 +233,8 @@ export class GfAnalysisPageComponent implements OnInit {
         } else if (mode === 'portfolio') {
           this.isLoadingPortfolioPrompt = false;
         }
+
+        this.changeDetectorRef.markForCheck();
       });
   }
 

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -390,6 +390,7 @@ export class GfAnalysisPageComponent implements OnInit {
       });
 
     this.fetchDividendsAndInvestments();
+
     this.changeDetectorRef.markForCheck();
   }
 

--- a/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/analysis/analysis-page.component.ts
@@ -171,6 +171,8 @@ export class GfAnalysisPageComponent implements OnInit {
 
           this.update();
         }
+
+        this.changeDetectorRef.markForCheck();
       });
   }
 


### PR DESCRIPTION
Closes #7230.

Migrates the analysis page component to `OnPush` change detection, following the same pattern as the already-merged portfolio holdings (#7264), FIRE (#7252) and portfolio page (#7241) migrations.

- Adds `changeDetection: ChangeDetectionStrategy.OnPush` to the component.
- Adds `markForCheck()` to the impersonation subscription (template-bound `hasImpersonationId`) and to the AI prompt copy subscription (which resets the template-bound `isLoadingAnalysisPrompt` / `isLoadingPortfolioPrompt` spinners); the other subscriptions already call `markForCheck()`.
- CHANGELOG entry under Unreleased -> Changed.

Verified locally: `nx lint client` passes and the production build succeeds.
