### PR TITLE
Bugfix/cash balance update related to activities in custom currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed the cash balance update related to activities in a custom currency
+
 ## 3.50.0 - 2026-08-13
 
 ### Changed
@@ -18,10 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the missing mapping for Turkey in the country weightings of the _Financial Modeling Prep_ service
 - Fixed the missing mapping for Czech Republic and Turkey in the data enhancer for asset profile data via _Yahoo Finance_
 - Resolved an error when fetching dividends from _Yahoo Finance_ for date ranges without events
-
-### Fixed
-
-- Fixed the cash balance update related to activities in a custom currency
 
 ## 3.49.0 - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the missing mapping for Czech Republic and Turkey in the data enhancer for asset profile data via _Yahoo Finance_
 - Resolved an error when fetching dividends from _Yahoo Finance_ for date ranges without events
 
+### Fixed
+
+- Fixed the currency of the cash balance update when creating an activity to use the activity's currency instead of the asset profile's currency
+
 ## 3.49.0 - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the currency of the cash balance update when creating an activity to use the activity's currency instead of the asset profile's currency
+- Fixed the cash balance update related to activities in a custom currency
 
 ## 3.49.0 - 2026-08-12
 

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -308,8 +308,7 @@ export class ActivitiesService {
         accountId,
         userId,
         amount: amount.toNumber(),
-        currency:
-          data.currency ?? data.SymbolProfile.connectOrCreate.create.currency,
+        currency: activity.currency ?? activity.SymbolProfile.currency,
         date: data.date as Date
       });
     }

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -308,7 +308,8 @@ export class ActivitiesService {
         accountId,
         userId,
         amount: amount.toNumber(),
-        currency: data.SymbolProfile.connectOrCreate.create.currency,
+        currency:
+          data.currency ?? data.SymbolProfile.connectOrCreate.create.currency,
         date: data.date as Date
       });
     }


### PR DESCRIPTION
The cash movement for activities with "Update Cash Balance" enabled used the asset profile's currency instead of the activity's currency.

The amount is derived from the unit price and is therefore denominated in the activity's currency. Using the asset profile's currency caused activities with a currency override to be converted from the wrong unit, silently writing an incorrect account balance.

A EUR 4,000 purchase of 7974.T, quoted in JPY, on a EUR account with a EUR 1 fee debited EUR 21.78 instead of EUR 4,001.00. The EUR 4,001 amount was incorrectly interpreted as JPY and converted using the JPY/EUR exchange rate.

Portfolio valuation is unaffected because it already uses the activity's currency correctly. Only the cash balance drifts.

The fix uses the activity's currency for the balance update and falls back to the asset profile's currency when no activity currency is set. This preserves the existing behavior for activities without a currency override.
