### PR TITLE
Task/improve type safety in access and account balance services

### DIFF
--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -78,7 +78,7 @@ export class AccessController {
   ): Promise<AccessModel> {
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
@@ -134,7 +134,7 @@ export class AccessController {
   ): Promise<AccessModel> {
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),

--- a/apps/api/src/app/account-balance/account-balance.service.ts
+++ b/apps/api/src/app/account-balance/account-balance.service.ts
@@ -178,7 +178,7 @@ export class AccountBalanceService {
           accountId: balance.account.id,
           valueInBaseCurrency: this.exchangeRateDataService.toCurrency(
             balance.value,
-            balance.account.currency,
+            balance.account.currency ?? userCurrency,
             userCurrency
           )
         };

--- a/libs/common/src/lib/interfaces/access.interface.ts
+++ b/libs/common/src/lib/interfaces/access.interface.ts
@@ -5,7 +5,7 @@ import { AccessPermission } from '@prisma/client';
 import { AccessSettings } from './access-settings.interface';
 
 export interface Access {
-  alias?: string;
+  alias: string | null;
   grantee?: string;
   id: string;
   permissions: AccessPermission[];

--- a/libs/common/src/lib/types/access-with-grantee-user.type.ts
+++ b/libs/common/src/lib/types/access-with-grantee-user.type.ts
@@ -1,3 +1,3 @@
 import { Access, User } from '@prisma/client';
 
-export type AccessWithGranteeUser = Access & { granteeUser?: User };
+export type AccessWithGranteeUser = Access & { granteeUser?: User | null };


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

* Improved type safety in `Access` interface and `AccessWithGranteeUser` type:
  * Updated `alias` in `Access` interface to `string | null` to match the Prisma model schema (`alias String?`).
  * Updated `granteeUser` in `AccessWithGranteeUser` type to `User | null` to support records without a grantee user.
* Improved type safety in `AccessController`:
  * Added optional chaining (`user.subscription?.type`) when checking subscription type to safely handle uninitialized or optional subscriptions.
* Improved type safety in `AccountBalanceService`:
  * Handled nullable `balance.account.currency` by providing a fallback to `userCurrency`.

## Resolved type errors

4 errors (before: 771, after: 767)
