### PR TITLE
Add SPLIT activity type to the database schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added the `SPLIT` activity type to the database schema as a foundation for upcoming stock split support
+
 ### Changed
 
 - Deprecated `firstOrderDate` in favor of `dateOfFirstActivity` in the `GET api/v2/portfolio/performance` endpoint

--- a/prisma/migrations/20260726075759_added_split_activity_type/migration.sql
+++ b/prisma/migrations/20260726075759_added_split_activity_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Type" ADD VALUE 'SPLIT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -379,6 +379,7 @@ enum Type {
   INTEREST
   LIABILITY
   SELL
+  SPLIT
 }
 
 enum ViewMode {


### PR DESCRIPTION
Picks up the `SPLIT` activity type discussed in #1072 and previously drafted in #3211.

Following @dtslvr's suggestion in #1072 to start with the core stock split functionality before any GUI or automatic import, this is split into three independent, incrementally-reviewable PRs. This is PR 1 of 3.

## This PR

- Adds the `SPLIT` value to the `Type` enum in the Prisma schema
- Adds the corresponding migration

The type is dormant here — nothing reads or writes it yet, so this is safe to merge on its own.

## Design (for context on the follow-up PRs)

The `quantity` field carries the split ratio:
- a positive value is a forward split multiplier (`2` = 2-for-1)
- a negative value is a reverse split divisor (`-2` = 1-for-2)

A split has no effect on cost basis, invested amount or cash — only the cumulative share quantity changes.

## Follow-up PRs

1. **This PR** — `SPLIT` in the database schema (dormant)
2. Allow a negative `quantity` for `SPLIT` in the create/update order DTO validation, reject `quantity: 0`
3. Apply `SPLIT` activities to the running share quantity in the portfolio calculator (chronological order, no GUI/automatic import yet)

Happy to adjust the design based on feedback before continuing with 2 and 3.
