### PR TITLE
Bugfix/allocation percentages in accounts section of holding detail dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the platform logo to the account selector in the create or update activity dialog
 
+### Fixed
+
+- Fixed the allocation percentages in the accounts section of the holding detail dialog by excluding the cash balances
+
 ## 3.42.0 - 2026-08-04
 
 ### Changed

--- a/apps/api/src/app/portfolio/portfolio.service.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.spec.ts
@@ -509,5 +509,36 @@ describe('PortfolioService', () => {
       expect(accounts[UNKNOWN_KEY]).toBeUndefined();
       expect(platforms[UNKNOWN_KEY]).toBeUndefined();
     });
+
+    it('should exclude the cash balance when filtering by a holding', async () => {
+      jest
+        .spyOn(accountService, 'accounts')
+        .mockResolvedValue([account] as unknown as Account[]);
+
+      const { accounts, platforms } = await getValueOfAccountsAndPlatforms({
+        activities: [
+          {
+            account,
+            accountId: account.id,
+            assetProfile: { symbol: 'AAPL' },
+            quantity: 1,
+            type: 'BUY'
+          }
+        ],
+        filters: [
+          { id: DataSource.YAHOO, type: 'DATA_SOURCE' },
+          { id: 'AAPL', type: 'SYMBOL' }
+        ],
+        portfolioItemsNow: {
+          AAPL: { marketPriceInBaseCurrency: 10 }
+        },
+        userCurrency: 'USD',
+        userId: userDummyData.id
+      });
+
+      // 1 * 10 (activity), without the balance of 100
+      expect(accounts[account.id].valueInBaseCurrency).toBe(10);
+      expect(platforms[account.platformId].valueInBaseCurrency).toBe(10);
+    });
   });
 });

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -2142,6 +2142,15 @@ export class PortfolioService {
     const accounts: PortfolioDetails['accounts'] = {};
     const platforms: PortfolioDetails['platforms'] = {};
 
+    const {
+      DATA_SOURCE: [filterByDataSource] = [],
+      SYMBOL: [filterBySymbol] = []
+    } = groupBy(filters, ({ type }) => {
+      return type;
+    });
+
+    const isFilteredByHolding = !!(filterByDataSource && filterBySymbol);
+
     let currentAccounts: (Account & {
       Order?: Order[];
       platform?: Platform;
@@ -2185,7 +2194,9 @@ export class PortfolioService {
         return account ? accountId === account.id : !accountId;
       });
 
-      if (account) {
+      // Skip the cash balance if the request is filtered by a holding, so that
+      // the values of the accounts and platforms reflect this holding only
+      if (account && !isFilteredByHolding) {
         accounts[account.id] = {
           balance: account.balance,
           currency: account.currency,


### PR DESCRIPTION
## Summary

Closes #5936.

The allocation percentages in the _Accounts_ tab of the holding detail dialog are computed from each account's **cash balance plus** the holding, instead of the holding alone. In the report, an account holding 1 of 18 shares is shown as 46.29% instead of ~5.55%.

## Root cause

1. The _Accounts_ tab requests the accounts scoped to the holding: `getActivityFilters()` returns `DATA_SOURCE` and `SYMBOL` (`apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.component.ts`), passed to `fetchAccounts()`.
2. `PortfolioService.getAccountsWithAggregations()` -> `getAccounts({ filters })` -> `getDetails({ filters })` -> `getValueOfAccountsAndPlatforms()` (`apps/api/src/app/portfolio/portfolio.service.ts`).
3. There, the value of every account is seeded with the **full cash balance** of that account, regardless of the filters, before the value of the filtered holding is added.
4. `getAccountsWithAggregations()` derives `allocationInPercentage` from those values, so an account with a large cash balance dominates the percentage.

The activities feeding the same calculation are already filtered by `DATA_SOURCE` and `SYMBOL` in `getActivitiesForPortfolioCalculator()`, so every other holding is excluded. The cash balance was the only component that was not filter-aware.

## Fix

Skip the cash balance in `getValueOfAccountsAndPlatforms()` when the request is filtered by a holding, reusing the same filter destructuring already used in `getAccounts()` in the same file.

The values are then built from the filtered activities only, so the accounts and platforms reflect that holding.

## Scope

`getValueOfAccountsAndPlatforms()` is only reached from `getDetails()`, which has three callers: `getAccounts()` (this path), the holdings lookup (uses `holdings` only) and the X-ray report (no filters). The unfiltered accounts page is therefore unaffected.

The change also applies to `GET /api/v1/portfolio/details` when it is filtered by a holding, so the _By Account_ and _By Platform_ values become holding-scoped there as well, which is consistent with this fix.

The _Cash Balance_ column of the accounts table is not affected: it is derived from `account.balance` in `getAccounts()`, not from `getDetails()`. It is also hidden in this dialog (`showBalance` is `false`).

## Verification

The activities exported in the issue reproduce the reported numbers: with 17 shares and 557.90 EUR at one account and 1 share and 585.03 EUR at the other, `(cash + holding) / total` yields 46.29% for a market price of 7.6331 EUR, and `holding / total` yields 5.56%.

## Test plan

- [x] Added a case to the existing `getValueOfAccountsAndPlatforms` suite in `apps/api/src/app/portfolio/portfolio.service.spec.ts`: filtered by `DATA_SOURCE` and `SYMBOL`, an account with a balance of 100 and a single position of 1 x 10 results in a value of 10 instead of 110, for both the account and the platform. Verified to fail before the fix and pass after.
- [x] The two existing tests of that method (unfiltered) still pass and cover the accounts page including the cash balances.
- [x] `npx nx test api` - 40 passed, 0 failed
- [x] `npx nx lint api` - 0 errors
- [x] Prettier - clean
