### PR TITLE
Task/improve type safety for unassigned variables in API

### DIFF
--- a/apps/api/src/app/activities/activities.controller.ts
+++ b/apps/api/src/app/activities/activities.controller.ts
@@ -66,8 +66,8 @@ export class ActivitiesController {
       tags
     }: ActivitiesFilterDto
   ): Promise<number> {
-    let endDate: Date;
-    let startDate: Date;
+    let endDate: Date | undefined;
+    let startDate: Date | undefined;
 
     if (range) {
       ({ endDate, startDate } = getIntervalFromDateRange({
@@ -139,8 +139,8 @@ export class ActivitiesController {
       take
     }: GetActivitiesDto
   ): Promise<ActivitiesResponse> {
-    let endDate: Date;
-    let startDate: Date;
+    let endDate: Date | undefined;
+    let startDate: Date | undefined;
 
     if (range) {
       ({ endDate, startDate } = getIntervalFromDateRange({

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -193,7 +193,7 @@ export class ActivitiesService {
       userId: data.userId
     });
 
-    let account: Prisma.AccountCreateNestedOneWithoutActivitiesInput;
+    let account: Prisma.AccountCreateNestedOneWithoutActivitiesInput | undefined;
 
     if (data.accountId) {
       account = {

--- a/apps/api/src/app/activities/activities.service.ts
+++ b/apps/api/src/app/activities/activities.service.ts
@@ -193,7 +193,8 @@ export class ActivitiesService {
       userId: data.userId
     });
 
-    let account: Prisma.AccountCreateNestedOneWithoutActivitiesInput | undefined;
+    let account:
+      Prisma.AccountCreateNestedOneWithoutActivitiesInput | undefined;
 
     if (data.accountId) {
       account = {

--- a/apps/api/src/app/admin/admin.controller.ts
+++ b/apps/api/src/app/admin/admin.controller.ts
@@ -186,7 +186,7 @@ export class AdminController {
     @Param('symbol') symbol: string,
     @Query('range') dateRange: DateRange
   ): Promise<void> {
-    let date: Date;
+    let date: Date | undefined;
 
     if (dateRange) {
       const { startDate } = getIntervalFromDateRange({ dateRange });

--- a/apps/api/src/app/admin/admin.service.ts
+++ b/apps/api/src/app/admin/admin.service.ts
@@ -659,7 +659,7 @@ export class AdminService {
   }
 
   private async countUsersWithAnalytics() {
-    let where: Prisma.UserWhereInput;
+    let where: Prisma.UserWhereInput | undefined;
 
     if (this.configurationService.get('ENABLE_FEATURE_SUBSCRIPTION')) {
       where = {

--- a/apps/api/src/app/endpoints/mcp/mcp.controller.ts
+++ b/apps/api/src/app/endpoints/mcp/mcp.controller.ts
@@ -99,8 +99,8 @@ export class GhostfolioMcpController {
       take
     }: z.infer<typeof GET_ACTIVITIES_PARAMETERS>
   ) {
-    let endDate: Date;
-    let startDate: Date;
+    let endDate: Date | undefined;
+    let startDate: Date | undefined;
 
     if (range) {
       ({ endDate, startDate } = getIntervalFromDateRange({

--- a/apps/api/src/app/export/export.controller.ts
+++ b/apps/api/src/app/export/export.controller.ts
@@ -45,8 +45,8 @@ export class ExportController {
       tags
     }: GetExportDto
   ): Promise<ExportResponse> {
-    let endDate: Date;
-    let startDate: Date;
+    let endDate: Date | undefined;
+    let startDate: Date | undefined;
 
     if (range) {
       ({ endDate, startDate } = getIntervalFromDateRange({

--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -395,7 +395,7 @@ export class ImportService {
 
           if (!isDryRun) {
             const existingTag = await this.tagService.getTag({ id: tag.id });
-            let oldTagId: string;
+            let oldTagId: string | undefined;
 
             if (existingTag) {
               oldTagId = tag.id;
@@ -509,7 +509,7 @@ export class ImportService {
           'tags'
         ]);
 
-        let oldAccountId: string;
+        let oldAccountId: string | undefined;
         const platformId =
           platformIdMapping[account.platformId] ?? account.platformId;
 
@@ -596,7 +596,7 @@ export class ImportService {
         ]);
 
       for (const assetProfileWithMarketData of assetProfilesWithMarketDataDto) {
-        let assetProfileToCreate: Prisma.SymbolProfileCreateInput;
+        let assetProfileToCreate: Prisma.SymbolProfileCreateInput | undefined;
         let symbol = assetProfileWithMarketData.symbol;
 
         // Check if there is any existing asset profile

--- a/apps/api/src/app/info/info.service.ts
+++ b/apps/api/src/app/info/info.service.ts
@@ -47,8 +47,8 @@ export class InfoService {
 
   public async get(): Promise<InfoItem> {
     const info: Partial<InfoItem> = {};
-    let isReadOnlyMode: boolean;
-    let latestFearAndGreedStocksMarketDataPromise: Promise<MarketData>;
+    let isReadOnlyMode: boolean | undefined;
+    let latestFearAndGreedStocksMarketDataPromise: Promise<MarketData> | undefined;
 
     const globalPermissions: string[] = [];
 

--- a/apps/api/src/app/info/info.service.ts
+++ b/apps/api/src/app/info/info.service.ts
@@ -48,7 +48,8 @@ export class InfoService {
   public async get(): Promise<InfoItem> {
     const info: Partial<InfoItem> = {};
     let isReadOnlyMode: boolean | undefined;
-    let latestFearAndGreedStocksMarketDataPromise: Promise<MarketData> | undefined;
+    let latestFearAndGreedStocksMarketDataPromise:
+      Promise<MarketData> | undefined;
 
     const globalPermissions: string[] = [];
 

--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -1166,7 +1166,7 @@ export abstract class PortfolioCalculator {
   private async initialize(attempt = 1) {
     const startTimeTotal = performance.now();
 
-    let cachedPortfolioSnapshot: PortfolioSnapshot;
+    let cachedPortfolioSnapshot: PortfolioSnapshot | undefined;
     let isCachedPortfolioSnapshotExpired = false;
     const portfolioSnapshotKey = this.redisCacheService.getPortfolioSnapshotKey(
       {

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -569,7 +569,10 @@ export class PortfolioService {
       });
     }
 
-    let streaks: PortfolioInvestmentsResponse['streaks'];
+    let streaks: PortfolioInvestmentsResponse['streaks'] = {
+      currentStreak: 0,
+      longestStreak: 0
+    };
 
     if (savingsRate) {
       streaks = this.getStreaks({
@@ -853,7 +856,7 @@ export class PortfolioService {
       ({ markets, marketsAdvanced } = this.getAggregatedMarkets(holdings));
     }
 
-    let summary: PortfolioSummary;
+    let summary: PortfolioSummary | undefined;
 
     if (withSummary) {
       summary = await this.getSummary({

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -46,7 +46,7 @@ async function bootstrap() {
 
   const configApp = await NestFactory.create(AppModule);
   const configService = configApp.get<ConfigService>(ConfigService);
-  let customLogLevels: LogLevel[];
+  let customLogLevels: LogLevel[] | undefined;
 
   try {
     customLogLevels = JSON.parse(

--- a/apps/api/src/services/data-provider/financial-modeling-prep/financial-modeling-prep.service.ts
+++ b/apps/api/src/services/data-provider/financial-modeling-prep/financial-modeling-prep.service.ts
@@ -726,11 +726,11 @@ export class FinancialModelingPrepService
   }
 
   private parseAssetClass(profile: any): {
-    assetClass: AssetClass;
-    assetSubClass: AssetSubClass;
+    assetClass: AssetClass | undefined;
+    assetSubClass: AssetSubClass | undefined;
   } {
-    let assetClass: AssetClass;
-    let assetSubClass: AssetSubClass;
+    let assetClass: AssetClass | undefined;
+    let assetSubClass: AssetSubClass | undefined;
 
     if (profile) {
       if (profile.isEtf) {

--- a/apps/api/src/services/fetch/fetch.service.ts
+++ b/apps/api/src/services/fetch/fetch.service.ts
@@ -156,7 +156,7 @@ export class FetchService implements OnModuleInit {
         text
       ];
 
-      let rejectedBody: string;
+      let rejectedBody: string | undefined;
 
       for (const candidate of candidates) {
         if (typeof candidate !== 'string') {

--- a/apps/api/src/services/prisma/prisma.service.ts
+++ b/apps/api/src/services/prisma/prisma.service.ts
@@ -21,7 +21,7 @@ export class PrismaService
       connectionString: configService.get<string>('DATABASE_URL')
     });
 
-    let customLogLevels: LogLevel[];
+    let customLogLevels: LogLevel[] | undefined;
 
     try {
       customLogLevels = JSON.parse(

--- a/apps/api/src/services/queues/data-gathering/data-gathering.processor.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.processor.ts
@@ -119,7 +119,7 @@ export class DataGatheringProcessor {
 
       const data: Prisma.MarketDataUpdateInput[] = [];
       const startOfUtcDateOfToday = getStartOfUtcDate(new Date());
-      let lastMarketPrice: number;
+      let lastMarketPrice: number | undefined;
 
       while (isBefore(currentDate, startOfUtcDateOfToday)) {
         const marketPriceOfDataProvider =


### PR DESCRIPTION
Hi @dtslvr, this PR is related to #6246. Please take a look :)

This PR specifically targets and resolves instances of TypeScript error `TS2454: Variable 'XXX' is used before being assigned` ([reference](https://js2ts.com/typescript-error/ts2454)) across `apps/api`, ensuring variables declared without initializers are properly typed with `| undefined` or guarded before being read.

## Changes

* Explicitly typed optional date filter parameters (`startDate`, `endDate`) as `Date | undefined` across `ActivitiesController`, `AdminController`, `GhostfolioMcpController`, and `ExportController`.
* Fixed `TS2454` for `account` in `ActivitiesService.createActivity` when an optional account ID is provided.
* Typed `where` filter parameter as optional in `AdminService.countUsersWithAnalytics`.
* Handled optional `oldTagId`, `oldAccountId`, and `assetProfileToCreate` variables safely during import operations in `ImportService`.
* Safely handled optional read-only mode status and market data promise resolution in `InfoService.get`.
* Typed `cachedPortfolioSnapshot` as optional `PortfolioSnapshot | undefined` in `PortfolioCalculator.initialize`.
* Initialized fallback `streaks` response object in `PortfolioService.getInvestments`.
* Handled optional `customLogLevels` JSON parsing in `main.ts` and `PrismaService`.
* Updated `parseAssetClass` return signature in `FinancialModelingPrepService` to support optional asset classifications.
* Handled optional `rejectedBody` string resolution safely in `FetchService`.
* Added optional type handling for `lastMarketPrice` carry-forward tracking in `DataGatheringProcessor`.

## Resolved type errors

28 errors (before: 704, after: 676)
