### PR TITLE
Bugfix/normalize date in market data update endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the check for duplicates in the preview step of the activities import for activities without a comment
 - Fixed the holdings mock data in the _Storybook_ story of the portfolio filter form component
+- Fixed the date normalization in the market data update endpoint to prevent duplicate entries on servers running in a non-UTC time zone
 
 ## 3.44.0 - 2026-08-07
 

--- a/apps/api/src/app/endpoints/market-data/market-data.controller.ts
+++ b/apps/api/src/app/endpoints/market-data/market-data.controller.ts
@@ -4,7 +4,12 @@ import { HasPermissionGuard } from '@ghostfolio/api/guards/has-permission.guard'
 import { MarketDataService } from '@ghostfolio/api/services/market-data/market-data.service';
 import { SymbolProfileService } from '@ghostfolio/api/services/symbol-profile/symbol-profile.service';
 import { UpdateBulkMarketDataDto } from '@ghostfolio/common/dtos';
-import { getCurrencyFromSymbol, isCurrency } from '@ghostfolio/common/helper';
+import {
+  getCurrencyFromSymbol,
+  isCurrency,
+  parseDate,
+  resetHours
+} from '@ghostfolio/common/helper';
 import { MarketDataOfMarketsResponse } from '@ghostfolio/common/interfaces';
 import { hasPermission, permissions } from '@ghostfolio/common/permissions';
 import { RequestWithUser } from '@ghostfolio/common/types';
@@ -24,7 +29,6 @@ import {
 import { REQUEST } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { DataSource, Prisma } from '@prisma/client';
-import { parseISO } from 'date-fns';
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 
 @Controller('market-data')
@@ -99,7 +103,7 @@ export class MarketDataController {
         dataSource,
         marketPrice,
         symbol,
-        date: parseISO(date),
+        date: resetHours(parseDate(date)),
         state: 'CLOSE'
       })
     );


### PR DESCRIPTION
## Problem

`POST /market-data/:dataSource/:symbol` parses the incoming date with
`parseISO(date)`. For a date-only string, `parseISO` returns **local**
midnight.

The data gathering path stores market data at **UTC** midnight, via
`resetHours` in `market-data.service.ts`:

```ts
date: resetHours(date);

On any server not running in UTC, the two disagree. Because MarketData is
keyed on (dataSource, date, symbol), the upsert then fails to match the
existing row and writes a duplicate one UTC offset away.

Reproduction

Parsing the input "2026-08-07":

┌───────────────────┬──────────────────────────┬───────────────────┐
│        TZ         │  parseISO('2026-08-07')  │                   │
├───────────────────┼──────────────────────────┼───────────────────┤
│ UTC               │ 2026-08-07T00:00:00.000Z │ matches gathering │
├───────────────────┼──────────────────────────┼───────────────────┤
│ Europe/Lisbon     │ 2026-08-06T23:00:00.000Z │ off by −1h        │
├───────────────────┼──────────────────────────┼───────────────────┤
│ America/Sao_Paulo │ 2026-08-07T03:00:00.000Z │ off by +3h        │
├───────────────────┼──────────────────────────┼───────────────────┤
│ Asia/Tokyo        │ 2026-08-06T15:00:00.000Z │ off by −9h        │
└───────────────────┴──────────────────────────┴───────────────────┘

TZ=Asia/Tokyo node -e "const {parseISO}=require('date-fns'); \
  console.log(parseISO('2026-08-07').toISOString())"
# 2026-08-06T15:00:00.000Z

Only a UTC host produces the value the rest of the codebase expects, which is
likely why this has gone unnoticed — containers commonly default to UTC.

Fix

-        date: parseISO(date),
+        date: resetHours(parseDate(date)),

resetHours(parseDate(date)) yields 2026-08-07T00:00:00.000Z in every time
zone. This is not a new convention: it is the same idiom already used by
market-data.service.ts, exchange-rate-data.service.ts and
data-gathering.service.ts, so the endpoint now agrees with the rest of the
codebase instead of only on UTC hosts. parseISO from date-fns is no longer
needed here and its import is dropped.

Notes

- One behavioural line changed; no API or schema change.
- nx lint api passes; Prettier-formatted.
- CHANGELOG entry added under Unreleased → Fixed.
- Found while bulk-importing historical market data on a Europe/Lisbon
host, where every imported day landed 1h before the gathered rows and
silently duplicated them.