### PR TITLE
Task/upgrade zod to version 4.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Upgraded `zod` from version `4.4.3` to `4.5.4`
+
 ## 3.68.0 - 2026-09-06
 
 ### Added

--- a/apps/api/src/app/endpoints/mcp/mcp.controller.ts
+++ b/apps/api/src/app/endpoints/mcp/mcp.controller.ts
@@ -10,6 +10,7 @@ import { UseFilters } from '@nestjs/common';
 import { Payload } from '@nestjs/microservices';
 import { McpController, Tool } from '@rekog/mcp-nest';
 import { z } from 'zod';
+import 'zod/compile';
 
 import {
   GET_ACCOUNTS_PARAMETERS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "undici": "8.10.0",
         "uuid": "14.0.2",
         "yahoo-finance2": "4.0.2",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
         "zone.js": "0.16.2"
       },
       "devDependencies": {
@@ -3376,6 +3376,16 @@
       },
       "engines": {
         "node": ">=22.13.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@angular/common": {
@@ -37225,9 +37235,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "undici": "8.10.0",
     "uuid": "14.0.2",
     "yahoo-finance2": "4.0.2",
-    "zod": "4.4.3",
+    "zod": "4.5.4",
     "zone.js": "0.16.2"
   },
   "devDependencies": {


### PR DESCRIPTION
And use zod/compile in MCP. Tested MCP before & after and works fine. Going over the UI itself works well still.

The only holdout in `package-lock.json` is `@angular/cli` that's pinned strictly to the old version.

Just upgrading to 4.5 has memory benefits. Using `compile` gives extra performance benefits. It's possible to hook the compile to the entire process (which would benefit imported code), but unlikely to do much.

https://zod.dev/blog/zod-4-5