### PR TITLE
Task/enforce noImplicitThis and allowUnreachableCode TypeScript rules

### DIFF
--- a/apps/api/src/services/queues/portfolio-snapshot/portfolio-snapshot.service.mock.ts
+++ b/apps/api/src/services/queues/portfolio-snapshot/portfolio-snapshot.service.mock.ts
@@ -1,4 +1,4 @@
-import { Job, JobOptions } from 'bull';
+import type { Job, JobId, JobOptions } from 'bull';
 import { setTimeout } from 'timers/promises';
 
 import { PortfolioSnapshotQueueJob } from './interfaces/portfolio-snapshot-queue-job.interface';
@@ -10,8 +10,8 @@ export const PortfolioSnapshotServiceMock = {
     data: PortfolioSnapshotQueueJob;
     name: string;
     opts?: JobOptions;
-  }): Promise<Job<any>> {
-    const mockJob: Partial<Job<any>> = {
+  }): Promise<Job> {
+    const mockJob: Partial<Job> = {
       finished: async () => {
         await setTimeout(100);
 
@@ -21,12 +21,12 @@ export const PortfolioSnapshotServiceMock = {
 
     this.jobsStore.set(opts?.jobId, mockJob);
 
-    return Promise.resolve(mockJob as Job<any>);
+    return Promise.resolve(mockJob as Job);
   },
-  getJob(jobId: string): Promise<Job<any>> {
+  getJob(jobId: JobId): Promise<Job> {
     const job = this.jobsStore.get(jobId);
 
-    return Promise.resolve(job as Job<any>);
+    return Promise.resolve(job as Job);
   },
-  jobsStore: new Map<string, Partial<Job<any>>>()
+  jobsStore: new Map<JobId, Partial<Job>>()
 };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,7 +34,7 @@
     "noPropertyAccessFromIndexSignature": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "allowUnreachableCode": true
+    "allowUnreachableCode": false
   },
   "exclude": ["node_modules", "tmp"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,7 +29,7 @@
     "strictPropertyInitialization": false,
     "noImplicitReturns": false,
     "noImplicitAny": false,
-    "noImplicitThis": false,
+    "noImplicitThis": true,
     "noImplicitOverride": false,
     "noPropertyAccessFromIndexSignature": false,
     "noUnusedLocals": true,


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

* Enabled `noImplicitThis` in `tsconfig.base.json`.
* Disabled `allowUnreachableCode` in `tsconfig.base.json`.
* Updated `PortfolioSnapshotServiceMock` in [portfolio-snapshot.service.mock.ts](https://github.com/ghostfolio/ghostfolio/blob/4f4477a9d2178d099f267022aef48c70197247e6/apps/api/src/services/queues/portfolio-snapshot/portfolio-snapshot.service.mock.ts) to satisfy the updated TypeScript configuration.

## Additional context

These rules are previously temporarily unenforced in #3878. I am creating this PR to gradually enforcing them back.