### PR TITLE
Fix portfolio current value responses

### DIFF
--- a/apps/api/src/app/portfolio/portfolio.controller.ts
+++ b/apps/api/src/app/portfolio/portfolio.controller.ts
@@ -399,13 +399,11 @@ export class PortfolioController {
       filterByTags: tags
     });
 
-    const holdings = await this.portfolioService.getHoldings({
+    return this.portfolioService.getHoldings({
       filters,
       userId,
       dateRange: range
     });
-
-    return { holdings };
   }
 
   @Get('investments')

--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -57,6 +57,7 @@ import {
   InvestmentItem,
   PortfolioDetails,
   PortfolioHoldingResponse,
+  PortfolioHoldingsResponse,
   PortfolioInvestmentsResponse,
   PortfolioPerformanceResponse,
   PortfolioPosition,
@@ -504,7 +505,14 @@ export class PortfolioService {
       });
     }
 
-    return holdings;
+    return {
+      holdings,
+      totalValueInBaseCurrency: getSum(
+        holdings.map(({ valueInBaseCurrency }) => {
+          return new Big(valueInBaseCurrency ?? 0);
+        })
+      ).toNumber()
+    };
   }
 
   public async getInvestments({
@@ -1182,7 +1190,7 @@ export class PortfolioService {
       currency: userCurrency
     });
 
-    const { errors, hasErrors, historicalData } =
+    const { currentValueInBaseCurrency, errors, hasErrors, historicalData } =
       await portfolioCalculator.getSnapshot();
 
     const { endDate, startDate } = getIntervalFromDateRange({ dateRange });
@@ -1199,8 +1207,7 @@ export class PortfolioService {
       netPerformanceWithCurrencyEffect,
       netWorth,
       totalInvestment,
-      totalInvestmentValueWithCurrencyEffect,
-      valueWithCurrencyEffect
+      totalInvestmentValueWithCurrencyEffect
     } = chart?.at(-1) ?? {
       netPerformance: 0,
       netPerformanceInPercentage: 0,
@@ -1208,7 +1215,7 @@ export class PortfolioService {
       netPerformanceWithCurrencyEffect: 0,
       netWorth: 0,
       totalInvestment: 0,
-      valueWithCurrencyEffect: 0
+      totalInvestmentValueWithCurrencyEffect: 0
     };
 
     return {
@@ -1222,7 +1229,7 @@ export class PortfolioService {
         totalInvestment,
         totalInvestmentValueWithCurrencyEffect,
         currentNetWorth: netWorth,
-        currentValueInBaseCurrency: valueWithCurrencyEffect,
+        currentValueInBaseCurrency: currentValueInBaseCurrency.toNumber(),
         netPerformancePercentage: netPerformanceInPercentage,
         netPerformancePercentageWithCurrencyEffect:
           netPerformanceInPercentageWithCurrencyEffect

--- a/libs/common/src/lib/interfaces/responses/portfolio-holdings-response.interface.ts
+++ b/libs/common/src/lib/interfaces/responses/portfolio-holdings-response.interface.ts
@@ -2,4 +2,5 @@ import { PortfolioPosition } from '@ghostfolio/common/interfaces';
 
 export interface PortfolioHoldingsResponse {
   holdings: PortfolioPosition[];
+  totalValueInBaseCurrency: number;
 }


### PR DESCRIPTION
Fixes #6851

Holdings total and performance current value could stay null or 0 when the snapshot and chart diverge (e.g. mixed YAHOO/MANUAL sources). Return the sum of holdings' valueInBaseCurrency as totalValueInBaseCurrency and use the snapshot's currentValueInBaseCurrency for the performance current value.