### PR TITLE
Task/upgrade ng-extract-i18n-merge to version 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+### Changed
+
+- Upgraded `ng-extract-i18n-merge` from `3.3.0` to `3.4.0`
+
 ## 3.53.0 - 2026-08-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "lodash": "4.18.1",
         "marked": "17.0.2",
         "ms": "3.0.0-canary.1",
-        "ng-extract-i18n-merge": "3.3.0",
+        "ng-extract-i18n-merge": "3.4.0",
         "ngx-device-detector": "11.0.0",
         "ngx-markdown": "21.2.0",
         "ngx-skeleton-loader": "12.0.0",
@@ -27176,22 +27176,22 @@
       "license": "MIT"
     },
     "node_modules/ng-extract-i18n-merge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ng-extract-i18n-merge/-/ng-extract-i18n-merge-3.3.0.tgz",
-      "integrity": "sha512-9VCi2gMSjvlz5+bvJ9wTzHEeEiVCM0lb/uvGx2K3FavG4p0HKhg0Y9Tjr/Hr23DSHAQQXS0gssIvznWW3DHIXQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ng-extract-i18n-merge/-/ng-extract-i18n-merge-3.4.0.tgz",
+      "integrity": "sha512-8eOvyTSeaEGtaLIFFRug16AwuVS400bKfT/AqTZG8FlSAT6T8UpItlMi4rW0Z8bdmOPkK0ZzxGk8Ew/+NMWiCg==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": ">=0.2000.0 <0.2200.0",
-        "@angular-devkit/core": "^20.0.0 || ^21.0.0",
-        "@angular-devkit/schematics": "^20.0.0 || ^21.0.0",
-        "@schematics/angular": "^20.0.0 || ^21.0.0",
+        "@angular-devkit/architect": ">=0.2000.0 <0.2300.0",
+        "@angular-devkit/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular-devkit/schematics": "^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@schematics/angular": "^20.0.0 || ^21.0.0 || ^22.0.0",
         "xmldoc": "^1.1.3"
       },
       "engines": {
         "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@angular/build": "^20.0.0 || ^21.0.0"
+        "@angular/build": "^20.0.0 || ^21.0.0 || ^22.0.0"
       }
     },
     "node_modules/ngx-device-detector": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "lodash": "4.18.1",
     "marked": "17.0.2",
     "ms": "3.0.0-canary.1",
-    "ng-extract-i18n-merge": "3.3.0",
+    "ng-extract-i18n-merge": "3.4.0",
     "ngx-device-detector": "11.0.0",
     "ngx-markdown": "21.2.0",
     "ngx-skeleton-loader": "12.0.0",


### PR DESCRIPTION
Hi @dtslvr, this PR bumps `ng-extract-i18n-merge` from `3.3.0` to `3.4.0`.

This update expands Angular Devkit peer dependency compatibility, paving the way for the upcoming Angular 22 framework upgrade.

## Changes Made
- Updated `ng-extract-i18n-merge` to `3.4.0` in `package.json` and `package-lock.json`.