### PR TITLE
Bugfix/duplicate asset profile creation on activity import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the activity import so it no longer fails when multiple rows create the same new manual asset profile
 - Fixed the handling of the _Exclude from Analysis_ tag in the activities table
 - Fixed the persistence of an empty comment in the create or update account dialog
 - Resolved a validation error caused by empty strings in the asset profile details dialog of the admin control panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the activity import so it no longer fails when multiple rows create the same new manual asset profile
+- Fixed the activity import to reuse an existing manual asset profile of the admin control panel instead of duplicating it
+
 ## 3.41.0 - 2026-08-03
 
 ### Added
@@ -36,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the activity import so it no longer fails when multiple rows create the same new manual asset profile
 - Fixed the handling of the _Exclude from Analysis_ tag in the activities table
 - Fixed the persistence of an empty comment in the create or update account dialog
 - Resolved a validation error caused by empty strings in the asset profile details dialog of the admin control panel

--- a/apps/api/src/app/import/import.service.spec.ts
+++ b/apps/api/src/app/import/import.service.spec.ts
@@ -1,0 +1,232 @@
+import { AccountService } from '@ghostfolio/api/app/account/account.service';
+import { ActivitiesService } from '@ghostfolio/api/app/activities/activities.service';
+import { DataProviderService } from '@ghostfolio/api/services/data-provider/data-provider.service';
+import { ExchangeRateDataService } from '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service';
+import { MarketDataService } from '@ghostfolio/api/services/market-data/market-data.service';
+import { DataGatheringService } from '@ghostfolio/api/services/queues/data-gathering/data-gathering.service';
+import { SymbolProfileService } from '@ghostfolio/api/services/symbol-profile/symbol-profile.service';
+import { TagService } from '@ghostfolio/api/services/tag/tag.service';
+import { UserWithSettings } from '@ghostfolio/common/types';
+
+import { DataSource } from '@prisma/client';
+
+import { ImportService } from './import.service';
+
+jest.mock('@ghostfolio/api/app/account/account.service', () => {
+  return {
+    AccountService: jest.fn().mockImplementation(() => {
+      return {
+        getAccounts: () => Promise.resolve([])
+      };
+    })
+  };
+});
+
+jest.mock('@ghostfolio/api/app/activities/activities.service', () => {
+  return {
+    ActivitiesService: jest.fn().mockImplementation(() => {
+      return {
+        getActivities: () => Promise.resolve({ activities: [] }),
+        createActivity: () => {
+          return Promise.resolve({
+            id: 'ee3949fa-9df5-4b4e-9856-14dd1cfe9c86',
+            SymbolProfile: { symbol: 'Repeated Fee' }
+          });
+        }
+      };
+    })
+  };
+});
+
+jest.mock(
+  '@ghostfolio/api/services/data-provider/data-provider.service',
+  () => {
+    return {
+      DataProviderService: jest.fn().mockImplementation(() => {
+        return {
+          getDataSourceForImport: () => DataSource.MANUAL,
+          validateActivities: () => Promise.resolve({})
+        };
+      })
+    };
+  }
+);
+
+jest.mock(
+  '@ghostfolio/api/services/exchange-rate-data/exchange-rate-data.service',
+  () => {
+    return {
+      ExchangeRateDataService: jest.fn().mockImplementation(() => {
+        return {
+          toCurrencyAtDate: () => Promise.resolve(0)
+        };
+      })
+    };
+  }
+);
+
+jest.mock('@ghostfolio/api/services/market-data/market-data.service', () => {
+  return {
+    MarketDataService: jest.fn().mockImplementation(() => {
+      return {
+        updateMany: () => Promise.resolve()
+      };
+    })
+  };
+});
+
+jest.mock(
+  '@ghostfolio/api/services/queues/data-gathering/data-gathering.service',
+  () => {
+    return {
+      DataGatheringService: jest.fn().mockImplementation(() => {
+        return {
+          gatherSymbols: () => undefined
+        };
+      })
+    };
+  }
+);
+
+jest.mock(
+  '@ghostfolio/api/services/symbol-profile/symbol-profile.service',
+  () => {
+    return {
+      SymbolProfileService: jest.fn().mockImplementation(() => {
+        return {
+          add: jest.fn().mockResolvedValue(undefined),
+          getSymbolProfiles: () => Promise.resolve([])
+        };
+      })
+    };
+  }
+);
+
+jest.mock('@ghostfolio/api/services/tag/tag.service', () => {
+  return {
+    TagService: jest.fn().mockImplementation(() => {
+      return {
+        getTagsForUser: () => Promise.resolve([])
+      };
+    })
+  };
+});
+
+describe('ImportService', () => {
+  let accountService: AccountService;
+  let activitiesService: ActivitiesService;
+  let dataGatheringService: DataGatheringService;
+  let dataProviderService: DataProviderService;
+  let exchangeRateDataService: ExchangeRateDataService;
+  let importService: ImportService;
+  let marketDataService: MarketDataService;
+  let symbolProfileService: SymbolProfileService;
+  let tagService: TagService;
+
+  beforeEach(() => {
+    accountService = new AccountService(null, null, null, null, null);
+    activitiesService = new ActivitiesService(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
+    dataGatheringService = new DataGatheringService(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
+    dataProviderService = new DataProviderService(
+      null,
+      [],
+      null,
+      null,
+      null,
+      null
+    );
+    exchangeRateDataService = new ExchangeRateDataService(
+      null,
+      null,
+      null,
+      null
+    );
+    marketDataService = new MarketDataService(null);
+    symbolProfileService = new SymbolProfileService(null);
+    tagService = new TagService(null);
+
+    importService = new ImportService(
+      accountService,
+      activitiesService,
+      null,
+      dataGatheringService,
+      dataProviderService,
+      exchangeRateDataService,
+      marketDataService,
+      null,
+      null,
+      symbolProfileService,
+      tagService
+    );
+  });
+
+  it('creates only one asset profile when the import payload contains duplicate new manual asset profiles', async () => {
+    const user = {
+      id: 'da8a5786-1223-4a51-9a86-2b60433c9f3f',
+      permissions: [],
+      settings: { settings: { baseCurrency: 'USD' } }
+    } as unknown as UserWithSettings;
+
+    const assetProfile = {
+      currency: 'USD',
+      dataSource: DataSource.MANUAL,
+      isActive: true,
+      marketData: [],
+      name: 'Repeated Fee',
+      symbol: 'Repeated Fee'
+    };
+
+    await importService.import({
+      accountsWithBalancesDto: [],
+      activitiesDto: [
+        {
+          currency: 'USD',
+          dataSource: DataSource.MANUAL,
+          date: '2024-01-01T00:00:00.000Z',
+          fee: 1,
+          quantity: 0,
+          symbol: 'Repeated Fee',
+          type: 'FEE',
+          unitPrice: 0
+        },
+        {
+          currency: 'USD',
+          dataSource: DataSource.MANUAL,
+          date: '2024-01-02T00:00:00.000Z',
+          fee: 1,
+          quantity: 0,
+          symbol: 'Repeated Fee',
+          type: 'FEE',
+          unitPrice: 0
+        }
+      ],
+      assetProfilesWithMarketDataDto: [assetProfile, assetProfile],
+      maxActivitiesToImport: 10,
+      tagsDto: [],
+      user
+    });
+
+    expect(symbolProfileService.add).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/app/import/import.service.spec.ts
+++ b/apps/api/src/app/import/import.service.spec.ts
@@ -8,9 +8,11 @@ import { SymbolProfileService } from '@ghostfolio/api/services/symbol-profile/sy
 import { TagService } from '@ghostfolio/api/services/tag/tag.service';
 import { UserWithSettings } from '@ghostfolio/common/types';
 
-import { DataSource } from '@prisma/client';
+import { DataSource, SymbolProfile } from '@prisma/client';
 
 import { ImportService } from './import.service';
+
+let mockExistingAssetProfiles: Partial<SymbolProfile>[] = [];
 
 jest.mock('@ghostfolio/api/app/account/account.service', () => {
   return {
@@ -27,12 +29,14 @@ jest.mock('@ghostfolio/api/app/activities/activities.service', () => {
     ActivitiesService: jest.fn().mockImplementation(() => {
       return {
         getActivities: () => Promise.resolve({ activities: [] }),
-        createActivity: () => {
+        createActivity: jest.fn().mockImplementation((data) => {
           return Promise.resolve({
             id: 'ee3949fa-9df5-4b4e-9856-14dd1cfe9c86',
-            SymbolProfile: { symbol: 'Repeated Fee' }
+            SymbolProfile: {
+              symbol: data.SymbolProfile.connectOrCreate.create.symbol
+            }
           });
-        }
+        })
       };
     })
   };
@@ -95,7 +99,7 @@ jest.mock(
       SymbolProfileService: jest.fn().mockImplementation(() => {
         return {
           add: jest.fn().mockResolvedValue(undefined),
-          getSymbolProfiles: () => Promise.resolve([])
+          getSymbolProfiles: () => Promise.resolve(mockExistingAssetProfiles)
         };
       })
     };
@@ -124,6 +128,8 @@ describe('ImportService', () => {
   let tagService: TagService;
 
   beforeEach(() => {
+    mockExistingAssetProfiles = [];
+
     accountService = new AccountService(null, null, null, null, null);
     activitiesService = new ActivitiesService(
       null,
@@ -223,10 +229,108 @@ describe('ImportService', () => {
       ],
       assetProfilesWithMarketDataDto: [assetProfile, assetProfile],
       maxActivitiesToImport: 10,
+      platformsDto: [],
       tagsDto: [],
       user
     });
 
     expect(symbolProfileService.add).toHaveBeenCalledTimes(1);
   });
+
+  it('reuses an existing manual asset profile without a user', async () => {
+    mockExistingAssetProfiles = [
+      {
+        currency: 'USD',
+        dataSource: DataSource.MANUAL,
+        name: 'Manual Asset Profile',
+        symbol: 'GF_MANUAL',
+        userId: null
+      }
+    ];
+
+    await importActivitiesWithExistingAssetProfile();
+
+    expect(symbolProfileService.add).not.toHaveBeenCalled();
+
+    for (const [{ SymbolProfile }] of (
+      activitiesService.createActivity as jest.Mock
+    ).mock.calls) {
+      expect(SymbolProfile.connectOrCreate.create.symbol).toEqual('GF_MANUAL');
+    }
+  });
+
+  it('creates a new asset profile when the existing manual asset profile belongs to a different user', async () => {
+    mockExistingAssetProfiles = [
+      {
+        currency: 'USD',
+        dataSource: DataSource.MANUAL,
+        name: 'Manual Asset Profile',
+        symbol: 'GF_MANUAL',
+        userId: '5b7a1b3a-1f1c-4c7a-9a1a-3a1b5b7a1b3a'
+      }
+    ];
+
+    await importActivitiesWithExistingAssetProfile();
+
+    expect(symbolProfileService.add).toHaveBeenCalledTimes(1);
+
+    const [[{ symbol }]] = (symbolProfileService.add as jest.Mock).mock.calls;
+
+    expect(symbol).not.toEqual('GF_MANUAL');
+
+    for (const [{ SymbolProfile }] of (
+      activitiesService.createActivity as jest.Mock
+    ).mock.calls) {
+      expect(SymbolProfile.connectOrCreate.create.symbol).toEqual(symbol);
+    }
+  });
+
+  function importActivitiesWithExistingAssetProfile() {
+    const user = {
+      id: 'da8a5786-1223-4a51-9a86-2b60433c9f3f',
+      permissions: [],
+      settings: { settings: { baseCurrency: 'USD' } }
+    } as unknown as UserWithSettings;
+
+    // The client creates a synthetic asset profile per activity
+    const assetProfile = {
+      currency: 'USD',
+      dataSource: DataSource.MANUAL,
+      isActive: true,
+      marketData: [],
+      name: 'GF_MANUAL',
+      symbol: 'GF_MANUAL'
+    };
+
+    return importService.import({
+      accountsWithBalancesDto: [],
+      activitiesDto: [
+        {
+          currency: 'USD',
+          dataSource: DataSource.MANUAL,
+          date: '2024-01-01T00:00:00.000Z',
+          fee: 0,
+          quantity: 1,
+          symbol: 'GF_MANUAL',
+          type: 'BUY',
+          unitPrice: 1
+        },
+        {
+          currency: 'USD',
+          dataSource: DataSource.MANUAL,
+          date: '2024-01-02T00:00:00.000Z',
+          fee: 0,
+          quantity: 2,
+          symbol: 'GF_MANUAL',
+          type: 'BUY',
+          unitPrice: 1
+        }
+      ],
+      assetProfilesWithMarketDataDto: [assetProfile, assetProfile],
+      maxActivitiesToImport: 10,
+      platformsDto: [],
+      tagsDto: [],
+      user
+    });
+  }
 });

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -413,9 +413,13 @@ export class ImportService {
         // If there is no asset profile or if the asset profile belongs to a
         // different user, then create a new asset profile, unless it has
         // already been created earlier in this loop (e.g. multiple imported
-        // activities referencing the same new manual asset profile)
+        // activities referencing the same new manual asset profile). An asset
+        // profile without a user is shared, for example created via the admin
+        // control panel, and is reused as is
         if (
-          (!existingAssetProfile || existingAssetProfile.userId !== user.id) &&
+          (!existingAssetProfile ||
+            (existingAssetProfile.userId &&
+              existingAssetProfile.userId !== user.id)) &&
           !createdAssetProfileIdentifiers.has(assetProfileIdentifier)
         ) {
           const assetProfile: CreateAssetProfileDto = omit(

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -392,7 +392,14 @@ export class ImportService {
           })
         );
 
+      const createdAssetProfileIdentifiers = new Set<string>();
+
       for (const assetProfileWithMarketData of assetProfilesWithMarketDataDto) {
+        const assetProfileIdentifier = getAssetProfileIdentifier({
+          dataSource: assetProfileWithMarketData.dataSource,
+          symbol: assetProfileWithMarketData.symbol
+        });
+
         // Check if there is any existing asset profile
         const existingAssetProfile = existingAssetProfiles.find(
           ({ dataSource, symbol }) => {
@@ -403,8 +410,14 @@ export class ImportService {
           }
         );
 
-        // If there is no asset profile or if the asset profile belongs to a different user, then create a new asset profile
-        if (!existingAssetProfile || existingAssetProfile.userId !== user.id) {
+        // If there is no asset profile or if the asset profile belongs to a
+        // different user, then create a new asset profile, unless it has
+        // already been created earlier in this loop (e.g. multiple imported
+        // activities referencing the same new manual asset profile)
+        if (
+          (!existingAssetProfile || existingAssetProfile.userId !== user.id) &&
+          !createdAssetProfileIdentifiers.has(assetProfileIdentifier)
+        ) {
           const assetProfile: CreateAssetProfileDto = omit(
             assetProfileWithMarketData,
             'marketData'
@@ -424,6 +437,7 @@ export class ImportService {
           };
 
           await this.symbolProfileService.add(assetProfileObject);
+          createdAssetProfileIdentifiers.add(assetProfileIdentifier);
         }
 
         // Insert or update market data


### PR DESCRIPTION
## Summary

Closes #7459.

The activity import can create duplicate `SymbolProfile` rows for the same manual symbol. There are two independent causes, both in the asset profile loop of `ImportService.import()` (`apps/api/src/app/import/import.service.ts`). This PR fixes both, since the second one was reported in the issue thread while the first was under review.

Relevant context for both: for a CSV import the client pushes **one synthetic asset profile per row** (`apps/client/src/app/services/import-activities.service.ts`, `importCsv()`), so a file with N rows for the same manual symbol sends N identical `{ dataSource, symbol }` entries.

### 1. Import fails with a unique constraint violation

`existingAssetProfiles` is fetched once before the loop and never refreshed as the loop creates rows. With two entries for the same *new* symbol, the first iteration creates the `SymbolProfile` and the second still sees the pre-loop snapshot, decides no profile exists yet, and calls `symbolProfileService.add()` again — producing the `SymbolProfile_dataSource_symbol_key` violation and the unhandled `P2002` in the issue's log. This is deterministic within a single request; it does not require actual concurrency.

Fix: track the asset profile identifiers already created during the loop (via the existing `getAssetProfileIdentifier` helper) and skip the redundant `add()`.

### 2. An existing manual asset profile is duplicated instead of reused

Reported by @schultzter in the thread: creating the asset profile manually beforehand does not help, and the import produces a set of duplicates.

An asset profile created through _Admin -> Asset Profiles_ is stored **without a user** — `addAssetProfile()` (`apps/api/src/app/admin/admin.service.ts`) calls `symbolProfileService.add({ currency, dataSource, symbol })` with no `user` connect, so `userId` is `null`. The loop then evaluates `existingAssetProfile.userId !== user.id`, which is true for `null`, concludes the profile belongs to a different user, and clones it under a `randomUUID()` symbol. The imported activities are remapped to the clone via `assetProfileSymbolMapping` while the original asset profile stays empty — matching the screenshots in the issue, where the profile holding the activities has a UUID symbol and the name of the original symbol.

Fix: only clone when the existing asset profile belongs to a *different* user, so an asset profile without a user is reused as is.

### Note on asset profiles without a user

An asset profile with `userId === null` and `dataSource === MANUAL` can only originate from the admin control panel — `POST admin/profile-data/:dataSource/:symbol` is gated by `permissions.accessAdminControl`, and every user facing creation path (`import.service.ts`, `activities.service.ts`) sets `userId`. Such an asset profile is therefore an intentionally shared one rather than another user's private one, which is what the clone branch was meant to protect.

This also aligns the asset profile loop with the activity creation a few lines below, which already connects on `{ dataSource, symbol }` through `connectOrCreate` without any ownership check.

## Test plan

Added `apps/api/src/app/import/import.service.spec.ts` with three cases, each verified to fail before the corresponding fix and pass after:

- duplicate entries for the same new manual asset profile result in exactly one `symbolProfileService.add()` call
- an existing manual asset profile without a user is reused: no `add()` call, and the activities connect to the original symbol
- an existing manual asset profile owned by a different user is still cloned under a new symbol, and the activities follow the clone

Checks (rebased onto `main` at 3.41.0):

- `npx nx test api` — 42 passed, 0 failed
- `npx nx lint api` — 0 errors
- Prettier — clean
