### PR TITLE
fix(benchmark): resolve stuck loading state in detail dialog on fetch error

### DIFF
--- a/libs/ui/src/lib/benchmark/benchmark-detail-dialog/benchmark-detail-dialog.component.ts
+++ b/libs/ui/src/lib/benchmark/benchmark-detail-dialog/benchmark-detail-dialog.component.ts
@@ -64,26 +64,34 @@ export class GfBenchmarkDetailDialogComponent implements OnInit {
         symbol: this.data.symbol
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(({ assetProfile, marketData }) => {
-        this.assetProfile = assetProfile;
+      .subscribe({
+  next: ({ assetProfile, marketData }) => {
+    this.assetProfile = assetProfile;
 
-        this.historicalDataItems = marketData.map(
-          ({ date, marketPrice }, index) => {
-            if (marketData.length - 1 === index) {
-              this.value = marketPrice;
-            }
+    this.historicalDataItems = marketData.map(
+      ({ date, marketPrice }, index) => {
+        if (marketData.length - 1 === index) {
+          this.value = marketPrice;
+        }
 
-            return {
-              date: format(date, DATE_FORMAT),
-              value: marketPrice
-            };
-          }
-        );
+        return {
+          date: format(date, DATE_FORMAT),
+          value: marketPrice
+        };
+      }
+    );
 
-        this.isLoading = false;
+    this.isLoading = false;
 
-        this.changeDetectorRef.markForCheck();
-      });
+    this.changeDetectorRef.markForCheck();
+  },
+  error: () => {
+    this.historicalDataItems = [];
+    this.isLoading = false;
+
+    this.changeDetectorRef.markForCheck();
+  }
+});
   }
 
   public onClose() {


### PR DESCRIPTION
## Problem

Fixes #7560

When opening the historical price chart dialog for an ETF on the
watchlist, the loading spinner gets stuck indefinitely if the
`fetchAsset` API call fails (e.g. no market data available for
the symbol).

The `subscribe()` call in `ngOnInit()` only had a positional
callback for the success case. When the observable errored,
`isLoading` was never set to `false` and `markForCheck()` was
never called — leaving the dialog frozen on the skeleton loader.

## Fix

Converted the positional `subscribe(fn)` call to the object form
`subscribe({ next, error })` and added an `error` handler that:
- Sets `historicalDataItems` to an empty array
- Sets `isLoading` to `false`
- Calls `changeDetectorRef.markForCheck()` to update the view

## Testing

- ETF with market data → chart loads normally, no behaviour change
- ETF with no/missing market data → spinner dismisses, empty state
  shown instead of infinite loading