### PR TITLE
Task/improve type safety in portfolio summary component

### DIFF
--- a/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
+++ b/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
@@ -9,6 +9,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
+  inject,
   Input,
   OnChanges,
   Output
@@ -49,6 +50,12 @@ export class GfPortfolioSummaryComponent implements OnChanges {
   protected precision = 2;
   protected timeInMarket: string | undefined;
 
+  private readonly notificationService = inject(NotificationService);
+
+  public constructor() {
+    addIcons({ ellipsisHorizontalCircleOutline, informationCircleOutline });
+  }
+
   protected get buyingPowerPercentage() {
     return this.summary?.totalValueInBaseCurrency
       ? this.summary.cash / this.summary.totalValueInBaseCurrency
@@ -67,10 +74,6 @@ export class GfPortfolioSummaryComponent implements OnChanges {
       ? this.summary.excludedAccountsAndActivities /
           this.summary.totalValueInBaseCurrency
       : 0;
-  }
-
-  public constructor(private notificationService: NotificationService) {
-    addIcons({ ellipsisHorizontalCircleOutline, informationCircleOutline });
   }
 
   public ngOnChanges() {

--- a/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
+++ b/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
@@ -42,27 +42,27 @@ export class GfPortfolioSummaryComponent implements OnChanges {
 
   @Output() emergencyFundChanged = new EventEmitter<number>();
 
-  public buyAndSellActivitiesTooltip = translate(
+  protected readonly buyAndSellActivitiesTooltip = translate(
     'BUY_AND_SELL_ACTIVITIES_TOOLTIP'
   );
 
-  public precision = 2;
-  public timeInMarket: string | undefined;
+  protected precision = 2;
+  protected timeInMarket: string | undefined;
 
-  public get buyingPowerPercentage() {
+  protected get buyingPowerPercentage() {
     return this.summary?.totalValueInBaseCurrency
       ? this.summary.cash / this.summary.totalValueInBaseCurrency
       : 0;
   }
 
-  public get emergencyFundPercentage() {
+  protected get emergencyFundPercentage() {
     return this.summary?.totalValueInBaseCurrency
       ? (this.summary.emergencyFund?.total || 0) /
           this.summary.totalValueInBaseCurrency
       : 0;
   }
 
-  public get excludedFromAnalysisPercentage() {
+  protected get excludedFromAnalysisPercentage() {
     return this.summary?.totalValueInBaseCurrency
       ? this.summary.excludedAccountsAndActivities /
           this.summary.totalValueInBaseCurrency
@@ -98,7 +98,7 @@ export class GfPortfolioSummaryComponent implements OnChanges {
     }
   }
 
-  public onEditEmergencyFund() {
+  protected onEditEmergencyFund() {
     this.notificationService.prompt({
       confirmFn: (value) => {
         const emergencyFund = parseFloat(value.trim()) || 0;

--- a/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
+++ b/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
@@ -8,11 +8,10 @@ import { GfValueComponent } from '@ghostfolio/ui/value';
 import {
   ChangeDetectionStrategy,
   Component,
-  EventEmitter,
   inject,
   Input,
   OnChanges,
-  Output
+  output
 } from '@angular/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { IonIcon } from '@ionic/angular/standalone';
@@ -41,7 +40,7 @@ export class GfPortfolioSummaryComponent implements OnChanges {
   @Input() summary: PortfolioSummary;
   @Input() user: User;
 
-  @Output() emergencyFundChanged = new EventEmitter<number>();
+  public emergencyFundChanged = output<number>();
 
   protected readonly buyAndSellActivitiesTooltip = translate(
     'BUY_AND_SELL_ACTIVITIES_TOOLTIP'

--- a/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
+++ b/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.ts
@@ -47,7 +47,7 @@ export class GfPortfolioSummaryComponent implements OnChanges {
   );
 
   public precision = 2;
-  public timeInMarket: string;
+  public timeInMarket: string | undefined;
 
   public get buyingPowerPercentage() {
     return this.summary?.totalValueInBaseCurrency
@@ -77,7 +77,7 @@ export class GfPortfolioSummaryComponent implements OnChanges {
     if (this.summary) {
       if (
         this.deviceType === 'mobile' &&
-        this.summary.totalValueInBaseCurrency >=
+        (this.summary.totalValueInBaseCurrency ?? 0) >=
           NUMERICAL_PRECISION_THRESHOLD_6_FIGURES
       ) {
         this.precision = 0;


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- Resolved type safety compilation errors in `GfPortfolioSummaryComponent`.
- Enforced encapsulation (made internal properties `buyAndSellActivitiesTooltip`, `precision`, and `timeInMarket` `protected`; made component getters `buyingPowerPercentage`, `emergencyFundPercentage`, and `excludedFromAnalysisPercentage` `protected`; made method `onEditEmergencyFund` `protected`).
- Enforced immutability (made `buyAndSellActivitiesTooltip` `readonly`).
- Replaced constructor-based dependency injection with the `inject` function for `NotificationService`.
- Migrated outputs to the modern Signals Output API (`output`).
- Cleaned up unused `EventEmitter` and `Output` imports from `@angular/core`.

## Resolved type errors

2 errors (before: 17, after: 15)
