### PR TITLE
Fix cash balance update for historical activities

### DIFF
--- a/apps/api/src/app/account/account.service.ts
+++ b/apps/api/src/app/account/account.service.ts
@@ -336,7 +336,7 @@ export class AccountService {
         accountId,
         userId,
         balance: new Big(balance).plus(amountInCurrencyOfAccount).toNumber(),
-        date: date.toISOString()
+        date: format(new Date(), DATE_FORMAT)
       });
     }
   }

--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -297,17 +297,6 @@ export class GfCreateOrUpdateActivityDialogComponent {
         this.changeDetectorRef.markForCheck();
       });
 
-    this.activityForm.get('date')?.valueChanges.subscribe(() => {
-      if (isToday(this.activityForm.get('date')?.value)) {
-        this.activityForm.get('updateAccountBalance')?.enable();
-      } else {
-        this.activityForm.get('updateAccountBalance')?.disable();
-        this.activityForm.get('updateAccountBalance')?.setValue(false);
-      }
-
-      this.changeDetectorRef.markForCheck();
-    });
-
     this.activityForm.get('searchSymbol')?.valueChanges.subscribe(() => {
       if (this.activityForm.get('searchSymbol')?.invalid) {
         this.data.activity.assetProfile = null;


### PR DESCRIPTION
Fixes an issue in the add activity dialog where selecting a historical date disabled the “Update Cash Balance” checkbox, and even after enabling it, the visible/current cash balance did not update.

The checkbox was disabled by a client-side date change handler whenever the selected activity date was not today.

After removing that restriction, the backend still wrote the updated cash balance to the activity date's historical balance row. Since the app displays the current cash balance from the latest account balance row, updating an older row did not change the visible cash balance.

## Fix

- Removed the date-based disabling/resetting of 'updateAccountBalance' in the activity dialog.
- Kept the activity date for exchange rate conversion.
- Changed the backend cash balance update to write the resulting balance to today's/current account balance row.