### PR TITLE
fix(import): scope duplicate detection to account and normalize currency comparison

### DIFF
--- a/apps/api/src/app/import/import.service.ts
+++ b/apps/api/src/app/import/import.service.ts
@@ -1075,19 +1075,20 @@ export class ImportService {
         const date = parseISO(dateString);
 
         const isDuplicate = existingActivities.some((activity) => {
-          return (
-            (activity.comment || null) === (comment || null) &&
-            (activity.currency === currency ||
-              activity.assetProfile.currency === currency) &&
-            activity.assetProfile.dataSource === dataSource &&
-            isSameSecond(activity.date, date) &&
-            activity.fee === fee &&
-            activity.quantity === quantity &&
-            activity.assetProfile.symbol === symbol &&
-            activity.type === type &&
-            activity.unitPrice === unitPrice
-          );
-        });
+  return (
+    (!accountId || activity.accountId === accountId) &&
+    (activity.comment || null) === (comment || null) &&
+    ((activity.currency || null) === (currency || null) ||
+      activity.assetProfile.currency === currency) &&
+    activity.assetProfile.dataSource === dataSource &&
+    isSameSecond(activity.date, date) &&
+    activity.fee === fee &&
+    activity.quantity === quantity &&
+    activity.assetProfile.symbol === symbol &&
+    activity.type === type &&
+    activity.unitPrice === unitPrice
+  );
+});
 
         const error: ActivityError = isDuplicate
           ? { code: 'IS_DUPLICATE' }


### PR DESCRIPTION
## Problem

This PR fixes two related bugs in `extendActivitiesWithErrors()` inside `import.service.ts`:

**Bug 1 — #7728: IS_DUPLICATE matches across different accounts**
The duplicate check fetched all existing activities for the user regardless of account, so an activity in Account A would incorrectly flag an identical activity being imported into Account B as a duplicate.

**Bug 2 — #7406: Identical activities bypass duplicate detection in v3.29.0**
The currency comparison used strict equality (`activity.currency === currency`). When currency is stored as `null` in the database but arrives as `undefined` from the import DTO, `null === undefined` evaluates to `false` in JavaScript — silently skipping the match and allowing the duplicate to be persisted.

## Fix

Both bugs are in the same `isDuplicate` check (one block, two lines changed):

1. Added `(!accountId || activity.accountId === accountId)` — scopes duplicate detection to the target account only
2. Changed `activity.currency === currency` to `(activity.currency || null) === (currency || null)` — normalizes null/undefined before comparison

## Testing

- Import identical activities into two different accounts → no longer flagged as duplicate
- Re-import already-existing activities into the same account → correctly flagged as IS_DUPLICATE
- Import with no accountId specified → behavior unchanged (guard condition uses `!accountId`)

Fixes #7728
Fixes #7406