### PR TITLE
Ignore future account balances when building cash activities

### DIFF
--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -468,6 +468,13 @@ export class ActivitiesService {
       let currentBalanceInBaseCurrency = 0;
 
       for (const balanceItem of balances) {
+        if (isAfter(new Date(balanceItem.date), endOfToday())) {
+          // Skip account balances dated in the future. Synthesizing an activity
+          // from one books a deposit or withdrawal that has not happened yet,
+          // which distorts the investment and performance of the cash position.
+          continue;
+        }
+
         const syntheticActivityTemplate: Activity = {
           userId,
           accountId: account.id,

--- a/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
+++ b/apps/api/src/app/portfolio/calculator/roai/portfolio-calculator-cash.spec.ts
@@ -161,6 +161,14 @@ describe('PortfolioCalculator', () => {
               id: randomUUID(),
               value: 2000,
               valueInBaseCurrency: 1800
+            },
+            {
+              // Ignored future account balance
+              accountId,
+              date: parseDate('2050-12-31'),
+              id: randomUUID(),
+              value: 0,
+              valueInBaseCurrency: 0
             }
           ]
         });


### PR DESCRIPTION
Fixes #6185.

An account balance dated in the future changes the calculation results today.

`ActivitiesService.getCashActivities()` walks every balance for an account and books a synthetic `BUY` or `SELL` for each delta against the running balance. Future-dated balances were included, so entering one ahead of time booked a deposit or withdrawal that has not happened yet.

That phantom activity is not simply ignored downstream either — `PortfolioCalculator` deliberately clamps future activity dates to today:

```ts
if (isAfter(date, new Date())) {
  // Adapt date to today if activity is in future (e.g. liability)
  date = endOfDay(new Date());
}
```

so it lands *inside* the calculation window and skews the cash position.

### Reproduction

Using the mock extension suggested in the issue — a `2050-12-31` balance of `0` added to `portfolio-calculator-cash.spec.ts` — the USD position goes from

```
activitiesCount: 2, averagePrice: 1, investment: 1820, investmentWithCurrencyEffect: 1750
```

to

```
activitiesCount: 3, averagePrice: 0, investment: 0, investmentWithCurrencyEffect: 0
```

The future balance of `0` reads as "sold everything", zeroing the position.

### Fix

Skip balances after `endOfToday()` when synthesizing cash activities. `endOfToday` and `isAfter` were already imported in that file.

### Note on a second, unfixed path

While tracing this I noticed `PortfolioCalculator.computeSnapshot()` also folds every `accountBalanceItem.date` into `chartDateMap` without bounding it by `endDate`:

```ts
for (const accountBalanceItem of this.accountBalanceItems) {
  chartDateMap[accountBalanceItem.date] = true;
}
```

`accountBalanceItems` comes from `getAccountBalanceItems()`, which is not filtered by this PR, so a future balance can still add a chart date beyond the end of the window. I could not demonstrate it with the cash spec — `historicalData` is empty there because `currentRateService.getValues()` is mocked to return no values — so I deliberately left it out rather than ship a change I could not verify. Happy to follow up with a separate PR if you'd like it bounded too.

### Verification

- `portfolio-calculator-cash.spec.ts` fails with `activitiesCount: 3` without the fix and passes with it.
- `npm run test:api` — 22 suites passed, 28 tests passed, 2 skipped; no new failures.
- 3 suites (`portfolio.service`, `current-rate.service`, `benchmark.service`) fail to compile locally with `Cannot find module 'keyv'`. That is an artifact of my sandbox install (`keyv` is missing from my `node_modules`); they fail identically with my change stashed, so it is unrelated to this PR.
- `prettier --check` clean; husky pre-commit lint passed.
