### PR TITLE
Task/improve type safety in rule models

### DIFF
--- a/apps/api/src/models/rule.ts
+++ b/apps/api/src/models/rule.ts
@@ -59,7 +59,7 @@ export abstract class Rule<T extends RuleSettings> implements RuleInterface<T> {
               new Big(currentValue.quantity)
                 .mul(currentValue.marketPrice ?? 0)
                 .toNumber(),
-              currentValue.assetProfile.currency,
+              currentValue.assetProfile.currency ?? baseCurrency,
               baseCurrency
             ),
           0

--- a/apps/api/src/models/rules/account-cluster-risk/current-investment.ts
+++ b/apps/api/src/models/rules/account-cluster-risk/current-investment.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import {
   PortfolioDetails,
   RuleSettings,
@@ -50,7 +51,7 @@ export class AccountClusterRiskCurrentInvestment extends Rule<Settings> {
       };
     }
 
-    let maxAccount: (typeof accounts)[0];
+    let maxAccount: (typeof accounts)[0] | undefined;
     let totalInvestment = 0;
 
     for (const account of Object.values(accounts)) {
@@ -67,7 +68,8 @@ export class AccountClusterRiskCurrentInvestment extends Rule<Settings> {
       }
     }
 
-    const maxInvestmentRatio = maxAccount?.investment / totalInvestment || 0;
+    const maxInvestmentRatio =
+      (maxAccount?.investment ?? 0) / totalInvestment || 0;
 
     if (maxInvestmentRatio > ruleSettings.thresholdMax) {
       return {
@@ -75,7 +77,7 @@ export class AccountClusterRiskCurrentInvestment extends Rule<Settings> {
           id: 'rule.accountClusterRiskCurrentInvestment.false',
           languageCode: this.getLanguageCode(),
           placeholders: {
-            maxAccountName: maxAccount.name,
+            maxAccountName: maxAccount?.name ?? '',
             maxInvestmentRatio: (maxInvestmentRatio * 100).toPrecision(3),
             thresholdMax: ruleSettings.thresholdMax * 100
           }
@@ -89,7 +91,7 @@ export class AccountClusterRiskCurrentInvestment extends Rule<Settings> {
         id: 'rule.accountClusterRiskCurrentInvestment.true',
         languageCode: this.getLanguageCode(),
         placeholders: {
-          maxAccountName: maxAccount.name,
+          maxAccountName: maxAccount?.name ?? '',
           maxInvestmentRatio: (maxInvestmentRatio * 100).toPrecision(3),
           thresholdMax: ruleSettings.thresholdMax * 100
         }
@@ -118,8 +120,8 @@ export class AccountClusterRiskCurrentInvestment extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/account-cluster-risk/single-account.ts
+++ b/apps/api/src/models/rules/account-cluster-risk/single-account.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import {
   PortfolioDetails,
   RuleSettings,
@@ -68,7 +69,10 @@ export class AccountClusterRiskSingleAccount extends Rule<RuleSettings> {
     });
   }
 
-  public getSettings({ locale, xRayRules }: UserSettings): RuleSettings {
+  public getSettings({
+    locale = DEFAULT_LOCALE,
+    xRayRules
+  }: UserSettings): RuleSettings {
     return {
       locale,
       isActive: xRayRules?.[this.getKey()]?.isActive ?? true

--- a/apps/api/src/models/rules/asset-class-cluster-risk/equity.ts
+++ b/apps/api/src/models/rules/asset-class-cluster-risk/equity.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import {
   PortfolioPosition,
   RuleSettings,
@@ -107,8 +108,8 @@ export class AssetClassClusterRiskEquity extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/asset-class-cluster-risk/fixed-income.ts
+++ b/apps/api/src/models/rules/asset-class-cluster-risk/fixed-income.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import {
   PortfolioPosition,
   RuleSettings,
@@ -107,8 +108,8 @@ export class AssetClassClusterRiskFixedIncome extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/currency-cluster-risk/base-currency-current-investment.ts
+++ b/apps/api/src/models/rules/currency-cluster-risk/base-currency-current-investment.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import {
   PortfolioPosition,
   RuleSettings,
@@ -94,8 +95,8 @@ export class CurrencyClusterRiskBaseCurrencyCurrentInvestment extends Rule<Setti
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/currency-cluster-risk/current-investment.ts
+++ b/apps/api/src/models/rules/currency-cluster-risk/current-investment.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import {
   PortfolioPosition,
   RuleSettings,
@@ -95,8 +96,8 @@ export class CurrencyClusterRiskCurrentInvestment extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/economic-market-cluster-risk/developed-markets.ts
+++ b/apps/api/src/models/rules/economic-market-cluster-risk/developed-markets.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { RuleSettings, UserSettings } from '@ghostfolio/common/interfaces';
 
 export class EconomicMarketClusterRiskDevelopedMarkets extends Rule<Settings> {
@@ -97,8 +98,8 @@ export class EconomicMarketClusterRiskDevelopedMarkets extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/economic-market-cluster-risk/emerging-markets.ts
+++ b/apps/api/src/models/rules/economic-market-cluster-risk/emerging-markets.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { RuleSettings, UserSettings } from '@ghostfolio/common/interfaces';
 
 export class EconomicMarketClusterRiskEmergingMarkets extends Rule<Settings> {
@@ -97,8 +98,8 @@ export class EconomicMarketClusterRiskEmergingMarkets extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/emergency-fund/emergency-fund-setup.ts
+++ b/apps/api/src/models/rules/emergency-fund/emergency-fund-setup.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { RuleSettings, UserSettings } from '@ghostfolio/common/interfaces';
 
 export class EmergencyFundSetup extends Rule<Settings> {
@@ -52,8 +53,8 @@ export class EmergencyFundSetup extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/fees/fee-ratio-total-investment-volume.ts
+++ b/apps/api/src/models/rules/fees/fee-ratio-total-investment-volume.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { RuleSettings, UserSettings } from '@ghostfolio/common/interfaces';
 
 export class FeeRatioTotalInvestmentVolume extends Rule<Settings> {
@@ -76,8 +77,8 @@ export class FeeRatioTotalInvestmentVolume extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/liquidity/buying-power.ts
+++ b/apps/api/src/models/rules/liquidity/buying-power.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { RuleSettings, UserSettings } from '@ghostfolio/common/interfaces';
 
 export class BuyingPower extends Rule<Settings> {
@@ -83,8 +84,8 @@ export class BuyingPower extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/regional-market-cluster-risk/asia-pacific.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/asia-pacific.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -91,8 +92,8 @@ export class RegionalMarketClusterRiskAsiaPacific extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/regional-market-cluster-risk/emerging-markets.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/emerging-markets.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -93,8 +94,8 @@ export class RegionalMarketClusterRiskEmergingMarkets extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/regional-market-cluster-risk/europe.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/europe.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -91,8 +92,8 @@ export class RegionalMarketClusterRiskEurope extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/regional-market-cluster-risk/japan.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/japan.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -91,8 +92,8 @@ export class RegionalMarketClusterRiskJapan extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/models/rules/regional-market-cluster-risk/north-america.ts
+++ b/apps/api/src/models/rules/regional-market-cluster-risk/north-america.ts
@@ -1,6 +1,7 @@
 import { Rule } from '@ghostfolio/api/models/rule';
 import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
 import { I18nService } from '@ghostfolio/api/services/i18n/i18n.service';
+import { DEFAULT_CURRENCY, DEFAULT_LOCALE } from '@ghostfolio/common/config';
 import { UserSettings } from '@ghostfolio/common/interfaces';
 
 import { Settings } from './interfaces/rule-settings.interface';
@@ -91,8 +92,8 @@ export class RegionalMarketClusterRiskNorthAmerica extends Rule<Settings> {
   }
 
   public getSettings({
-    baseCurrency,
-    locale,
+    baseCurrency = DEFAULT_CURRENCY,
+    locale = DEFAULT_LOCALE,
     xRayRules
   }: UserSettings): Settings {
     return {

--- a/apps/api/src/services/interfaces/environment.interface.ts
+++ b/apps/api/src/services/interfaces/environment.interface.ts
@@ -38,9 +38,9 @@ export interface Environment extends CleanedEnvAccessors {
   MAX_CHART_ITEMS: number;
   OIDC_AUTHORIZATION_URL: string;
   OIDC_CALLBACK_URL: string;
-  OIDC_CLIENT_ID: string;
-  OIDC_CLIENT_SECRET: string;
-  OIDC_ISSUER: string;
+  OIDC_CLIENT_ID?: string;
+  OIDC_CLIENT_SECRET?: string;
+  OIDC_ISSUER?: string;
   OIDC_SCOPE: string[];
   OIDC_TOKEN_URL: string;
   OIDC_USER_INFO_URL: string;


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

## Changes

* Improved type safety across portfolio `Rule` models.
* Enhanced default parameter handling in `getSettings` for all rule classes by safely falling back to `DEFAULT_CURRENCY` and `DEFAULT_LOCALE`.
* Fixed unsafe currency conversion in `Rule.groupCurrentHoldingsByAttribute` by providing a fallback to `baseCurrency` when `assetProfile.currency` is undefined.
* Resolved undefined checks and nullability errors for `maxAccount` calculations in `AccountClusterRiskCurrentInvestment`.
* Marked optional OIDC configuration fields (`OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER`) as optional properties (`?`).

## Resolved type errors

36 errors (before: 740, after: 704)
