### PR TITLE
Bugfix/rounding of value per account and platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the allocation in the accounts tab of the holding detail dialog caused by floating-point rounding
+
 ## 3.47.0 - 2026-08-10
 
 ### Changed

--- a/apps/api/src/app/portfolio/portfolio.service.spec.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.spec.ts
@@ -510,5 +510,43 @@ describe('PortfolioService', () => {
       expect(accounts[UNKNOWN_KEY]).toBeUndefined();
       expect(platforms[UNKNOWN_KEY]).toBeUndefined();
     });
+
+    it('should not accumulate rounding errors of activities cancelling each other out', async () => {
+      const { accounts, platforms } = await getValueOfAccountsAndPlatforms({
+        activities: [
+          {
+            account,
+            accountId: account.id,
+            assetProfile: { symbol: 'AAPL' },
+            quantity: 0.1,
+            type: 'BUY'
+          },
+          {
+            account,
+            accountId: account.id,
+            assetProfile: { symbol: 'AAPL' },
+            quantity: 0.2,
+            type: 'BUY'
+          },
+          {
+            account,
+            accountId: account.id,
+            assetProfile: { symbol: 'AAPL' },
+            quantity: 0.3,
+            type: 'SELL'
+          }
+        ],
+        filters: [],
+        portfolioItemsNow: {
+          AAPL: { marketPriceInBaseCurrency: 1234.5678 }
+        },
+        userCurrency: 'USD',
+        userId: userDummyData.id
+      });
+
+      // 100 (balance) + 0 (activities)
+      expect(accounts[account.id].valueInBaseCurrency).toBe(100);
+      expect(platforms[account.platformId].valueInBaseCurrency).toBe(100);
+    });
   });
 });

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -2262,38 +2262,54 @@ export class PortfolioService {
         }
       }
 
-      for (const { account, assetProfile, quantity, type } of ordersByAccount) {
-        const currentValueOfSymbolInBaseCurrency =
-          getFactor(type) *
-          quantity *
-          (portfolioItemsNow[assetProfile.symbol]?.marketPriceInBaseCurrency ??
-            0);
+      if (ordersByAccount.length === 0) {
+        continue;
+      }
 
-        if (accounts[account?.id || UNKNOWN_KEY]?.valueInBaseCurrency) {
-          accounts[account?.id || UNKNOWN_KEY].valueInBaseCurrency +=
-            currentValueOfSymbolInBaseCurrency;
-        } else {
-          accounts[account?.id || UNKNOWN_KEY] = {
-            balance: 0,
-            currency: account?.currency,
-            name: account?.name,
-            valueInBaseCurrency: currentValueOfSymbolInBaseCurrency
-          };
-        }
+      let valueOfAccountInBaseCurrency = new Big(0);
 
-        if (
-          platforms[account?.platformId || UNKNOWN_KEY]?.valueInBaseCurrency
-        ) {
-          platforms[account?.platformId || UNKNOWN_KEY].valueInBaseCurrency +=
-            currentValueOfSymbolInBaseCurrency;
-        } else {
-          platforms[account?.platformId || UNKNOWN_KEY] = {
-            balance: 0,
-            currency: account?.currency,
-            name: account?.platform?.name,
-            valueInBaseCurrency: currentValueOfSymbolInBaseCurrency
-          };
-        }
+      for (const { assetProfile, quantity, type } of ordersByAccount) {
+        valueOfAccountInBaseCurrency = valueOfAccountInBaseCurrency.plus(
+          new Big(quantity)
+            .mul(getFactor(type))
+            .mul(
+              portfolioItemsNow[assetProfile.symbol]
+                ?.marketPriceInBaseCurrency ?? 0
+            )
+        );
+      }
+
+      const currentAccountId = account?.id || UNKNOWN_KEY;
+      const currentPlatformId = account?.platformId || UNKNOWN_KEY;
+
+      if (accounts[currentAccountId]) {
+        accounts[currentAccountId].valueInBaseCurrency = new Big(
+          accounts[currentAccountId].valueInBaseCurrency
+        )
+          .plus(valueOfAccountInBaseCurrency)
+          .toNumber();
+      } else {
+        accounts[currentAccountId] = {
+          balance: 0,
+          currency: account?.currency,
+          name: account?.name,
+          valueInBaseCurrency: valueOfAccountInBaseCurrency.toNumber()
+        };
+      }
+
+      if (platforms[currentPlatformId]) {
+        platforms[currentPlatformId].valueInBaseCurrency = new Big(
+          platforms[currentPlatformId].valueInBaseCurrency
+        )
+          .plus(valueOfAccountInBaseCurrency)
+          .toNumber();
+      } else {
+        platforms[currentPlatformId] = {
+          balance: 0,
+          currency: account?.currency,
+          name: account?.platform?.name,
+          valueInBaseCurrency: valueOfAccountInBaseCurrency.toNumber()
+        };
       }
     }
 


### PR DESCRIPTION
Aggregate the value of accounts and platforms with Big.js, so that activities cancelling each other out result in exactly zero instead of a floating-point residue. Such a residue distorted the allocation per account in the holding detail dialog, e.g. -8.5277e-16 for a closed position and 1.0000000000000009 for the remaining one.