### PR TITLE
ci: support parallel dev mode by adding 'nx run-many' flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `dotenv` from version `17.2.3` to `17.4.2`
 - Upgraded `dotenv-expand` from version `12.0.3` to `13.0.0`
 - Upgraded `fuse.js` from version `7.3.0` to `7.5.0`
+- Added support for starting the server and the client in parallel during development
 
 ### Fixed
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,10 @@
 1. Open https://localhost:4200/en in your browser
 1. Create a new user via _Get Started_ (this first user will get the role `ADMIN`)
 
+### Start Server and Client
+
+Run `npm run dev` to start the server and the client in the same terminal.
+
 ### Start Server
 
 #### Debug

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "database:setup": "npm run database:push && npm run database:seed",
     "database:validate-schema": "prisma validate",
     "dep-graph": "nx dep-graph",
+    "dev": "nx run-many --target=copy-assets --projects=api,client && nx run-many --target=serve --projects=api,client --configuration=development-en",
     "extract-locales": "nx run client:extract-i18n --output-path ./apps/client/src/locales",
     "format": "nx format:write",
     "format:check": "nx format:check",


### PR DESCRIPTION
#### What type of PR is this?

Cleanup task

#### What this PR does / why we need it:

Improve the local development experience. Close #6460 . 

#### Which issue(s) this PR is related to:

[Support parallel dev mode](https://github.com/ghostfolio/ghostfolio/issues/6460)

#### Special notes for your reviewer:

Assume local PostgreSQL and Redis are available before running `npm run dev`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation:

```docs
NONE
```
