### PR TITLE
Task/improve type safety across API services and controllers

### DIFF
--- a/apps/api/src/app/access/access.controller.ts
+++ b/apps/api/src/app/access/access.controller.ts
@@ -78,7 +78,7 @@ export class AccessController {
   ): Promise<AccessModel> {
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),
@@ -134,7 +134,7 @@ export class AccessController {
   ): Promise<AccessModel> {
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       throw new HttpException(
         getReasonPhrase(StatusCodes.FORBIDDEN),

--- a/apps/api/src/app/endpoints/public/public.controller.ts
+++ b/apps/api/src/app/endpoints/public/public.controller.ts
@@ -65,7 +65,7 @@ export class PublicController {
     });
 
     if (this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION')) {
-      hasDetails = user.subscription.type === SubscriptionType.Premium;
+      hasDetails = user?.subscription?.type === SubscriptionType.Premium;
     }
 
     const { filters } = (access.settings ?? {}) as AccessSettings;
@@ -98,7 +98,7 @@ export class PublicController {
       sortDirection: 'desc',
       take: 10,
       types: [ActivityType.BUY, ActivityType.SELL],
-      userCurrency: user.settings?.settings.baseCurrency ?? DEFAULT_CURRENCY,
+      userCurrency: user?.settings?.settings.baseCurrency ?? DEFAULT_CURRENCY,
       userId: user.id,
       withExcludedAccountsAndActivities: false
     });
@@ -167,7 +167,7 @@ export class PublicController {
           this.exchangeRateDataService.toCurrency(
             quantity * marketPrice,
             assetProfile.currency,
-            user.settings?.settings.baseCurrency ?? DEFAULT_CURRENCY
+            user?.settings?.settings.baseCurrency ?? DEFAULT_CURRENCY
           )
         );
       })

--- a/apps/api/src/app/import/import.controller.ts
+++ b/apps/api/src/app/import/import.controller.ts
@@ -65,7 +65,7 @@ export class ImportController {
 
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Premium
+      this.request.user.subscription?.type === SubscriptionType.Premium
     ) {
       maxActivitiesToImport = Number.MAX_SAFE_INTEGER;
     }
@@ -109,7 +109,7 @@ export class ImportController {
 
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Premium
+      this.request.user.subscription?.type === SubscriptionType.Premium
     ) {
       maxActivitiesToImport = Number.MAX_SAFE_INTEGER;
     }

