### PR TITLE
Task/enable strict null checks in apps/client

### DIFF
--- a/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
+++ b/apps/client/src/app/components/rule/rule-settings-dialog/rule-settings-dialog.html
@@ -7,8 +7,8 @@
 >
   <div class="py-3" mat-dialog-content>
     @if (
-      data.rule.configuration.thresholdMin &&
-      data.rule.configuration.thresholdMax
+      data.rule.configuration?.thresholdMin &&
+      data.rule.configuration?.thresholdMax
     ) {
       <div class="w-100">
         <h6 class="d-flex mb-0">

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -92,7 +92,7 @@ export class GfActivitiesPageComponent implements OnInit {
               .pipe(map((activity) => ({ activity, params })));
           }
 
-          return of({ activity: undefined, params });
+          return of({ params, activity: undefined });
         })
       )
       .subscribe(({ activity, params }) => {

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -31,7 +31,6 @@ import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { format, parseISO } from 'date-fns';
 import { DeviceDetectorService } from 'ngx-device-detector';
-import { Subscription } from 'rxjs';
 
 import { GfCreateOrUpdateActivityDialogComponent } from './create-or-update-activity-dialog/create-or-update-activity-dialog.component';
 import { CreateOrUpdateActivityDialogParams } from './create-or-update-activity-dialog/interfaces/interfaces';
@@ -51,19 +50,19 @@ import { ImportActivitiesDialogParams } from './import-activities-dialog/interfa
   templateUrl: './activities-page.html'
 })
 export class GfActivitiesPageComponent implements OnInit {
-  public activityTypesFilter: string[] = [];
-  public dataSource: MatTableDataSource<Activity> | undefined;
-  public deviceType: string;
-  public hasImpersonationId: boolean;
-  public hasPermissionToCreateActivity: boolean;
-  public hasPermissionToDeleteActivity: boolean;
-  public pageIndex = 0;
-  public pageSize = DEFAULT_PAGE_SIZE;
-  public routeQueryParams: Subscription;
-  public sortColumn = 'date';
-  public sortDirection: SortDirection = 'desc';
-  public totalItems: number | undefined;
-  public user: User;
+  protected dataSource: MatTableDataSource<Activity> | undefined;
+  protected deviceType: string;
+  protected hasImpersonationId: boolean;
+  protected hasPermissionToCreateActivity: boolean;
+  protected hasPermissionToDeleteActivity: boolean;
+  protected pageIndex = 0;
+  protected pageSize = DEFAULT_PAGE_SIZE;
+  protected sortColumn = 'date';
+  protected sortDirection: SortDirection = 'desc';
+  protected totalItems: number | undefined;
+  protected user: User;
+
+  private activityTypesFilter: string[] = [];
 
   public constructor(
     private changeDetectorRef: ChangeDetectorRef,
@@ -77,7 +76,7 @@ export class GfActivitiesPageComponent implements OnInit {
     private router: Router,
     private userService: UserService
   ) {
-    this.routeQueryParams = route.queryParams
+    route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((params) => {
         if (params['createDialog']) {
@@ -131,7 +130,188 @@ export class GfActivitiesPageComponent implements OnInit {
       });
   }
 
-  public fetchActivities() {
+  protected onChangePage(page: PageEvent) {
+    this.pageIndex = page.pageIndex;
+
+    this.fetchActivities();
+  }
+
+  protected onClickActivity({ dataSource, symbol }: AssetProfileIdentifier) {
+    this.router.navigate([], {
+      queryParams: {
+        dataSource,
+        symbol,
+        holdingDetailDialog: true
+      }
+    });
+  }
+
+  protected onCloneActivity(aActivity: Activity) {
+    this.openCreateActivityDialog(aActivity);
+  }
+
+  protected onDeleteActivities() {
+    this.dataService
+      .deleteActivities({
+        filters: this.userService.getFilters()
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.userService
+          .get(true)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe();
+
+        this.fetchActivities();
+
+        this.changeDetectorRef.markForCheck();
+      });
+  }
+
+  protected onDeleteActivity(aId: string) {
+    this.dataService
+      .deleteActivity(aId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.userService
+          .get(true)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe();
+
+        this.fetchActivities();
+
+        this.changeDetectorRef.markForCheck();
+      });
+  }
+
+  protected onExport(activityIds?: string[]) {
+    let fetchExportParams: any = { activityIds };
+
+    if (!activityIds) {
+      fetchExportParams = {
+        activityTypes: this.activityTypesFilter.length
+          ? this.activityTypesFilter
+          : undefined,
+        filters: this.userService.getFilters()
+      };
+    }
+
+    this.dataService
+      .fetchExport(fetchExportParams)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data) => {
+        for (const activity of data.activities) {
+          delete (activity as Omit<typeof activity, 'id'> & { id?: string }).id;
+        }
+
+        downloadAsFile({
+          content: data,
+          fileName: `ghostfolio-export-${format(
+            parseISO(data.meta.date),
+            'yyyyMMddHHmm'
+          )}.json`,
+          format: 'json'
+        });
+      });
+  }
+
+  protected onExportDrafts(activityIds?: string[]) {
+    this.dataService
+      .fetchExport({ activityIds })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data) => {
+        downloadAsFile({
+          content: this.icsService.transformActivitiesToIcsContent(
+            data.activities
+          ),
+          contentType: 'text/calendar',
+          fileName: `ghostfolio-draft${
+            data.activities.length > 1 ? 's' : ''
+          }-${format(parseISO(data.meta.date), 'yyyyMMddHHmmss')}.ics`,
+          format: 'string'
+        });
+      });
+  }
+
+  protected onImport() {
+    const dialogRef = this.dialog.open<
+      GfImportActivitiesDialogComponent,
+      ImportActivitiesDialogParams
+    >(GfImportActivitiesDialogComponent, {
+      data: {
+        deviceType: this.deviceType,
+        user: this.user
+      },
+      height: this.deviceType === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+    });
+
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.userService
+          .get(true)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe();
+
+        this.fetchActivities();
+
+        this.changeDetectorRef.markForCheck();
+      });
+  }
+
+  protected onImportDividends() {
+    const dialogRef = this.dialog.open<
+      GfImportActivitiesDialogComponent,
+      ImportActivitiesDialogParams
+    >(GfImportActivitiesDialogComponent, {
+      data: {
+        activityTypes: ['DIVIDEND'],
+        deviceType: this.deviceType,
+        user: this.user
+      },
+      height: this.deviceType === 'mobile' ? '98vh' : undefined,
+      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
+    });
+
+    dialogRef
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.userService
+          .get(true)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe();
+
+        this.fetchActivities();
+
+        this.changeDetectorRef.markForCheck();
+      });
+  }
+
+  protected onSortChanged({ active, direction }: Sort) {
+    this.pageIndex = 0;
+    this.sortColumn = active;
+    this.sortDirection = direction;
+
+    this.fetchActivities();
+  }
+
+  protected onTypesFilterChanged(aTypes: string[]) {
+    this.activityTypesFilter = aTypes;
+    this.pageIndex = 0;
+
+    this.fetchActivities();
+  }
+
+  protected onUpdateActivity(aActivity: Activity) {
+    this.router.navigate([], {
+      queryParams: { activityId: aActivity.id, editDialog: true }
+    });
+  }
+
+  private fetchActivities() {
     // Reset dataSource and totalItems to show loading state
     this.dataSource = undefined;
     this.totalItems = undefined;
@@ -167,188 +347,7 @@ export class GfActivitiesPageComponent implements OnInit {
       });
   }
 
