### PR TITLE
Bugfix/fix validation of empty url in asset profile dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the validation of an empty url in the asset profile dialog of the admin control panel
+
 ## 3.39.0 - 2026-08-01
 
 ### Changed

--- a/libs/common/src/lib/dtos/update-asset-profile.dto.ts
+++ b/libs/common/src/lib/dtos/update-asset-profile.dto.ts
@@ -7,7 +7,7 @@ import {
   DataSource,
   Prisma
 } from '@prisma/client';
-import { Type } from 'class-transformer';
+import { Transform, TransformFnParams, Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -18,6 +18,7 @@ import {
   IsUrl,
   ValidateNested
 } from 'class-validator';
+import { isString } from 'lodash';
 
 import { CountryDto } from './country.dto';
 import { HoldingDto } from './holding.dto';
@@ -96,5 +97,8 @@ export class UpdateAssetProfileDto {
     protocols: ['http', 'https'],
     require_protocol: true
   })
+  @Transform(({ value }: TransformFnParams) =>
+    isString(value) && value.trim() === '' ? undefined : value
+  )
   url?: string;
 }


### PR DESCRIPTION
## Problem

The url attribute in the asset profile dialog of the admin control panel is optional, but saving the dialog with an empty url field fails with the validation error "url must be a URL address", which makes the url appear to be required.

## Root cause

The form initializes the url control with an empty string (`''`). On submit, `url: this.assetProfileForm.controls.url.value ?? undefined` passes the empty string through, since `??` only catches `null` and `undefined`. In `UpdateAssetProfileDto`, the `@IsOptional()` decorator also only skips `null` and `undefined`, so `@IsUrl()` runs against `''` and rejects it.

## Steps to reproduce

1. Log in as admin and open the *Admin Control* panel → *Market Data*
2. Create an asset profile (e.g. via *Add Manually*)
3. Open the asset profile, fill in a name, leave the url field empty
4. Save → the url field shows "url must be a URL address"

## Fix

Add a `@Transform` to the `url` attribute of `UpdateAssetProfileDto` that maps empty (or whitespace-only) strings to `undefined`, following the existing pattern used in `CreateAccountDto`. Since the global `ValidationPipe` runs with `transform: true` and the client-side pre-validation uses `plainToInstance`, both validation paths are covered by the single change.

Verified behavior:

| Input | After transform | Validation |
| --- | --- | --- |
| `''` | `undefined` | ✅ passes |
| `'   '` | `undefined` | ✅ passes |
| `'https://example.com'` | unchanged | ✅ passes |
| `'not-a-url'` | unchanged | ❌ rejected (unchanged behavior) |

Also adds a changelog entry under *Unreleased*.