--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -97,7 +97,7 @@ export class PortfolioController {
 
     if (this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION')) {
       hasDetails =
-        this.request.user.subscription.type === SubscriptionType.Premium;
+        this.request.user.subscription?.type === SubscriptionType.Premium;
     }
 
     const filters = this.apiService.buildFiltersFromQueryParams({
@@ -383,7 +383,7 @@ export class PortfolioController {
 
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       dividends = dividends.map((item) => {
         return nullifyValuesInObject(item, ['investment']);
@@ -511,7 +511,7 @@ export class PortfolioController {
 
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       investments = investments.map((item) => {
         return nullifyValuesInObject(item, ['investment']);
@@ -623,7 +623,7 @@ export class PortfolioController {
 
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       performanceInformation.chart = performanceInformation.chart.map(
         (item) => {
@@ -651,7 +651,7 @@ export class PortfolioController {
 
     if (
       this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-      this.request.user.subscription.type === SubscriptionType.Basic
+      this.request.user.subscription?.type === SubscriptionType.Basic
     ) {
       for (const category of report.xRay.categories) {
         category.rules = null;

--- a/apps/api/src/app/subscription/subscription.service.ts
+++ b/apps/api/src/app/subscription/subscription.service.ts
@@ -149,7 +149,7 @@ export class SubscriptionService {
       }
 
       const subscriptionOffer: SubscriptionOffer = JSON.parse(
-        session.metadata.subscriptionOffer ?? '{}'
+        session.metadata?.subscriptionOffer ?? '{}'
       );
 
       const durationExtension = subscriptionOffer?.durationExtension;

--- a/apps/api/src/services/benchmark/benchmark.service.ts
+++ b/apps/api/src/services/benchmark/benchmark.service.ts
@@ -18,7 +18,6 @@ import {
   BenchmarkProperty,
   BenchmarkResponse
 } from '@ghostfolio/common/interfaces';
-import { BenchmarkTrend } from '@ghostfolio/common/types';
 
 import { Injectable, Logger } from '@nestjs/common';
 import { SymbolProfile } from '@prisma/client';
@@ -146,7 +145,7 @@ export class BenchmarkService {
   public async addBenchmark({
     dataSource,
     symbol
-  }: AssetProfileIdentifier): Promise<Partial<SymbolProfile>> {
+  }: AssetProfileIdentifier): Promise<Partial<SymbolProfile> | undefined> {
     const assetProfile = await this.prismaService.symbolProfile.findFirst({
       where: {
         dataSource,
@@ -183,7 +182,7 @@ export class BenchmarkService {
   public async deleteBenchmark({
     dataSource,
     symbol
-  }: AssetProfileIdentifier): Promise<Partial<SymbolProfile>> {
+  }: AssetProfileIdentifier): Promise<Partial<SymbolProfile> | null> {
     const assetProfile = await this.prismaService.symbolProfile.findFirst({
       where: {
         dataSource,
@@ -240,12 +239,12 @@ export class BenchmarkService {
       enableSharing
     });
 
-    const promisesAllTimeHighs: Promise<{ date: Date; marketPrice: number }>[] =
-      [];
-    const promisesBenchmarkTrends: Promise<{
-      trend50d: BenchmarkTrend;
-      trend200d: BenchmarkTrend;
-    }>[] = [];
+    const promisesAllTimeHighs: ReturnType<
+      typeof this.marketDataService.getMax
+    >[] = [];
+    const promisesBenchmarkTrends: ReturnType<
+      typeof this.getBenchmarkTrends
+    >[] = [];
 
     const quotes = await this.dataProviderService.getQuotes({
       items: benchmarkAssetProfiles.map(({ dataSource, symbol }) => {

--- a/apps/api/src/services/data-provider/data-enhancer/yahoo-finance/yahoo-finance.service.ts
+++ b/apps/api/src/services/data-provider/data-enhancer/yahoo-finance/yahoo-finance.service.ts
@@ -200,13 +200,13 @@ export class YahooFinanceDataEnhancerService implements DataEnhancerInterface {
 
       response.assetClass = assetClass;
       response.assetSubClass = assetSubClass;
-      response.currency = assetProfile.price.currency;
+      response.currency = assetProfile.price?.currency;
       response.dataSource = this.getName();
       response.name = this.formatName({
-        longName: assetProfile.price.longName,
-        quoteType: assetProfile.price.quoteType,
-        shortName: assetProfile.price.shortName,
-        symbol: assetProfile.price.symbol
+        longName: assetProfile.price?.longName,
+        quoteType: assetProfile.price?.quoteType,
+        shortName: assetProfile.price?.shortName,
+        symbol: assetProfile.price?.symbol
       });
       response.symbol = this.convertFromYahooFinanceSymbol(
         assetProfile.price.symbol

--- a/apps/api/src/services/data-provider/data-provider.service.ts
+++ b/apps/api/src/services/data-provider/data-provider.service.ts
@@ -248,7 +248,7 @@ export class DataProviderService implements OnModuleInit {
 
       if (
         this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-        user.subscription.type === SubscriptionType.Basic
+        user.subscription?.type === SubscriptionType.Basic
       ) {
         const dataProvider = this.getDataProvider(DataSource[dataSource]);
 
@@ -660,7 +660,7 @@ export class DataProviderService implements OnModuleInit {
           } else if (
             dataProvider.getDataProviderInfo().isPremium &&
             this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION') &&
-            user?.subscription.type === SubscriptionType.Basic
+            user?.subscription?.type === SubscriptionType.Basic
           ) {
             // Skip symbols of Premium data providers for users without subscription
             return false;
@@ -876,7 +876,7 @@ export class DataProviderService implements OnModuleInit {
       })
       .map((lookupItem) => {
         if (this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION')) {
-          if (user.subscription.type === SubscriptionType.Premium) {
+          if (user.subscription?.type === SubscriptionType.Premium) {
             lookupItem.dataProviderInfo.isPremium = false;
           }
 

--- a/apps/api/src/services/data-provider/data-provider.service.ts
+++ b/apps/api/src/services/data-provider/data-provider.service.ts
@@ -99,7 +99,7 @@ export class DataProviderService implements OnModuleInit {
       return dataSource;
     });
 
-    const promises = [];
+    const promises: Promise<void>[] = [];
 
     for (const [dataSource, assetProfileIdentifiers] of Object.entries(
       itemsGroupedByDataSource


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

* Improved type safety for subscription access across controllers & services:
  * Added optional chaining (`user.subscription?.type`) across `AccessController`, `ImportController`, `PublicController`, `PortfolioController`, and `DataProviderService` to safely handle optional/uninitialized subscriptions.
* Improved null safety in `SubscriptionService`:
  * Added optional chaining for `session.metadata?.subscriptionOffer` handling.
* Improved type safety in `YahooFinanceDataEnhancerService`:
  * Added optional chaining for `assetProfile.price` property accesses (`currency`, `longName`, `quoteType`, `shortName`, `symbol`).
* Improved type definitions in `BenchmarkService`:
  * Updated return types (`addBenchmark`, `deleteBenchmark`) and typed promise arrays (`promisesAllTimeHighs`, `promisesBenchmarkTrends`).
* Explicitly typed promise array initialization in `DataProviderService`.

## Resolved type errors

26 errors (before: 771, after: 745)