-  public onChangePage(page: PageEvent) {
-    this.pageIndex = page.pageIndex;
-
-    this.fetchActivities();
-  }
-
-  public onClickActivity({ dataSource, symbol }: AssetProfileIdentifier) {
-    this.router.navigate([], {
-      queryParams: {
-        dataSource,
-        symbol,
-        holdingDetailDialog: true
-      }
-    });
-  }
-
-  public onCloneActivity(aActivity: Activity) {
-    this.openCreateActivityDialog(aActivity);
-  }
-
-  public onDeleteActivities() {
-    this.dataService
-      .deleteActivities({
-        filters: this.userService.getFilters()
-      })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.userService
-          .get(true)
-          .pipe(takeUntilDestroyed(this.destroyRef))
-          .subscribe();
-
-        this.fetchActivities();
-
-        this.changeDetectorRef.markForCheck();
-      });
-  }
-
-  public onDeleteActivity(aId: string) {
-    this.dataService
-      .deleteActivity(aId)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.userService
-          .get(true)
-          .pipe(takeUntilDestroyed(this.destroyRef))
-          .subscribe();
-
-        this.fetchActivities();
-
-        this.changeDetectorRef.markForCheck();
-      });
-  }
-
-  public onExport(activityIds?: string[]) {
-    let fetchExportParams: any = { activityIds };
-
-    if (!activityIds) {
-      fetchExportParams = {
-        activityTypes: this.activityTypesFilter.length
-          ? this.activityTypesFilter
-          : undefined,
-        filters: this.userService.getFilters()
-      };
-    }
-
-    this.dataService
-      .fetchExport(fetchExportParams)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((data) => {
-        for (const activity of data.activities) {
-          delete (activity as Omit<typeof activity, 'id'> & { id?: string }).id;
-        }
-
-        downloadAsFile({
-          content: data,
-          fileName: `ghostfolio-export-${format(
-            parseISO(data.meta.date),
-            'yyyyMMddHHmm'
-          )}.json`,
-          format: 'json'
-        });
-      });
-  }
-
-  public onExportDrafts(activityIds?: string[]) {
-    this.dataService
-      .fetchExport({ activityIds })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((data) => {
-        downloadAsFile({
-          content: this.icsService.transformActivitiesToIcsContent(
-            data.activities
-          ),
-          contentType: 'text/calendar',
-          fileName: `ghostfolio-draft${
-            data.activities.length > 1 ? 's' : ''
-          }-${format(parseISO(data.meta.date), 'yyyyMMddHHmmss')}.ics`,
-          format: 'string'
-        });
-      });
-  }
-
-  public onImport() {
-    const dialogRef = this.dialog.open<
-      GfImportActivitiesDialogComponent,
-      ImportActivitiesDialogParams
-    >(GfImportActivitiesDialogComponent, {
-      data: {
-        deviceType: this.deviceType,
-        user: this.user
-      },
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
-    });
-
-    dialogRef
-      .afterClosed()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.userService
-          .get(true)
-          .pipe(takeUntilDestroyed(this.destroyRef))
-          .subscribe();
-
-        this.fetchActivities();
-
-        this.changeDetectorRef.markForCheck();
-      });
-  }
-
-  public onImportDividends() {
-    const dialogRef = this.dialog.open<
-      GfImportActivitiesDialogComponent,
-      ImportActivitiesDialogParams
-    >(GfImportActivitiesDialogComponent, {
-      data: {
-        activityTypes: ['DIVIDEND'],
-        deviceType: this.deviceType,
-        user: this.user
-      },
-      height: this.deviceType === 'mobile' ? '98vh' : undefined,
-      width: this.deviceType === 'mobile' ? '100vw' : '50rem'
-    });
-
-    dialogRef
-      .afterClosed()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.userService
-          .get(true)
-          .pipe(takeUntilDestroyed(this.destroyRef))
-          .subscribe();
-
-        this.fetchActivities();
-
-        this.changeDetectorRef.markForCheck();
-      });
-  }
-
-  public onSortChanged({ active, direction }: Sort) {
-    this.pageIndex = 0;
-    this.sortColumn = active;
-    this.sortDirection = direction;
-
-    this.fetchActivities();
-  }
-
-  public onTypesFilterChanged(aTypes: string[]) {
-    this.activityTypesFilter = aTypes;
-    this.pageIndex = 0;
-
-    this.fetchActivities();
-  }
-
-  public onUpdateActivity(aActivity: Activity) {
-    this.router.navigate([], {
-      queryParams: { activityId: aActivity.id, editDialog: true }
-    });
-  }
-
-  public openUpdateActivityDialog(aActivity: Activity) {
+  private openUpdateActivityDialog(aActivity: Activity) {
     const dialogRef = this.dialog.open<
       GfCreateOrUpdateActivityDialogComponent,
       CreateOrUpdateActivityDialogParams

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -52,7 +52,7 @@ import { ImportActivitiesDialogParams } from './import-activities-dialog/interfa
 })
 export class GfActivitiesPageComponent implements OnInit {
   public activityTypesFilter: string[] = [];
-  public dataSource: MatTableDataSource<Activity>;
+  public dataSource: MatTableDataSource<Activity> | undefined;
   public deviceType: string;
   public hasImpersonationId: boolean;
   public hasPermissionToCreateActivity: boolean;
@@ -238,7 +238,7 @@ export class GfActivitiesPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data) => {
         for (const activity of data.activities) {
-          delete activity.id;
+          delete (activity as Omit<typeof activity, 'id'> & { id?: string }).id;
         }
 
         downloadAsFile({
@@ -383,7 +383,7 @@ export class GfActivitiesPageComponent implements OnInit {
       });
   }
 
-  private isCalendarYear(dateRange: DateRange) {
+  private isCalendarYear(dateRange?: DateRange) {
     if (!dateRange) {
       return false;
     }
@@ -410,11 +410,12 @@ export class GfActivitiesPageComponent implements OnInit {
               date: new Date(),
               id: null,
               fee: 0,
+              SymbolProfile: null,
               type: aActivity?.type ?? 'BUY',
               unitPrice: null
             },
             user: this.user
-          },
+          } satisfies CreateOrUpdateActivityDialogParams,
           height: this.deviceType === 'mobile' ? '98vh' : '80vh',
           width: this.deviceType === 'mobile' ? '100vw' : '50rem'
         });

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -20,6 +20,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  inject,
   OnInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -64,19 +65,19 @@ export class GfActivitiesPageComponent implements OnInit {
 
   private activityTypesFilter: string[] = [];
 
-  public constructor(
-    private readonly changeDetectorRef: ChangeDetectorRef,
-    private readonly dataService: DataService,
-    private readonly destroyRef: DestroyRef,
-    private readonly deviceDetectorService: DeviceDetectorService,
-    private readonly dialog: MatDialog,
-    private readonly icsService: IcsService,
-    private readonly impersonationStorageService: ImpersonationStorageService,
-    private readonly route: ActivatedRoute,
-    private readonly router: Router,
-    private readonly userService: UserService
-  ) {
-    route.queryParams
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly dataService = inject(DataService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly deviceDetectorService = inject(DeviceDetectorService);
+  private readonly dialog = inject(MatDialog);
+  private readonly icsService = inject(IcsService);
+  private readonly impersonationStorageService = inject(ImpersonationStorageService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
+
+  public constructor() {
+    this.route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((params) => {
         if (params['createDialog']) {

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -32,11 +32,14 @@ import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { format, parseISO } from 'date-fns';
 import { DeviceDetectorService } from 'ngx-device-detector';
+import { of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 
 import { GfCreateOrUpdateActivityDialogComponent } from './create-or-update-activity-dialog/create-or-update-activity-dialog.component';
 import { CreateOrUpdateActivityDialogParams } from './create-or-update-activity-dialog/interfaces/interfaces';
 import { GfImportActivitiesDialogComponent } from './import-activities-dialog/import-activities-dialog.component';
 import { ImportActivitiesDialogParams } from './import-activities-dialog/interfaces/interfaces';
+import { ActivitiesPageParams } from './interfaces/interfaces';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -71,34 +74,33 @@ export class GfActivitiesPageComponent implements OnInit {
   private readonly deviceDetectorService = inject(DeviceDetectorService);
   private readonly dialog = inject(MatDialog);
   private readonly icsService = inject(IcsService);
-  private readonly impersonationStorageService = inject(ImpersonationStorageService);
+  private readonly impersonationStorageService = inject(
+    ImpersonationStorageService
+  );
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
 
   public constructor() {
     this.route.queryParams
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((params) => {
-        if (params['createDialog']) {
-          if (params['activityId']) {
-            this.dataService
-              .fetchActivity(params['activityId'])
-              .pipe(takeUntilDestroyed(this.destroyRef))
-              .subscribe((activity) => {
-                this.openCreateActivityDialog(activity);
-              });
-          } else {
-            this.openCreateActivityDialog();
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        switchMap((params: ActivitiesPageParams) => {
+          if (params.activityId && (params.createDialog || params.editDialog)) {
+            return this.dataService
+              .fetchActivity(params.activityId)
+              .pipe(map((activity) => ({ activity, params })));
           }
-        } else if (params['editDialog']) {
-          if (params['activityId']) {
-            this.dataService
-              .fetchActivity(params['activityId'])
-              .pipe(takeUntilDestroyed(this.destroyRef))
-              .subscribe((activity) => {
-                this.openUpdateActivityDialog(activity);
-              });
+
+          return of({ activity: undefined, params });
+        })
+      )
+      .subscribe(({ activity, params }) => {
+        if (params.createDialog) {
+          this.openCreateActivityDialog(activity);
+        } else if (params.editDialog) {
+          if (activity) {
+            this.openUpdateActivityDialog(activity);
           } else {
             this.router.navigate(['.'], { relativeTo: this.route });
           }

--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -56,7 +56,7 @@ export class GfActivitiesPageComponent implements OnInit {
   protected hasPermissionToCreateActivity: boolean;
   protected hasPermissionToDeleteActivity: boolean;
   protected pageIndex = 0;
-  protected pageSize = DEFAULT_PAGE_SIZE;
+  protected readonly pageSize = DEFAULT_PAGE_SIZE;
   protected sortColumn = 'date';
   protected sortDirection: SortDirection = 'desc';
   protected totalItems: number | undefined;
@@ -65,16 +65,16 @@ export class GfActivitiesPageComponent implements OnInit {
   private activityTypesFilter: string[] = [];
 
   public constructor(
-    private changeDetectorRef: ChangeDetectorRef,
-    private dataService: DataService,
-    private destroyRef: DestroyRef,
-    private deviceDetectorService: DeviceDetectorService,
-    private dialog: MatDialog,
-    private icsService: IcsService,
-    private impersonationStorageService: ImpersonationStorageService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly dataService: DataService,
+    private readonly destroyRef: DestroyRef,
+    private readonly deviceDetectorService: DeviceDetectorService,
+    private readonly dialog: MatDialog,
+    private readonly icsService: IcsService,
+    private readonly impersonationStorageService: ImpersonationStorageService,
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly userService: UserService
   ) {
     route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -536,7 +536,11 @@ export class GfCreateOrUpdateActivityDialogComponent {
 
         this.dialogRef.close(activity);
       } else {
-        (activity as UpdateOrderDto).id = this.data.activity?.id;
+        const activityId = this.data.activity?.id;
+        if (!activityId) {
+          throw new Error('Activity ID is required for update');
+        }
+        (activity as UpdateOrderDto).id = activityId;
 
         await validateObjectForForm({
           classDto: UpdateOrderDto,

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -537,9 +537,11 @@ export class GfCreateOrUpdateActivityDialogComponent {
         this.dialogRef.close(activity);
       } else {
         const activityId = this.data.activity?.id;
+
         if (!activityId) {
           throw new Error('Activity ID is required for update');
         }
+
         (activity as UpdateOrderDto).id = activityId;
 
         await validateObjectForForm({

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/interfaces/interfaces.ts
@@ -4,10 +4,10 @@ import { Account } from '@prisma/client';
 
 export interface CreateOrUpdateActivityDialogParams {
   accounts: Account[];
-  activity: Partial<Omit<Activity, 'SymbolProfile' | 'id' | 'unitPrice'>> & {
+  activity: Partial<Omit<Activity, 'id' | 'SymbolProfile' | 'unitPrice'>> & {
     id: string | null;
-    unitPrice: number | null;
     SymbolProfile: Activity['SymbolProfile'] | null;
+    unitPrice: number | null;
   };
   user: User;
 }

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/interfaces/interfaces.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/interfaces/interfaces.ts
@@ -4,7 +4,9 @@ import { Account } from '@prisma/client';
 
 export interface CreateOrUpdateActivityDialogParams {
   accounts: Account[];
-  activity: Omit<Activity, 'SymbolProfile'> & {
+  activity: Partial<Omit<Activity, 'SymbolProfile' | 'id' | 'unitPrice'>> & {
+    id: string | null;
+    unitPrice: number | null;
     SymbolProfile: Activity['SymbolProfile'] | null;
   };
   user: User;

--- a/apps/client/src/app/pages/portfolio/activities/interfaces/interfaces.ts
+++ b/apps/client/src/app/pages/portfolio/activities/interfaces/interfaces.ts
@@ -1,0 +1,7 @@
+import { Params } from '@angular/router';
+
+export interface ActivitiesPageParams extends Params {
+  activityId?: string;
+  createDialog?: string;
+  editDialog?: string;
+}

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -22,6 +22,7 @@
   "compilerOptions": {
     "lib": ["dom", "es2022"],
     "module": "preserve",
+    "strictNullChecks": true,
     "target": "es2020"
   }
 }

--- a/libs/ui/src/lib/assistant/assistant.component.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.ts
@@ -713,7 +713,7 @@ export class GfAssistantComponent implements OnChanges, OnDestroy, OnInit {
       return {
         routerLink,
         mode: SearchMode.QUICK_LINK as const,
-        name: title
+        name: title ?? ''
       };
     });
   }


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. It resolves the remaining type errors in client app and enables strict null checks TypeScript configuration. Please take a look :)

## Changes

- Resolved type safety compilation errors in `GfActivitiesPageComponent`, `GfCreateOrUpdateActivityDialogComponent`, `GfRuleSettingsDialogComponent`, and `GfAssistantComponent`.
- Enforced encapsulation in `GfActivitiesPageComponent` (made template-accessed component properties and methods `protected`, and internal helpers `private`).
- Enforced immutability in `GfActivitiesPageComponent` (added `readonly` modifier to `pageSize`).
- Replaced constructor-based dependency injection with the `inject` function in `GfActivitiesPageComponent`.
- Flattened nested query parameter subscriptions in `GfActivitiesPageComponent` using RxJS `switchMap` and `map` with `ActivitiesPageParams` to prevent potential race conditions when opening dialogs.
- Cleaned up unused `routeQueryParams` property and its unused `Subscription` import from `rxjs` in `GfActivitiesPageComponent`.

## Resolved type errors

7 errors (before: 7, after: 0)