### PR TITLE
Task/improve type safety in multiple client components

### DIFF
--- a/apps/client/src/app/components/home-holdings/home-holdings.component.ts
+++ b/apps/client/src/app/components/home-holdings/home-holdings.component.ts
@@ -75,7 +75,9 @@ export class GfHomeHoldingsComponent implements OnInit {
   private readonly dataService = inject(DataService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly deviceDetectorService = inject(DeviceDetectorService);
-  private readonly impersonationStorageService = inject(ImpersonationStorageService);
+  private readonly impersonationStorageService = inject(
+    ImpersonationStorageService
+  );
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
 

--- a/apps/client/src/app/components/home-holdings/home-holdings.component.ts
+++ b/apps/client/src/app/components/home-holdings/home-holdings.component.ts
@@ -20,6 +20,7 @@ import {
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
+  inject,
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -53,32 +54,32 @@ import { DeviceDetectorService } from 'ngx-device-detector';
 export class GfHomeHoldingsComponent implements OnInit {
   public static DEFAULT_HOLDINGS_VIEW_MODE: HoldingsViewMode = 'TABLE';
 
-  public deviceType: string;
-  public hasImpersonationId: boolean;
-  public hasPermissionToAccessHoldingsChart: boolean;
-  public hasPermissionToCreateActivity: boolean;
-  public holdings: PortfolioPosition[];
-  public holdingType: HoldingType = 'ACTIVE';
-  public holdingTypeOptions: ToggleOption[] = [
+  protected deviceType: string;
+  protected hasImpersonationId: boolean;
+  protected hasPermissionToAccessHoldingsChart: boolean;
+  protected hasPermissionToCreateActivity: boolean;
+  protected holdings: PortfolioPosition[];
+  protected holdingType: HoldingType = 'ACTIVE';
+  protected readonly holdingTypeOptions: ToggleOption[] = [
     { label: $localize`Active`, value: 'ACTIVE' },
     { label: $localize`Closed`, value: 'CLOSED' }
   ];
-  public routerLinkPortfolioActivities =
+  protected readonly routerLinkPortfolioActivities =
     internalRoutes.portfolio.subRoutes.activities.routerLink;
-  public user: User;
-  public viewModeFormControl = new FormControl<HoldingsViewMode>(
+  protected user: User;
+  protected readonly viewModeFormControl = new FormControl<HoldingsViewMode>(
     GfHomeHoldingsComponent.DEFAULT_HOLDINGS_VIEW_MODE
   );
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private deviceDetectorService: DeviceDetectorService,
-    private impersonationStorageService: ImpersonationStorageService,
-    private router: Router,
-    private userService: UserService
-  ) {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly impersonationStorageService = inject(ImpersonationStorageService);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
     addIcons({ gridOutline, reorderFourOutline });
   }
 
@@ -139,13 +140,13 @@ export class GfHomeHoldingsComponent implements OnInit {
       });
   }
 
-  public onChangeHoldingType(aHoldingType: HoldingType) {
+  protected onChangeHoldingType(aHoldingType: HoldingType) {
     this.holdingType = aHoldingType;
 
     this.initialize();
   }
 
-  public onHoldingClicked({ dataSource, symbol }: AssetProfileIdentifier) {
+  protected onHoldingClicked({ dataSource, symbol }: AssetProfileIdentifier) {
     if (dataSource && symbol) {
       this.router.navigate([], {
         queryParams: { dataSource, symbol, holdingDetailDialog: true }

--- a/apps/client/src/app/components/home-holdings/home-holdings.component.ts
+++ b/apps/client/src/app/components/home-holdings/home-holdings.component.ts
@@ -119,6 +119,10 @@ export class GfHomeHoldingsComponent implements OnInit {
     this.viewModeFormControl.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((holdingsViewMode) => {
+        if (!holdingsViewMode) {
+          return;
+        }
+
         this.dataService
           .putUserSetting({ holdingsViewMode })
           .pipe(takeUntilDestroyed(this.destroyRef))
@@ -185,7 +189,7 @@ export class GfHomeHoldingsComponent implements OnInit {
       );
     }
 
-    this.holdings = undefined;
+    this.holdings = [];
 
     this.fetchHoldings()
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
+++ b/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
@@ -71,19 +71,19 @@ import { catchError } from 'rxjs/operators';
   templateUrl: './user-account-settings.html'
 })
 export class GfUserAccountSettingsComponent implements OnInit {
-  protected appearancePlaceholder = $localize`Auto`;
-  protected baseCurrency: string;
+  protected readonly appearancePlaceholder = $localize`Auto`;
+  protected readonly baseCurrency: string;
   protected closeUserAccountMail: string;
-  protected currencies: string[] = [];
-  protected deleteOwnUserForm: FormGroup;
+  protected readonly currencies: string[] = [];
+  protected readonly deleteOwnUserForm: FormGroup;
   protected hasPermissionToDeleteOwnUser: boolean;
   protected hasPermissionToRequestOwnUserDeletion: boolean;
   protected hasPermissionToUpdateViewMode: boolean;
   protected hasPermissionToUpdateUserSettings: boolean;
   protected isAccessTokenHidden = true;
-  protected isFingerprintSupported = this.doesBrowserSupportAuthn();
+  protected readonly isFingerprintSupported = this.doesBrowserSupportAuthn();
   protected isWebAuthnEnabled: boolean;
-  protected language = document.documentElement.lang;
+  protected readonly language = document.documentElement.lang;
   protected locales = [
     'ca',
     'de',
@@ -104,15 +104,15 @@ export class GfUserAccountSettingsComponent implements OnInit {
   ];
   protected user: User;
 
-  private changeDetectorRef = inject(ChangeDetectorRef);
-  private dataService = inject(DataService);
-  private destroyRef = inject(DestroyRef);
-  private formBuilder = inject(FormBuilder);
-  private notificationService = inject(NotificationService);
-  private settingsStorageService = inject(SettingsStorageService);
-  private snackBar = inject(MatSnackBar);
-  private userService = inject(UserService);
-  private webAuthnService = inject(WebAuthnService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly notificationService = inject(NotificationService);
+  private readonly settingsStorageService = inject(SettingsStorageService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly userService = inject(UserService);
+  private readonly webAuthnService = inject(WebAuthnService);
 
   public constructor() {
     this.deleteOwnUserForm = this.formBuilder.group({

--- a/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
+++ b/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
@@ -151,6 +151,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
           if (this.user.settings.locale) {
             this.locales.push(this.user.settings.locale);
           }
+
           this.locales = Array.from(new Set(this.locales)).sort();
 
           this.changeDetectorRef.markForCheck();

--- a/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
+++ b/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
@@ -69,22 +69,22 @@ import { catchError } from 'rxjs/operators';
   templateUrl: './user-account-settings.html'
 })
 export class GfUserAccountSettingsComponent implements OnInit {
-  public appearancePlaceholder = $localize`Auto`;
-  public baseCurrency: string;
-  public closeUserAccountMail: string;
-  public currencies: string[] = [];
-  public deleteOwnUserForm = this.formBuilder.group({
+  protected appearancePlaceholder = $localize`Auto`;
+  protected baseCurrency: string;
+  protected closeUserAccountMail: string;
+  protected currencies: string[] = [];
+  protected deleteOwnUserForm = this.formBuilder.group({
     accessToken: ['', Validators.required]
   });
-  public hasPermissionToDeleteOwnUser: boolean;
-  public hasPermissionToRequestOwnUserDeletion: boolean;
-  public hasPermissionToUpdateViewMode: boolean;
-  public hasPermissionToUpdateUserSettings: boolean;
-  public isAccessTokenHidden = true;
-  public isFingerprintSupported = this.doesBrowserSupportAuthn();
-  public isWebAuthnEnabled: boolean;
-  public language = document.documentElement.lang;
-  public locales = [
+  protected hasPermissionToDeleteOwnUser: boolean;
+  protected hasPermissionToRequestOwnUserDeletion: boolean;
+  protected hasPermissionToUpdateViewMode: boolean;
+  protected hasPermissionToUpdateUserSettings: boolean;
+  protected isAccessTokenHidden = true;
+  protected isFingerprintSupported = this.doesBrowserSupportAuthn();
+  protected isWebAuthnEnabled: boolean;
+  protected language = document.documentElement.lang;
+  protected locales = [
     'ca',
     'de',
     'de-CH',
@@ -102,7 +102,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
     'uk',
     'zh'
   ];
-  public user: User;
+  protected user: User;
 
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
@@ -113,7 +113,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
     private settingsStorageService: SettingsStorageService,
     private snackBar: MatSnackBar,
     private userService: UserService,
-    public webAuthnService: WebAuthnService
+    private webAuthnService: WebAuthnService
   ) {
     const { baseCurrency, currencies } = this.dataService.fetchInfo();
 
@@ -164,11 +164,11 @@ export class GfUserAccountSettingsComponent implements OnInit {
     this.update();
   }
 
-  public isCommunityLanguage() {
+  protected isCommunityLanguage() {
     return !['de', 'en'].includes(this.language);
   }
 
-  public onChangeUserSetting(aKey: string, aValue: string) {
+  protected onChangeUserSetting(aKey: string, aValue: string) {
     this.dataService
       .putUserSetting({ [aKey]: aValue })
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -192,7 +192,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       });
   }
 
-  public onCloseAccount() {
+  protected onCloseAccount() {
     this.notificationService.confirm({
       confirmFn: () => {
         this.dataService
@@ -220,7 +220,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
     });
   }
 
-  public onExperimentalFeaturesChange(aEvent: MatSlideToggleChange) {
+  protected onExperimentalFeaturesChange(aEvent: MatSlideToggleChange) {
     this.dataService
       .putUserSetting({ isExperimentalFeatures: aEvent.checked })
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -236,7 +236,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       });
   }
 
-  public onExport() {
+  protected onExport() {
     this.dataService
       .fetchExport()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -256,7 +256,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       });
   }
 
-  public onRestrictedViewChange(aEvent: MatSlideToggleChange) {
+  protected onRestrictedViewChange(aEvent: MatSlideToggleChange) {
     this.dataService
       .putUserSetting({ isRestrictedView: aEvent.checked })
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -272,7 +272,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       });
   }
 
-  public async onSignInWithFingerprintChange(aEvent: MatSlideToggleChange) {
+  protected async onSignInWithFingerprintChange(aEvent: MatSlideToggleChange) {
     if (aEvent.checked) {
       try {
         await this.registerDevice();
@@ -295,7 +295,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
     }
   }
 
-  public onViewModeChange(aEvent: MatSlideToggleChange) {
+  protected onViewModeChange(aEvent: MatSlideToggleChange) {
     this.dataService
       .putUserSetting({ viewMode: aEvent.checked === true ? 'ZEN' : 'DEFAULT' })
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
+++ b/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
@@ -148,7 +148,9 @@ export class GfUserAccountSettingsComponent implements OnInit {
             permissions.updateViewMode
           );
 
-          this.locales.push(this.user.settings.locale);
+          if (this.user.settings.locale) {
+            this.locales.push(this.user.settings.locale);
+          }
           this.locales = Array.from(new Set(this.locales)).sort();
 
           this.changeDetectorRef.markForCheck();
@@ -195,7 +197,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       confirmFn: () => {
         this.dataService
           .deleteOwnUser({
-            accessToken: this.deleteOwnUserForm.get('accessToken').value
+            accessToken: this.deleteOwnUserForm.get('accessToken')?.value ?? ''
           })
           .pipe(
             catchError(() => {
@@ -240,7 +242,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data) => {
         for (const activity of data.activities) {
-          delete activity.id;
+          delete (activity as Omit<typeof activity, 'id'> & { id?: string }).id;
         }
 
         downloadAsFile({

--- a/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
+++ b/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
@@ -20,11 +20,13 @@ import {
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
   DestroyRef,
+  inject,
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   FormBuilder,
+  FormGroup,
   FormsModule,
   ReactiveFormsModule,
   Validators
@@ -73,9 +75,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
   protected baseCurrency: string;
   protected closeUserAccountMail: string;
   protected currencies: string[] = [];
-  protected deleteOwnUserForm = this.formBuilder.group({
-    accessToken: ['', Validators.required]
-  });
+  protected deleteOwnUserForm: FormGroup;
   protected hasPermissionToDeleteOwnUser: boolean;
   protected hasPermissionToRequestOwnUserDeletion: boolean;
   protected hasPermissionToUpdateViewMode: boolean;
@@ -104,17 +104,21 @@ export class GfUserAccountSettingsComponent implements OnInit {
   ];
   protected user: User;
 
-  public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private formBuilder: FormBuilder,
-    private notificationService: NotificationService,
-    private settingsStorageService: SettingsStorageService,
-    private snackBar: MatSnackBar,
-    private userService: UserService,
-    private webAuthnService: WebAuthnService
-  ) {
+  private changeDetectorRef = inject(ChangeDetectorRef);
+  private dataService = inject(DataService);
+  private destroyRef = inject(DestroyRef);
+  private formBuilder = inject(FormBuilder);
+  private notificationService = inject(NotificationService);
+  private settingsStorageService = inject(SettingsStorageService);
+  private snackBar = inject(MatSnackBar);
+  private userService = inject(UserService);
+  private webAuthnService = inject(WebAuthnService);
+
+  public constructor() {
+    this.deleteOwnUserForm = this.formBuilder.group({
+      accessToken: ['', Validators.required]
+    });
+
     const { baseCurrency, currencies } = this.dataService.fetchInfo();
 
     this.baseCurrency = baseCurrency;

--- a/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
+++ b/apps/client/src/app/components/user-account-settings/user-account-settings.component.ts
@@ -25,8 +25,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
-  FormBuilder,
-  FormGroup,
+  NonNullableFormBuilder,
   FormsModule,
   ReactiveFormsModule,
   Validators
@@ -75,7 +74,9 @@ export class GfUserAccountSettingsComponent implements OnInit {
   protected readonly baseCurrency: string;
   protected closeUserAccountMail: string;
   protected readonly currencies: string[] = [];
-  protected readonly deleteOwnUserForm: FormGroup;
+  protected readonly deleteOwnUserForm = inject(NonNullableFormBuilder).group({
+    accessToken: ['', Validators.required]
+  });
   protected hasPermissionToDeleteOwnUser: boolean;
   protected hasPermissionToRequestOwnUserDeletion: boolean;
   protected hasPermissionToUpdateViewMode: boolean;
@@ -107,7 +108,6 @@ export class GfUserAccountSettingsComponent implements OnInit {
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly dataService = inject(DataService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly formBuilder = inject(FormBuilder);
   private readonly notificationService = inject(NotificationService);
   private readonly settingsStorageService = inject(SettingsStorageService);
   private readonly snackBar = inject(MatSnackBar);
@@ -115,10 +115,6 @@ export class GfUserAccountSettingsComponent implements OnInit {
   private readonly webAuthnService = inject(WebAuthnService);
 
   public constructor() {
-    this.deleteOwnUserForm = this.formBuilder.group({
-      accessToken: ['', Validators.required]
-    });
-
     const { baseCurrency, currencies } = this.dataService.fetchInfo();
 
     this.baseCurrency = baseCurrency;
@@ -201,7 +197,7 @@ export class GfUserAccountSettingsComponent implements OnInit {
       confirmFn: () => {
         this.dataService
           .deleteOwnUser({
-            accessToken: this.deleteOwnUserForm.get('accessToken')?.value ?? ''
+            accessToken: this.deleteOwnUserForm.controls.accessToken.value
           })
           .pipe(
             catchError(() => {

--- a/apps/client/src/app/components/user-detail-dialog/user-detail-dialog.component.ts
+++ b/apps/client/src/app/components/user-detail-dialog/user-detail-dialog.component.ts
@@ -114,7 +114,7 @@ export class GfUserDetailDialogComponent implements OnInit {
           return price !== null;
         })
         .map(({ price }) => {
-          return new Big(price);
+          return new Big(price ?? 0);
         })
     ).toNumber();
   }

--- a/apps/client/src/app/components/user-detail-dialog/user-detail-dialog.component.ts
+++ b/apps/client/src/app/components/user-detail-dialog/user-detail-dialog.component.ts
@@ -49,7 +49,7 @@ import {
   templateUrl: './user-detail-dialog.html'
 })
 export class GfUserDetailDialogComponent implements OnInit {
-  protected baseCurrency: string;
+  protected readonly baseCurrency: string;
   protected readonly getCountryName = getCountryName;
   protected readonly subscriptionsDataSource =
     new MatTableDataSource<Subscription>();


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

### `GfUserAccountSettingsComponent`
- Resolved type safety compilation errors (locale validation, accessToken fallback, type assertion for activities export).
- Enforced encapsulation (made template-accessed component properties and methods `protected`; made `webAuthnService` `private`).
- Enforced immutability (added `readonly` modifier to properties and injected dependencies that are never reassigned).
- Replaced constructor-based dependency injection with the modern `inject` function.
- Migrated `deleteOwnUserForm` to use `NonNullableFormBuilder` via inline injection for strict type safety.
- Cleaned up unused `FormGroup` import from `@angular/forms`.

### `GfHomeHoldingsComponent`
- Resolved type safety compilation errors (guarded `viewModeFormControl` null values, initialized `holdings` to `[]` instead of `undefined`).
- Enforced encapsulation (made template-accessed component properties and methods `protected`).
- Enforced immutability (added `readonly` modifier to properties and injected dependencies that are never reassigned).
- Replaced constructor-based dependency injection with the modern `inject` function.

### `GfUserDetailDialogComponent`
- Resolved type safety compilation errors (utilized a nullish coalescing fallback `price ?? 0` for `BigSource` compatibility).
- Enforced immutability (added `readonly` modifier to `baseCurrency` property).

## Resolved type errors

7 errors (before: 14, after: 7)