### PR TITLE
feat: add parallel development mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@
 1. Run `npm install`
 1. Run `docker compose -f docker/docker-compose.dev.yml up -d` to start [PostgreSQL](https://www.postgresql.org) and [Redis](https://redis.io)
 1. Run `npm run database:setup` to initialize the database schema
-1. Start the [server](#start-server) and the [client](#start-client)
+1. Run `npm run dev` to start both the server and client
 1. Open https://localhost:4200/en in your browser
 1. Create a new user via _Get Started_ (this first user will get the role `ADMIN`)
 
@@ -37,6 +37,14 @@ Run `npm run start:client` and open https://localhost:4200/en in your browser.
 #### Other Languages
 
 To start the client in a different language, such as German (`de`), adapt the `start:client` script in the `package.json` file by changing `--configuration=development-en` to `--configuration=development-de`. Then, run `npm run start:client` and open https://localhost:4200/de in your browser.
+
+### Start Server and Client
+
+To start both the server and client simultaneously, run:
+
+```bash
+npm run dev
+```
 
 ### Start _Storybook_
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "start:client": "nx run client:copy-assets && nx run client:serve --configuration=development-en --hmr -o",
     "start:production": "npm run database:migrate && npm run database:seed && node main",
     "start:server": "nx run api:copy-assets && nx run api:serve --watch",
+    "dev": "nx run api:copy-assets && nx run-many --target=serve --projects=api,client",
     "start:storybook": "nx run ui:storybook",
     "test": "npx dotenv-cli -e .env.example -- npx nx run-many --target=test --all --parallel=4",
     "test:api": "npx dotenv-cli -e .env.example -- nx test api",


### PR DESCRIPTION
## Description

Adds a single command to start the Ghostfolio server and client simultaneously during development.

## Changes

- Add `npm run dev` to start the API and client in parallel
- Copy API assets before starting the development servers
- Update `DEVELOPMENT.md` with the new development workflow

## Testing

- Verified `npm run dev` starts both `api:serve` and `client:serve`
- Verified the client loads successfully at `https://localhost:4200/en`
- Verified API assets are copied before startup
- `nx format:check` passes
- Pre-commit checks pass

Closes #6460