### PR TITLE
Task/enforce noImplicitOverride TypeScript rule

### DIFF
--- a/apps/api/src/guards/custom-throttler.guard.ts
+++ b/apps/api/src/guards/custom-throttler.guard.ts
@@ -5,7 +5,9 @@ import { ThrottlerException, ThrottlerGuard } from '@nestjs/throttler';
 export class CustomThrottlerGuard extends ThrottlerGuard {
   private readonly logger = new Logger(CustomThrottlerGuard.name);
 
-  public async canActivate(context: ExecutionContext): Promise<boolean> {
+  public override async canActivate(
+    context: ExecutionContext
+  ): Promise<boolean> {
     try {
       return await super.canActivate(context);
     } catch (error) {

--- a/apps/api/src/models/rules/account-cluster-risk/current-investment.ts
+++ b/apps/api/src/models/rules/account-cluster-risk/current-investment.ts
@@ -13,7 +13,7 @@ export class AccountClusterRiskCurrentInvestment extends Rule<Settings> {
   private accounts: PortfolioDetails['accounts'];
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     accounts: PortfolioDetails['accounts']

--- a/apps/api/src/models/rules/account-cluster-risk/single-account.ts
+++ b/apps/api/src/models/rules/account-cluster-risk/single-account.ts
@@ -11,7 +11,7 @@ export class AccountClusterRiskSingleAccount extends Rule<RuleSettings> {
   private accounts: PortfolioDetails['accounts'];
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     accounts: PortfolioDetails['accounts']

--- a/apps/api/src/models/rules/asset-class-cluster-risk/equity.ts
+++ b/apps/api/src/models/rules/asset-class-cluster-risk/equity.ts
@@ -11,7 +11,7 @@ export class AssetClassClusterRiskEquity extends Rule<Settings> {
   private holdings: PortfolioPosition[];
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     holdings: PortfolioPosition[]

--- a/apps/api/src/models/rules/asset-class-cluster-risk/fixed-income.ts
+++ b/apps/api/src/models/rules/asset-class-cluster-risk/fixed-income.ts
@@ -11,7 +11,7 @@ export class AssetClassClusterRiskFixedIncome extends Rule<Settings> {
   private holdings: PortfolioPosition[];
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     holdings: PortfolioPosition[]

--- a/apps/api/src/models/rules/currency-cluster-risk/base-currency-current-investment.ts
+++ b/apps/api/src/models/rules/currency-cluster-risk/base-currency-current-investment.ts
@@ -11,7 +11,7 @@ export class CurrencyClusterRiskBaseCurrencyCurrentInvestment extends Rule<Setti
   private holdings: PortfolioPosition[];
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     holdings: PortfolioPosition[],
     languageCode: string

--- a/apps/api/src/models/rules/currency-cluster-risk/current-investment.ts
+++ b/apps/api/src/models/rules/currency-cluster-risk/current-investment.ts
@@ -11,7 +11,7 @@ export class CurrencyClusterRiskCurrentInvestment extends Rule<Settings> {
   private holdings: PortfolioPosition[];
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     holdings: PortfolioPosition[],
     languageCode: string

--- a/apps/api/src/models/rules/economic-market-cluster-risk/developed-markets.ts
+++ b/apps/api/src/models/rules/economic-market-cluster-risk/developed-markets.ts
@@ -8,7 +8,7 @@ export class EconomicMarketClusterRiskDevelopedMarkets extends Rule<Settings> {
   private developedMarketsValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     currentValueInBaseCurrency: number,
     developedMarketsValueInBaseCurrency: number,

--- a/apps/api/src/models/rules/economic-market-cluster-risk/emerging-markets.ts
+++ b/apps/api/src/models/rules/economic-market-cluster-risk/emerging-markets.ts
@@ -8,7 +8,7 @@ export class EconomicMarketClusterRiskEmergingMarkets extends Rule<Settings> {
   private emergingMarketsValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     currentValueInBaseCurrency: number,
     emergingMarketsValueInBaseCurrency: number,

--- a/apps/api/src/models/rules/emergency-fund/emergency-fund-setup.ts
+++ b/apps/api/src/models/rules/emergency-fund/emergency-fund-setup.ts
@@ -7,7 +7,7 @@ export class EmergencyFundSetup extends Rule<Settings> {
   private emergencyFund: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     emergencyFund: number

--- a/apps/api/src/models/rules/fees/fee-ratio-total-investment-volume.ts
+++ b/apps/api/src/models/rules/fees/fee-ratio-total-investment-volume.ts
@@ -8,7 +8,7 @@ export class FeeRatioTotalInvestmentVolume extends Rule<Settings> {
   private totalInvestmentVolumeInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     totalInvestmentVolumeInBaseCurrency: number,

--- a/apps/api/src/models/rules/liquidity/buying-power.ts
+++ b/apps/api/src/models/rules/liquidity/buying-power.ts
@@ -7,7 +7,7 @@ export class BuyingPower extends Rule<Settings> {
   private buyingPower: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     buyingPower: number,
     languageCode: string

--- a/apps/api/src/models/rules/regional-market-cluster-risk/asia-pacific.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/asia-pacific.ts
@@ -10,7 +10,7 @@ export class RegionalMarketClusterRiskAsiaPacific extends Rule<Settings> {
   private currentValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     currentValueInBaseCurrency: number,

--- a/apps/api/src/models/rules/regional-market-cluster-risk/emerging-markets.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/emerging-markets.ts
@@ -10,7 +10,7 @@ export class RegionalMarketClusterRiskEmergingMarkets extends Rule<Settings> {
   private emergingMarketsValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     currentValueInBaseCurrency: number,

--- a/apps/api/src/models/rules/regional-market-cluster-risk/europe.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/europe.ts
@@ -10,7 +10,7 @@ export class RegionalMarketClusterRiskEurope extends Rule<Settings> {
   private europeValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     currentValueInBaseCurrency: number,

--- a/apps/api/src/models/rules/regional-market-cluster-risk/japan.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/japan.ts
@@ -10,7 +10,7 @@ export class RegionalMarketClusterRiskJapan extends Rule<Settings> {
   private japanValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     currentValueInBaseCurrency: number,

--- a/apps/api/src/models/rules/regional-market-cluster-risk/north-america.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/north-america.ts
@@ -10,7 +10,7 @@ export class RegionalMarketClusterRiskNorthAmerica extends Rule<Settings> {
   private northAmericaValueInBaseCurrency: number;
 
   public constructor(
-    protected exchangeRateDataService: ExchangeRateDataService,
+    exchangeRateDataService: ExchangeRateDataService,
     private i18nService: I18nService,
     languageCode: string,
     currentValueInBaseCurrency: number,

--- a/apps/client/src/app/adapter/custom-date-adapter.ts
+++ b/apps/client/src/app/adapter/custom-date-adapter.ts
@@ -6,7 +6,7 @@ import { addYears, format, getYear, parse } from 'date-fns';
 
 export class CustomDateAdapter extends NativeDateAdapter {
   public constructor(
-    @Inject(MAT_DATE_LOCALE) public locale: string,
+    @Inject(MAT_DATE_LOCALE) public override locale: string,
     @Inject(forwardRef(() => MAT_DATE_LOCALE)) matDateLocale: string
   ) {
     super(matDateLocale);
@@ -15,21 +15,21 @@ export class CustomDateAdapter extends NativeDateAdapter {
   /**
    * Formats a date as a string
    */
-  public format(aDate: Date): string {
+  public override format(aDate: Date): string {
     return format(aDate, getDateFormatString(this.locale));
   }
 
   /**
    * Sets the first day of the week to Monday
    */
-  public getFirstDayOfWeek(): number {
+  public override getFirstDayOfWeek(): number {
     return 1;
   }
 
   /**
    * Parses a date from a provided value
    */
-  public parse(aValue: string): Date {
+  public override parse(aValue: string): Date {
     let date = parse(aValue, getDateFormatString(this.locale), new Date());
 
     if (getYear(date) < 1900) {

--- a/libs/common/src/lib/dtos/create-asset-profile-with-market-data.dto.ts
+++ b/libs/common/src/lib/dtos/create-asset-profile-with-market-data.dto.ts
@@ -9,7 +9,7 @@ export class CreateAssetProfileWithMarketDataDto extends CreateAssetProfileDto {
   @IsIn([DataSource.MANUAL], {
     message: `dataSource must be '${DataSource.MANUAL}'`
   })
-  dataSource: DataSource;
+  override dataSource: DataSource;
 
   @IsArray()
   @IsOptional()

--- a/libs/ui/src/lib/currency-selector/currency-selector.component.ts
+++ b/libs/ui/src/lib/currency-selector/currency-selector.component.ts
@@ -75,22 +75,22 @@ export class GfCurrencySelectorComponent
   private readonly input = viewChild.required(MatInput);
 
   public constructor(
-    public readonly _elementRef: ElementRef,
-    public readonly _focusMonitor: FocusMonitor,
+    public override readonly _elementRef: ElementRef,
+    public override readonly _focusMonitor: FocusMonitor,
     public readonly changeDetectorRef: ChangeDetectorRef,
     private readonly formGroupDirective: FormGroupDirective,
-    public readonly ngControl: NgControl
+    public override readonly ngControl: NgControl
   ) {
     super(_elementRef, _focusMonitor, ngControl);
 
     this.controlType = 'currency-selector';
   }
 
-  public get empty() {
+  public override get empty() {
     return this.input().empty;
   }
 
-  public set value(value: string | null) {
+  public override set value(value: string | null) {
     this.control.setValue(value);
     super.value = value;
   }
@@ -138,7 +138,7 @@ export class GfCurrencySelectorComponent
       });
   }
 
-  public ngDoCheck() {
+  public override ngDoCheck() {
     if (this.ngControl) {
       this.validateRequired();
       this.errorState = !!(this.ngControl.invalid && this.ngControl.touched);

--- a/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.ts
+++ b/libs/ui/src/lib/symbol-autocomplete/symbol-autocomplete.component.ts
@@ -95,22 +95,22 @@ export class GfSymbolAutocompleteComponent
   private readonly input = viewChild.required(MatInput);
 
   public constructor(
-    public readonly _elementRef: ElementRef,
-    public readonly _focusMonitor: FocusMonitor,
+    public override readonly _elementRef: ElementRef<HTMLElement>,
+    public override readonly _focusMonitor: FocusMonitor,
     public readonly changeDetectorRef: ChangeDetectorRef,
     public readonly dataService: DataService,
-    public readonly ngControl: NgControl
+    public override readonly ngControl: NgControl
   ) {
     super(_elementRef, _focusMonitor, ngControl);
 
     this.controlType = 'symbol-autocomplete';
   }
 
-  public get empty() {
+  public override get empty() {
     return this.input().empty;
   }
 
-  public set value(value: LookupItem) {
+  public override set value(value: LookupItem) {
     this.control.setValue(value);
     super.value = value;
   }
@@ -188,7 +188,7 @@ export class GfSymbolAutocompleteComponent
     });
   }
 
-  public ngDoCheck() {
+  public override ngDoCheck() {
     if (this.ngControl) {
       this.validateRequired();
       this.errorState = !!(this.ngControl.invalid && this.ngControl.touched);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,7 +30,7 @@
     "noImplicitReturns": false,
     "noImplicitAny": false,
     "noImplicitThis": false,
-    "noImplicitOverride": false,
+    "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

* Enabled `noImplicitOverride` rule in `tsconfig.base.json`.
* Modernized constructor signatures in `Rule` subclasses (e.g., in `apps/api/src/models/rules/`) by removing the redundant `protected` keyword from inherited constructor parameters.
* Added `override` keyword to overridden methods and properties in:
  * `CustomThrottlerGuard`
  * `CustomDateAdapter`
  * `CreateAssetProfileWithMarketDataDto`
  * UI library components (`CurrencySelectorComponent`, `SymbolAutocompleteComponent`)

## Additional context

These rules are previously unenforced temporarily in #3878. I am creating this PR to gradually enforcing them back.