### PR TITLE
Bugfix/historical market data dates shifting to the previous day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the platform logo to the account selector in the create or update activity dialog
 
+### Fixed
+
+- Fixed the date handling in the historical market data editor so entries no longer shift to the previous day for users in timezones behind UTC
+
 ## 3.42.0 - 2026-08-04
 
 ### Changed

--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@ghostfolio/common/config';
 import {
   extractNumberFromString,
+  getLocalDateFromUtcDate,
   getNumberFormatGroup,
   getStringOrNull,
   getStringOrUndefined,
@@ -353,6 +354,38 @@ describe('Helper', () => {
       expect(
         isValidCustomAssetProfileSymbol('7e91b7d4-1430-4212-8380-289a06c9bbc1')
       ).toEqual(true);
+    });
+  });
+
+  describe('Get local date from UTC date', () => {
+    const originalTz = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = originalTz;
+    });
+
+    it('Preserve the calendar date in a timezone behind UTC', () => {
+      process.env.TZ = 'America/New_York';
+
+      const localDate = getLocalDateFromUtcDate(
+        new Date('2026-01-05T00:00:00.000Z')
+      );
+
+      expect(localDate.getFullYear()).toEqual(2026);
+      expect(localDate.getMonth()).toEqual(0);
+      expect(localDate.getDate()).toEqual(5);
+    });
+
+    it('Preserve the calendar date in a timezone ahead of UTC', () => {
+      process.env.TZ = 'Asia/Tokyo';
+
+      const localDate = getLocalDateFromUtcDate(
+        new Date('2026-01-05T00:00:00.000Z')
+      );
+
+      expect(localDate.getFullYear()).toEqual(2026);
+      expect(localDate.getMonth()).toEqual(0);
+      expect(localDate.getDate()).toEqual(5);
     });
   });
 });

--- a/libs/common/src/lib/helper.ts
+++ b/libs/common/src/lib/helper.ts
@@ -359,6 +359,14 @@ export function getEmojiFlag(aCountryCode: string) {
     );
 }
 
+export function getLocalDateFromUtcDate(aUtcDate: Date) {
+  return new Date(
+    aUtcDate.getUTCFullYear(),
+    aUtcDate.getUTCMonth(),
+    aUtcDate.getUTCDate()
+  );
+}
+
 export function getLocale() {
   return navigator.language ?? DEFAULT_LOCALE;
 }

--- a/libs/ui/src/lib/services/data.service.ts
+++ b/libs/ui/src/lib/services/data.service.ts
@@ -16,7 +16,10 @@ import {
   UpdateTagDto,
   UpdateUserSettingDto
 } from '@ghostfolio/common/dtos';
-import { DATE_FORMAT } from '@ghostfolio/common/helper';
+import {
+  DATE_FORMAT,
+  getLocalDateFromUtcDate
+} from '@ghostfolio/common/helper';
 import {
   Access,
   AccessTokenResponse,
@@ -586,7 +589,7 @@ export class DataService {
       .pipe(
         map((data) => {
           for (const item of data.marketData) {
-            item.date = parseISO(item.date);
+            item.date = getLocalDateFromUtcDate(parseISO(item.date));
           }
 
           for (const item of data.splits ?? []) {


### PR DESCRIPTION
## Summary

- Historical market data entries (added via CSV import or the admin GUI's day-square editor) were being saved/displayed one day earlier than specified, for any user in a timezone behind UTC.
- Root cause: `fetchMarketDataBySymbol()` in `libs/ui/src/lib/services/data.service.ts` kept the raw UTC instant returned by the API (the backend stores date-only values at UTC midnight). Downstream, `historical-market-data-editor.component.ts` buckets/formats these dates with date-fns `format()`, which reads the browser's **local** timezone — so a UTC-midnight instant renders as the previous calendar day for anyone west of UTC (e.g. `2026-01-05T00:00:00.000Z` → Jan 4 in `America/New_York`).
- Fix: normalize the date once at the fetch boundary, rebuilding it from its UTC calendar components (`getLocalDateFromUtcDate`, added to `libs/common/src/lib/helper.ts` alongside the existing `getStartOfUtcDate`/`resetHours` date utilities). Every downstream local-time `format()` call then reads the correct day, regardless of the browser's offset.
- Scoped to the frontend read path only; the backend's `parseISO` write path and other `MarketData.date` consumers are untouched (not reported as affected).

## Test plan

- [x] Added unit tests in `libs/common/src/lib/helper.spec.ts` covering a timezone behind UTC (`America/New_York`) and ahead of UTC (`Asia/Tokyo`); manually confirmed the bug reproduces without the fix (`getDate()` → 4) and is corrected with it (`getDate()` → 5)
- [x] `npx nx test common` — 42/42 passed
- [x] `npx nx test ui --testPathPattern=historical-market-data-editor` — 6/6 passed
- [x] `npx nx lint common` / `npx nx lint ui` — 0 errors
- [x] `npm test` (full suite) — 25 passed, 2 pre-existing skips, 0 failed

Closes #6177