### PR TITLE
Task/migrate away from deprecated node10 module resolution

### DIFF
--- a/apps/api/src/services/data-provider/data-enhancer/yahoo-finance/yahoo-finance.service.ts
+++ b/apps/api/src/services/data-provider/data-enhancer/yahoo-finance/yahoo-finance.service.ts
@@ -20,7 +20,7 @@ import {
 } from '@prisma/client';
 import { isISIN } from 'class-validator';
 import YahooFinance from 'yahoo-finance2';
-import type { Price } from 'yahoo-finance2/esm/src/modules/quoteSummary-iface';
+import type { Price } from 'yahoo-finance2/modules/quoteSummary-iface';
 
 @Injectable()
 export class YahooFinanceDataEnhancerService implements DataEnhancerInterface {

--- a/apps/api/src/services/data-provider/yahoo-finance/yahoo-finance.service.ts
+++ b/apps/api/src/services/data-provider/yahoo-finance/yahoo-finance.service.ts
@@ -25,7 +25,7 @@ import { addDays, format, isSameDay } from 'date-fns';
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import { uniqBy } from 'lodash';
 import YahooFinance from 'yahoo-finance2';
-import { ChartResultArray } from 'yahoo-finance2/modules/chart';
+import type { ChartResultArray } from 'yahoo-finance2/modules/chart';
 import type {
   HistoricalDividendsResult,
   HistoricalHistoryResult

--- a/apps/api/src/services/data-provider/yahoo-finance/yahoo-finance.service.ts
+++ b/apps/api/src/services/data-provider/yahoo-finance/yahoo-finance.service.ts
@@ -26,13 +26,16 @@ import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import { uniqBy } from 'lodash';
 import YahooFinance from 'yahoo-finance2';
 import { ChartResultArray } from 'yahoo-finance2/modules/chart';
-import {
+import type {
   HistoricalDividendsResult,
   HistoricalHistoryResult
 } from 'yahoo-finance2/modules/historical';
-import { Quote, QuoteResponseArray } from 'yahoo-finance2/modules/quote';
-import { Price, QuoteSummaryResult } from 'yahoo-finance2/modules/quoteSummary';
-import { SearchQuoteNonYahoo } from 'yahoo-finance2/modules/search';
+import type { Quote, QuoteResponseArray } from 'yahoo-finance2/modules/quote';
+import type {
+  Price,
+  QuoteSummaryResult
+} from 'yahoo-finance2/modules/quoteSummary';
+import type { SearchQuoteNonYahoo } from 'yahoo-finance2/modules/search';
 
 @Injectable()
 export class YahooFinanceService implements DataProviderInterface {

--- a/apps/api/src/services/data-provider/yahoo-finance/yahoo-finance.service.ts
+++ b/apps/api/src/services/data-provider/yahoo-finance/yahoo-finance.service.ts
@@ -25,20 +25,14 @@ import { addDays, format, isSameDay } from 'date-fns';
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import { uniqBy } from 'lodash';
 import YahooFinance from 'yahoo-finance2';
-import { ChartResultArray } from 'yahoo-finance2/esm/src/modules/chart';
+import { ChartResultArray } from 'yahoo-finance2/modules/chart';
 import {
   HistoricalDividendsResult,
   HistoricalHistoryResult
-} from 'yahoo-finance2/esm/src/modules/historical';
-import {
-  Quote,
-  QuoteResponseArray
-} from 'yahoo-finance2/esm/src/modules/quote';
-import {
-  Price,
-  QuoteSummaryResult
-} from 'yahoo-finance2/esm/src/modules/quoteSummary';
-import { SearchQuoteNonYahoo } from 'yahoo-finance2/esm/src/modules/search';
+} from 'yahoo-finance2/modules/historical';
+import { Quote, QuoteResponseArray } from 'yahoo-finance2/modules/quote';
+import { Price, QuoteSummaryResult } from 'yahoo-finance2/modules/quoteSummary';
+import { SearchQuoteNonYahoo } from 'yahoo-finance2/modules/search';
 
 @Injectable()
 export class YahooFinanceService implements DataProviderInterface {

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -4,10 +4,8 @@
     "outDir": "../../dist/out-tsc",
     "types": ["node"],
     "emitDecoratorMetadata": true,
-    "ignoreDeprecations": "6.0",
-    "moduleResolution": "node10",
     "target": "es2021",
-    "module": "commonjs"
+    "module": "preserve"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "include": ["**/*.ts"]

--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
-    "moduleResolution": "node10",
+    "module": "preserve",
     "types": ["jest", "node"]
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "jest.config.ts"]


### PR DESCRIPTION
Hi @dtslvr, this PR migrates API app away from the deprecated `node10` module resolution. It now inherits the module resolution from the base TypeScript configuration, which is `bundler`.

## Changes

* Removed `moduleResolution=node10` configuration from both API app and spec.
* Changed `module` to `preserve`.
* Updated `yahoo-finance2` imports.
* Remove ignore deprecations flag.