### PR TITLE
Fix portfolio calculation crash when exchange rate data is missing

### DIFF
--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -145,8 +145,13 @@ export abstract class PortfolioCalculator {
             tags,
             type,
             date: format(date, DATE_FORMAT),
-            fee: new Big(feeInAssetProfileCurrency),
-            feeInBaseCurrency: new Big(feeInBaseCurrency),
+            // Fees are converted via the exchange rate data service, which
+            // yields undefined when no rate is available for the activity’s
+            // date. Fees are only ever accumulated, so falling back to 0 keeps
+            // the portfolio computable instead of failing the whole request
+            // with “[big.js] Invalid number”.
+            fee: new Big(feeInAssetProfileCurrency ?? 0),
+            feeInBaseCurrency: new Big(feeInBaseCurrency ?? 0),
             quantity: new Big(quantity),
             unitPrice: new Big(unitPriceInAssetProfileCurrency)
           };

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-baln-buy-without-exchange-rate.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-baln-buy-without-exchange-rate.spec.ts
@@ -1,0 +1,141 @@
+import {
+  activityDummyData,
+  assetProfileDummyData,
+  userDummyData
+} from '@ghostfolio/api/app/portfolio/calculator/portfolio-calculator-test-utils';
+import { PortfolioCalculatorFactory } from '@ghostfolio/api/app/portfolio/calculator/portfolio-calculator.factory';
+import { CurrentRateService } from '@ghostfolio/api/app/portfolio/current-rate.service';
+import { CurrentRateServiceMock } from '@ghostfolio/api/app/portfolio/current-rate.service.mock';
+import { RedisCacheService } from '@ghostfolio/api/app/redis-cache/redis-cache.service';
+import { RedisCacheServiceMock } from '@ghostfolio/api/app/redis-cache/redis-cache.service.mock';
+import { ConfigurationService } from '@ghostfolio/api/services/configuration/configuration.service';
+import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { PortfolioSnapshotService } from '@ghostfolio/api/services/queues/portfolio-snapshot/portfolio-snapshot.service';
+import { PortfolioSnapshotServiceMock } from '@ghostfolio/api/services/queues/portfolio-snapshot/portfolio-snapshot.service.mock';
+import { parseDate } from '@ghostfolio/common/helper';
+import { Activity } from '@ghostfolio/common/interfaces';
+import { PerformanceCalculationType } from '@ghostfolio/common/types/performance-calculation-type.type';
+
+import { Big } from 'big.js';
+
+jest.mock('@ghostfolio/api/app/portfolio/current-rate.service', () => {
+  return {
+    CurrentRateService: jest.fn().mockImplementation(() => {
+      return CurrentRateServiceMock;
+    })
+  };
+});
+
+jest.mock(
+  '@ghostfolio/api/services/queues/portfolio-snapshot/portfolio-snapshot.service',
+  () => {
+    return {
+      PortfolioSnapshotService: jest.fn().mockImplementation(() => {
+        return PortfolioSnapshotServiceMock;
+      })
+    };
+  }
+);
+
+jest.mock('@ghostfolio/api/app/redis-cache/redis-cache.service', () => {
+  return {
+    RedisCacheService: jest.fn().mockImplementation(() => {
+      return RedisCacheServiceMock;
+    })
+  };
+});
+
+describe('PortfolioCalculator', () => {
+  let configurationService: ConfigurationService;
+  let currentRateService: CurrentRateService;
+  let exchangeRateDataService: ExchangeRateDataService;
+  let portfolioCalculatorFactory: PortfolioCalculatorFactory;
+  let portfolioSnapshotService: PortfolioSnapshotService;
+  let redisCacheService: RedisCacheService;
+
+  beforeEach(() => {
+    configurationService = new ConfigurationService();
+
+    currentRateService = new CurrentRateService(null, null, null, null);
+
+    exchangeRateDataService = new ExchangeRateDataService(
+      null,
+      null,
+      null,
+      null
+    );
+
+    portfolioSnapshotService = new PortfolioSnapshotService(null, null);
+
+    redisCacheService = new RedisCacheService(null, null);
+
+    portfolioCalculatorFactory = new PortfolioCalculatorFactory(
+      configurationService,
+      currentRateService,
+      exchangeRateDataService,
+      portfolioSnapshotService,
+      redisCacheService
+    );
+  });
+
+  describe('get current positions', () => {
+    it.only('with BALN.SW buy and a missing exchange rate', async () => {
+      jest.useFakeTimers().setSystemTime(parseDate('2021-12-18').getTime());
+
+      // ExchangeRateDataService.toCurrencyAtDate() resolves to undefined when
+      // no exchange rate is available for the activity’s date, which leaves the
+      // converted fee fields undefined by the time they reach the calculator.
+      const activities: Activity[] = [
+        {
+          ...activityDummyData,
+          assetProfile: {
+            ...assetProfileDummyData,
+            currency: 'CHF',
+            dataSource: 'YAHOO',
+            name: 'Bâloise Holding AG',
+            symbol: 'BALN.SW'
+          },
+          date: new Date('2021-11-30'),
+          feeInAssetProfileCurrency: undefined,
+          feeInBaseCurrency: undefined,
+          quantity: 2,
+          type: 'BUY',
+          unitPriceInAssetProfileCurrency: 136.6
+        }
+      ];
+
+      const portfolioCalculator = portfolioCalculatorFactory.createCalculator({
+        activities,
+        calculationType: PerformanceCalculationType.ROAI,
+        currency: 'CHF',
+        userId: userDummyData.id
+      });
+
+      const portfolioSnapshot = await portfolioCalculator.computeSnapshot();
+
+      // The snapshot is still computed; the unconvertible fees count as 0
+      // rather than aborting the request with “[big.js] Invalid number”.
+      expect(portfolioSnapshot).toMatchObject({
+        currentValueInBaseCurrency: new Big('297.8'),
+        errors: [],
+        hasErrors: false,
+        totalFeesWithCurrencyEffect: new Big('0'),
+        positions: [
+          {
+            activitiesCount: 1,
+            averagePrice: new Big('136.6'),
+            currency: 'CHF',
+            dataSource: 'YAHOO',
+            dateOfFirstActivity: '2021-11-30',
+            fee: new Big('0'),
+            feeInBaseCurrency: new Big('0'),
+            investment: new Big('273.2'),
+            quantity: new Big('2'),
+            symbol: 'BALN.SW',
+            valueInBaseCurrency: new Big('297.8')
+          }
+        ]
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6482.

When no exchange rate is available for an activity's date, `ExchangeRateDataService.toCurrencyAtDate()` resolves to `undefined`. That `undefined` reaches the calculator as `feeInAssetProfileCurrency` / `feeInBaseCurrency` and is passed straight into `new Big()`:

```ts
fee: new Big(feeInAssetProfileCurrency),
feeInBaseCurrency: new Big(feeInBaseCurrency),   // throws
```

`big.js` rejects it with `[big.js] Invalid number`, which fails the whole portfolio request — the Overview, Portfolio and Holdings pages all render *"Oops! Something went wrong"*.

This is reachable on a normal fresh self-hosted install: import activities in a currency other than the base currency and open the portfolio before the exchange rate gathering job has caught up.

```
ERROR [ExchangeRateDataService] No exchange rate has been found for USDEUR at 2021-04-15
ERROR [ExceptionsHandler] Error: [big.js] Invalid number
    at new PortfolioCalculator (.../portfolio-calculator.ts:149)
```

### Fix

Default the two converted fee fields to `0`. Fees are only ever accumulated — `oldAccumulatedSymbol.feeInBaseCurrency.plus(feeInBaseCurrency)` on line 1007 — so `0` is the identity and the snapshot stays computable while the exchange rate data is still incomplete.

Deliberately scoped to the fee fields: `quantity` and `unitPriceInAssetProfileCurrency` are recorded in the asset profile's own currency and never go through `toCurrencyAtDate()`, so they are not part of this failure mode. Leaving them unguarded means genuinely malformed activities still surface loudly instead of being silently valued at 0.

### Trade-off

This makes the portfolio render with the affected fees counted as 0 rather than crashing. It does not invent an exchange rate — the underlying "no exchange rate found" condition is still logged by `ExchangeRateDataService`, and the numbers become exact once gathering completes. Happy to rework this toward surfacing it through the existing `errors` / `hasErrors` channel on `PortfolioSnapshot` instead if you'd prefer the user to see an explicit warning.

### Verification

- New spec `portfolio-calculator-baln-buy-without-exchange-rate.spec.ts` fails with `[big.js] Invalid number` on `main` and passes with the fix (confirmed by stashing the `portfolio-calculator.ts` change).
- `npm run test:api` — 23 suites passed, 29 tests passed, 2 skipped.
- 3 suites (`portfolio.service`, `current-rate.service`, `benchmark.service`) fail to compile in my sandbox with `Cannot find module 'keyv'`. That is an artifact of my local `npm install --legacy-peer-deps`; `keyv` is absent from my `node_modules` and those same 3 suites fail identically with my change stashed, so it is unrelated to this PR and should be fine under `npm ci` in CI.
- `prettier --check` clean on both changed files; the husky pre-commit lint passed.

I left `CHANGELOG.md` alone since release notes look like they're curated at release time.
