### PR TITLE
Bugfix/hover styling of tags selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the language localization for German (`de`)
 - Upgraded `stripe` from version `22.2.3` to `22.3.2`
 
+### Fixed
+
+- Fixed an issue with the delete button in the tags selector component
+
 ## 3.28.0 - 2026-07-17
 
 ### Changed
@@ -27,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed an issue with the delete button in the tags selector component
 - Fixed the missing validation of the tags when creating or updating an activity
 - Fixed the missing validation of the tags when updating the tags of a holding
 - Fixed an issue where the tags of an activity were lost if updating the activity failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where the dividends, the interest and the liabilities of asset profiles without market data have been valued at zero in the portfolio calculation
 - Fixed an issue where an error has been reported for asset profiles without market data which do not hold any units
 - Fixed an issue with removing a linked account from a buy, sell or dividend activity
+- Fixed the hover styling of the tags selector component
 
 ## 3.27.0 - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue with the delete button in the tags selector component
 - Fixed the missing validation of the tags when creating or updating an activity
 - Fixed the missing validation of the tags when updating the tags of a holding
 - Fixed an issue where the tags of an activity were lost if updating the activity failed
 - Fixed an issue where the dividends, the interest and the liabilities of asset profiles without market data have been valued at zero in the portfolio calculation
 - Fixed an issue where an error has been reported for asset profiles without market data which do not hold any units
 - Fixed an issue with removing a linked account from a buy, sell or dividend activity
-- Fixed the hover styling of the tags selector component
 
 ## 3.27.0 - 2026-07-15
 

--- a/libs/ui/src/lib/tags-selector/tags-selector.component.html
+++ b/libs/ui/src/lib/tags-selector/tags-selector.component.html
@@ -34,11 +34,9 @@
           @for (tag of tagsSelected(); track tag.id) {
             <mat-chip-row [removable]="true" (removed)="onRemoveTag(tag)">
               {{ tag.name }}
-              <ion-icon
-                matChipRemove
-                matChipTrailingIcon
-                name="close-outline"
-              />
+              <button matChipRemove type="button">
+                <ion-icon name="close-outline" />
+              </button>
             </mat-chip-row>
           }
           <input

--- a/libs/ui/src/lib/tags-selector/tags-selector.component.html
+++ b/libs/ui/src/lib/tags-selector/tags-selector.component.html
@@ -32,13 +32,13 @@
             }
           }
           @for (tag of tagsSelected(); track tag.id) {
-            <mat-chip-row
-              matChipRemove
-              [removable]="true"
-              (removed)="onRemoveTag(tag)"
-            >
+            <mat-chip-row [removable]="true" (removed)="onRemoveTag(tag)">
               {{ tag.name }}
-              <ion-icon matChipTrailingIcon name="close-outline" />
+              <ion-icon
+                matChipRemove
+                matChipTrailingIcon
+                name="close-outline"
+              />
             </mat-chip-row>
           }
           <input


### PR DESCRIPTION
## Summary

- Move `matChipRemove` from the chip row to the trailing close icon
- The fix preserves Angular Material’s default chip hover styling while preventing the remove-action hover layer from covering the entire chip.

## Testing

- Ran `npm run start:storybook`
- Verified the Tags Selector default story
- Confirmed the hover state follows the chip shape
- Confirmed clicking the close icon removes the tag

## Screenshot
<img width="341" height="138" alt="Screenshot_20260717_225744" src="https://github.com/user-attachments/assets/f7c3f45c-3484-4887-8fa7-226493639d7b" />




Fixes #7348