### PR TITLE
Setup VS Code Dev Container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:22-slim
 
-# Match the build tooling used by the production Dockerfile so native
+# Match the build tooling used by the production Dockerfile (keep this
+# list and the --no-install-suggests flag in sync with it) so native
 # dependencies (e.g. Prisma) compile correctly inside the Dev Container
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-suggests \
   g++ \
   git \
   make \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-slim
+
+# Match the build tooling used by the production Dockerfile so native
+# dependencies (e.g. Prisma) compile correctly inside the Dev Container
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  git \
+  make \
+  openssl \
+  python3 \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Ghostfolio",
+  "dockerComposeFile": [
+    "../docker/docker-compose.dev.yml",
+    "docker-compose.yml"
+  ],
+  "service": "app",
+  "workspaceFolder": "/workspaces/ghostfolio",
+  "shutdownAction": "stopCompose",
+  "remoteUser": "node",
+  "forwardPorts": [3333, 4200],
+  "portsAttributes": {
+    "3333": {
+      "label": "API"
+    },
+    "4200": {
+      "label": "Client"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "angular.ng-template",
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "nrwl.angular-console"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspaces/ghostfolio:cached
+    command: sleep infinity
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,9 +5,13 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
       - ..:/workspaces/ghostfolio:cached
+      - node_modules:/workspaces/ghostfolio/node_modules
     command: sleep infinity
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+
+volumes:
+  node_modules:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,9 +26,9 @@ As an alternative to the manual _Setup_ above, [Visual Studio Code](https://code
 
 - [Docker](https://www.docker.com/products/docker-desktop)
 - [Visual Studio Code](https://code.visualstudio.com) with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
-- Copy the file `.env.example` to `.env` and populate it with your data (`cp .env.example .env`)
+- Copy the file `.env.dev` to `.env` and populate it with your data (`cp .env.dev .env`)
 
-**Info:** Use `.env.example`, not `.env.dev`, as the base for `.env`. Inside the Dev Container, the application and the databases run as separate containers on the same Docker network, so `DATABASE_URL` and `REDIS_HOST` must point to the service names `postgres` and `redis` (as `.env.example` already does), not `localhost`.
+**Info:** Use `.env.dev`, not `.env.example`, as the base for `.env`, since it also sets `NX_ADD_PLUGINS=false` to keep _Nx_ behaving the same as in the manual _Setup_ above. Inside the Dev Container, the application and the databases run as separate containers on the same Docker network, so after copying, change `DATABASE_URL` and `REDIS_HOST` to point to the service names `postgres` and `redis` instead of `localhost`.
 
 #### Setup
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,30 @@
 1. Open https://localhost:4200/en in your browser
 1. Create a new user via _Get Started_ (this first user will get the role `ADMIN`)
 
+### Dev Container
+
+As an alternative to the manual _Setup_ above, [Visual Studio Code](https://code.visualstudio.com) users can develop inside a [Dev Container](https://containers.dev). It runs the application in a Docker container alongside [PostgreSQL](https://www.postgresql.org) and [Redis](https://redis.io), pre-installed with the required build tooling (Node.js 22, `g++`, `make`, `python3`).
+
+#### Prerequisites
+
+- [Docker](https://www.docker.com/products/docker-desktop)
+- [Visual Studio Code](https://code.visualstudio.com) with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+- Copy the file `.env.example` to `.env` and populate it with your data (`cp .env.example .env`)
+
+**Info:** Use `.env.example`, not `.env.dev`, as the base for `.env`. Inside the Dev Container, the application and the databases run as separate containers on the same Docker network, so `DATABASE_URL` and `REDIS_HOST` must point to the service names `postgres` and `redis` (as `.env.example` already does), not `localhost`.
+
+#### Setup
+
+1. Open the repository folder in Visual Studio Code
+1. Run the command _Dev Containers: Reopen in Container_ (this builds the container and runs `npm install` automatically)
+1. In the container's integrated terminal, run `npm run database:setup` to initialize the database schema
+1. Start the [server](#start-server)
+1. Start the client with `npm run start:client -- --host 0.0.0.0` instead of the usual command (see note below)
+1. Open https://localhost:4200/en in your browser
+1. Create a new user via _Get Started_ (this first user will get the role `ADMIN`)
+
+**Info:** The client dev server binds to `localhost` by default, which is only reachable from within the container itself. Passing `--host 0.0.0.0` makes it listen on all interfaces so Visual Studio Code's forwarded port reaches it from your browser on the host. This is not required for the server, which already binds to `0.0.0.0` by default.
+
 ### Start Server
 
 #### Debug

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,7 +40,7 @@ As an alternative to the manual _Setup_ above, [Visual Studio Code](https://code
 1. Open https://localhost:4200/en in your browser
 1. Create a new user via _Get Started_ (this first user will get the role `ADMIN`)
 
-**Info:** The client dev server binds to `localhost` by default, which is only reachable from within the container itself. Passing `--host 0.0.0.0` makes it listen on all interfaces so Visual Studio Code's forwarded port reaches it from your browser on the host. This is not required for the server, which already binds to `0.0.0.0` by default.
+**Info:** The client dev server binds to `localhost` by default, which is only reachable from within the container itself. Passing `--host 0.0.0.0` makes it listen on all interfaces so Visual Studio Code's forwarded port reaches it from your browser on the host. This is not required for the server, which already binds to `0.0.0.0` by default. The `start:client` script also passes `-o` to open a browser automatically; since there is no browser inside the container, this will harmlessly fail and can be ignored.
 
 ### Start Server
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ As an alternative to the manual _Setup_ above, [Visual Studio Code](https://code
 - [Visual Studio Code](https://code.visualstudio.com) with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
 - Copy the file `.env.dev` to `.env` and populate it with your data (`cp .env.dev .env`)
 
-**Info:** Use `.env.dev`, not `.env.example`, as the base for `.env`, since it also sets `NX_ADD_PLUGINS=false` to keep _Nx_ behaving the same as in the manual _Setup_ above. Inside the Dev Container, the application and the databases run as separate containers on the same Docker network, so after copying, change `DATABASE_URL` and `REDIS_HOST` to point to the service names `postgres` and `redis` instead of `localhost`.
+**Info:** Use `.env.dev`, not `.env.example`, as the base for `.env`. After copying, change `DATABASE_URL` and `REDIS_HOST` to point to the service names `postgres` and `redis` instead of `localhost`.
 
 #### Setup
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@
 
 ### Dev Container
 
-As an alternative to the manual _Setup_ above, [Visual Studio Code](https://code.visualstudio.com) users can develop inside a [Dev Container](https://containers.dev). It runs the application in a Docker container alongside [PostgreSQL](https://www.postgresql.org) and [Redis](https://redis.io), pre-installed with the required build tooling (Node.js 22, `g++`, `make`, `python3`).
+As an alternative to the manual _Setup_ above, [Visual Studio Code](https://code.visualstudio.com) users can develop inside a [Dev Container](https://containers.dev). It runs the application in a Docker container alongside [PostgreSQL](https://www.postgresql.org) and [Redis](https://redis.io), pre-installed with the required build tooling (Node.js 22, `g++`, `git`, `make`, `openssl`, `python3`).
 
 #### Prerequisites
 


### PR DESCRIPTION
## Summary
- Add `.devcontainer/devcontainer.json`, `.devcontainer/docker-compose.yml` and `.devcontainer/Dockerfile` so contributors can develop Ghostfolio fully inside VS Code's Dev Containers, with Node.js 22, PostgreSQL and Redis wired together automatically
- The `app` service extends `docker/docker-compose.dev.yml` (rather than duplicating the Postgres/Redis definitions) and waits on their healthchecks before starting
- Document the new workflow in `DEVELOPMENT.md`, including the two non-obvious gotchas discovered while testing this locally:
  - Inside the container, `.env` must be based on `.env.example` (service names `postgres`/`redis`), not `.env.dev` (`localhost`), since the app runs as its own container on the same Docker network
  - The Angular client dev server binds to `localhost` by default, so it must be started with `--host 0.0.0.0` for VS Code's forwarded ports to reach it from the host browser; the API server already binds to `0.0.0.0` by default and needs no change

Closes #7380

## Test plan
- [x] Built the `.devcontainer/Dockerfile` image and confirmed it builds successfully
- [x] Brought up the merged compose stack (`docker/docker-compose.dev.yml` + `.devcontainer/docker-compose.yml`) and confirmed the `app` service can reach `postgres:5432` and `redis:6379` by service name
- [x] Confirmed the existing Postgres data volume is unaffected by adding the `app` service
- [x] Opened the repo in VS Code via "Dev Containers: Reopen in Container", ran `npm run database:setup`, `npm run start:server`, and `npm run start:client -- --host 0.0.0.0`, and confirmed the app loads at `https://localhost:4200/en` in the host browser