### PR TITLE
Task/improve language localization for PL (20260723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Improved the language localization for Polish (`pl`)
+
 ## 3.32.0 - 2026-07-22
 
 ### Changed

--- a/apps/client/src/locales/messages.pl.xlf
+++ b/apps/client/src/locales/messages.pl.xlf
@@ -6526,7 +6526,7 @@
       </trans-unit>
       <trans-unit id="8204176479746810612" datatype="html">
         <source>Active</source>
-        <target state="translated">Antywne</target>
+        <target state="translated">Aktywne</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/client/src/app/components/home-holdings/home-holdings.component.ts</context>
           <context context-type="linenumber">64</context>


### PR DESCRIPTION
/pl/home/holdings
The Polish translation of the holdings filter toggle read Antywne instead of Aktywne. Fixed the typo in messages.pl.xlf

<img width="1207" height="167" alt="obraz" src="https://github.com/user-attachments/assets/9ab78e8f-84f2-49a4-9c9d-d6a5b5b25441" />

