### PR TITLE
fix: add safe-area-inset-bottom padding to gf-page-tabs component (Closes #6878)

### DIFF
--- a/libs/ui/src/lib/page-tabs/page-tabs.component.scss
+++ b/libs/ui/src/lib/page-tabs/page-tabs.component.scss
@@ -4,6 +4,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: constant(safe-area-inset-bottom);
   width: 100%;
 
   .external-link-icon {


### PR DESCRIPTION
## Summary

Fix #6878: The bottom navigation tab bar overlaps the iOS home indicator on mobile devices.

### Root cause

Following the refactoring in #6797, the tab navigation was extracted into a standalone `<gf-page-tabs>` component. The `padding-bottom: env(safe-area-inset-bottom)` rule was left behind on the global `.page` class in `styles.scss` rather than being brought into the new component.

Because the `<gf-page-tabs>` layout enforces `height: 100%`, it fully overrides its parent container's padding. This causes the bottom navigation bar to stretch entirely to the bottom edge of the screen, overlapping the iOS home indicator.

### Fix

Added `padding-bottom: env(safe-area-inset-bottom)` (with `constant()` fallback for older iOS versions) directly to the `:host` of the `gf-page-tabs` component (`page-tabs.component.scss`), so the component natively manages its own safe-area inset.

## Test Plan

- [x] Verified the SCSS change is valid
- [x] The `padding-bottom` applies to the component's host element, floating the bottom tabs above the iOS home indicator
- [x] `constant()` fallback retained for iOS < 11.2 compatibility (mirrors existing pattern in `styles.scss`)

Closes #6878