### PR TITLE
Bugfix/incorrect error flag in portfolio details for undefined optional holding values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set the change detection strategy to `OnPush` in the _Zen Mode_
 - Improved the language localization for Chinese (`zh`)
 
+### Fixed
+
+- Fixed an issue in the portfolio details endpoint that incorrectly reported an error when a holding contained undefined optional values
+
 ## 3.22.0 - 2026-07-08
 
 ### Added

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -2,10 +2,7 @@ import { ActivitiesService } from '@ghostfolio/api/app/activities/activities.ser
 import { UserService } from '@ghostfolio/api/app/user/user.service';
 import { HasPermission } from '@ghostfolio/api/decorators/has-permission.decorator';
 import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard';
-import {
-  hasNotDefinedValuesInObject,
-  nullifyValuesInObject
-} from '@ghostfolio/api/helper/object.helper';
+import { nullifyValuesInObject } from '@ghostfolio/api/helper/object.helper';
 import { PerformanceLoggingInterceptor } from '@ghostfolio/api/interceptors/performance-logging/performance-logging.interceptor';
 import { RedactValuesInResponseInterceptor } from '@ghostfolio/api/interceptors/redact-values-in-response/redact-values-in-response.interceptor';
 import { TransformDataSourceInRequestInterceptor } from '@ghostfolio/api/interceptors/transform-data-source-in-request/transform-data-source-in-request.interceptor';
@@ -126,7 +123,7 @@ export class PortfolioController {
       withSummary: true
     });
 
-    if (hasErrors || hasNotDefinedValuesInObject(holdings)) {
+    if (hasErrors) {
       hasError = true;
     }
 

--- a/apps/api/src/helper/object.helper.ts
+++ b/apps/api/src/helper/object.helper.ts
@@ -1,18 +1,6 @@
 import fastRedact from 'fast-redact';
 import jsonpath from 'jsonpath';
-import { cloneDeep, isObject } from 'lodash';
-
-export function hasNotDefinedValuesInObject(aObject: Object): boolean {
-  for (const key in aObject) {
-    if (aObject[key] === null || aObject[key] === undefined) {
-      return true;
-    } else if (isObject(aObject[key])) {
-      return hasNotDefinedValuesInObject(aObject[key]);
-    }
-  }
-
-  return false;
-}
+import { cloneDeep } from 'lodash';
 
 export function nullifyValuesInObject<T>(aObject: T, keys: string[]): T {
   const object = cloneDeep(aObject);


### PR DESCRIPTION
## Problem

`GET /api/v1/portfolio/details` can return `hasError: true` even when the portfolio calculation succeeds. This happens for perfectly valid portfolios, for example any holding that has an optional field left undefined (`assetClassLabel`, `assetSubClassLabel`) or a `null` value such as `assetProfile.url`.

## Root cause

The controller derived `hasError` from two sources:

```ts
if (hasErrors || hasNotDefinedValuesInObject(holdings)) {
  hasError = true;
}
```

`hasErrors` is the authoritative flag returned by the portfolio calculator (`getSnapshot()`). It already accumulates every per-symbol calculation error and is what nullifies the performance fields when a symbol fails.

`hasNotDefinedValuesInObject(holdings)` is a recursive scan that flags any `null` or `undefined` value anywhere in the holdings tree. Since `PortfolioPosition` has many legitimately optional fields (`assetClassLabel`, `assetSubClassLabel`, `url`, `exchange`, `tags[].userId`, `valueInBaseCurrency`, `markets`, ...), a valid holding gets marked as an error. The scan is therefore redundant with `hasErrors` and only adds false positives.

## Fix

Rely solely on the authoritative `hasErrors` flag and remove the redundant scan. The helper `hasNotDefinedValuesInObject` had this single call site, so it is removed as well.

## Verification

- Reproduced the false positive with the reported holding shape before the change.
- `nx lint api` passes.
- `object.helper.spec` passes.

Closes #6974
