### PR TITLE
Fix symbol when cloning an activity

### DIFF
--- a/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/activities-page.component.ts
@@ -409,7 +409,7 @@ export class GfActivitiesPageComponent implements OnInit {
             activity: {
               ...aActivity,
               accountId: aActivity?.accountId,
-              assetProfile: null,
+              assetProfile: aActivity?.assetProfile ?? null,
               date: new Date(),
               id: null,
               fee: 0,


### PR DESCRIPTION
Closes #7337

## Summary

Cloning an activity from the portfolio activities page now passes the activity's symbol into the add-activity dialog. The clone path previously passed `undefined`, so the Name, Symbol or ISIN field was no longer prefilled after the regression described in the issue.

## Validation

- Nx lint passed
- TypeScript check passed
- Prettier check passed
