### PR TITLE
Task/improve type safety in user account registration dialog component

### DIFF
--- a/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
+++ b/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
@@ -9,7 +9,7 @@ import {
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
-  Inject,
+  inject,
   ViewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -63,12 +63,14 @@ export class GfUserAccountRegistrationDialogComponent {
   protected readonly routerLinkAboutTermsOfService =
     publicRoutes.about.subRoutes.termsOfService.routerLink;
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    @Inject(MAT_DIALOG_DATA) protected data: UserAccountRegistrationDialogParams,
-    private dataService: DataService,
-    private destroyRef: DestroyRef
-  ) {
+  protected readonly data =
+    inject<UserAccountRegistrationDialogParams>(MAT_DIALOG_DATA);
+
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  public constructor() {
     addIcons({ arrowForwardOutline, checkmarkOutline, copyOutline });
   }
 

--- a/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
+++ b/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
@@ -55,7 +55,7 @@ import { UserAccountRegistrationDialogParams } from './interfaces/interfaces';
 export class GfUserAccountRegistrationDialogComponent {
   @ViewChild(MatStepper) stepper!: MatStepper;
 
-  public accessToken: string;
+  public accessToken: string | undefined;
   public authToken: string;
   public isCreateAccountButtonDisabled = true;
   public isDisclaimerChecked = false;

--- a/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
+++ b/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
@@ -53,26 +53,26 @@ import { UserAccountRegistrationDialogParams } from './interfaces/interfaces';
   templateUrl: 'user-account-registration-dialog.html'
 })
 export class GfUserAccountRegistrationDialogComponent {
-  @ViewChild(MatStepper) stepper!: MatStepper;
+  @ViewChild(MatStepper) protected stepper!: MatStepper;
 
-  public accessToken: string | undefined;
-  public authToken: string;
-  public isCreateAccountButtonDisabled = true;
-  public isDisclaimerChecked = false;
-  public role: string;
-  public routerLinkAboutTermsOfService =
+  protected accessToken: string | undefined;
+  protected authToken: string;
+  protected isCreateAccountButtonDisabled = true;
+  protected isDisclaimerChecked = false;
+  protected role: string;
+  protected readonly routerLinkAboutTermsOfService =
     publicRoutes.about.subRoutes.termsOfService.routerLink;
 
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    @Inject(MAT_DIALOG_DATA) public data: UserAccountRegistrationDialogParams,
+    @Inject(MAT_DIALOG_DATA) protected data: UserAccountRegistrationDialogParams,
     private dataService: DataService,
     private destroyRef: DestroyRef
   ) {
     addIcons({ arrowForwardOutline, checkmarkOutline, copyOutline });
   }
 
-  public createAccount() {
+  protected createAccount() {
     this.dataService
       .postUser()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -87,11 +87,11 @@ export class GfUserAccountRegistrationDialogComponent {
       });
   }
 
-  public enableCreateAccountButton() {
+  protected enableCreateAccountButton() {
     this.isCreateAccountButtonDisabled = false;
   }
 
-  public onChangeDislaimerChecked() {
+  protected onChangeDislaimerChecked() {
     this.isDisclaimerChecked = !this.isDisclaimerChecked;
   }
 }

--- a/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
+++ b/apps/client/src/app/pages/register/user-account-registration-dialog/user-account-registration-dialog.component.ts
@@ -10,7 +10,7 @@ import {
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
   inject,
-  ViewChild
+  viewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -53,7 +53,7 @@ import { UserAccountRegistrationDialogParams } from './interfaces/interfaces';
   templateUrl: 'user-account-registration-dialog.html'
 })
 export class GfUserAccountRegistrationDialogComponent {
-  @ViewChild(MatStepper) protected stepper!: MatStepper;
+  protected readonly stepper = viewChild.required(MatStepper);
 
   protected accessToken: string | undefined;
   protected authToken: string;
@@ -83,7 +83,7 @@ export class GfUserAccountRegistrationDialogComponent {
         this.authToken = authToken;
         this.role = role;
 
-        this.stepper.next();
+        this.stepper().next();
 
         this.changeDetectorRef.markForCheck();
       });


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

- Resolved type safety compilation errors in `GfUserAccountRegistrationDialogComponent`.
- Enforced encapsulation (made component properties `accessToken`, `authToken`, `isCreateAccountButtonDisabled`, `isDisclaimerChecked`, `role`, `routerLinkAboutTermsOfService`, and `data` `protected`; made `stepper` ViewChild `protected`; made component methods `createAccount`, `enableCreateAccountButton`, and `onChangeDislaimerChecked` `protected`).
- Enforced immutability (added `readonly` modifier to `routerLinkAboutTermsOfService`).
- Replaced constructor-based dependency injection with the `inject` function for `ChangeDetectorRef`, `MAT_DIALOG_DATA`, `DataService`, and `DestroyRef`.
- Migrated `@ViewChild` stepper to the modern Signal-based `viewChild.required` API.
- Cleaned up unused `Inject` and `ViewChild` imports from `@angular/core`.

## Resolved type errors

1 error (before: 15, after: 14)
