### PR TITLE
Fix quote fallback to prefer recent market data

### DIFF
--- a/apps/api/src/app/portfolio/current-rate.service.spec.ts
+++ b/apps/api/src/app/portfolio/current-rate.service.spec.ts
@@ -1,3 +1,4 @@
+import { ActivitiesService } from '@ghostfolio/api/app/activities/activities.service';
 import { DataProviderService } from '@ghostfolio/api/services/data-provider/data-provider.service';
 import { MarketDataService } from '@ghostfolio/api/services/market-data/market-data.service';
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
@@ -151,5 +152,52 @@ describe('CurrentRateService', () => {
         }
       ]
     });
+  });
+
+  it('uses the latest market price when the current quote is unavailable', async () => {
+    const historicalDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const activitiesService = {
+      getLatestActivity: jest.fn().mockResolvedValue({ unitPrice: 100 })
+    };
+    const dataProviderService = {
+      getQuotes: jest.fn().mockResolvedValue({})
+    };
+    const marketDataService = {
+      getRange: jest.fn().mockResolvedValue([
+        {
+          createdAt: historicalDate,
+          dataSource: DataSource.YAHOO,
+          date: historicalDate,
+          id: '40520fdf-4e31-47ab-8bd0-ca61c70d4684',
+          isCarriedForward: false,
+          marketPrice: 200,
+          state: 'CLOSE',
+          symbol: 'AMZN'
+        }
+      ]),
+      getRangeCount: jest.fn().mockResolvedValue(1)
+    };
+    const service = new CurrentRateService(
+      activitiesService as unknown as ActivitiesService,
+      dataProviderService as unknown as DataProviderService,
+      marketDataService as unknown as MarketDataService,
+      null
+    );
+
+    const response = await service.getValues({
+      dataGatheringItems: [{ dataSource: DataSource.YAHOO, symbol: 'AMZN' }],
+      dateQuery: {
+        gte: historicalDate,
+        lt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+      }
+    });
+    const latestValue = response.values
+      .filter(({ dataSource, symbol }) => {
+        return dataSource === DataSource.YAHOO && symbol === 'AMZN';
+      })
+      .sort((a, b) => b.date.getTime() - a.date.getTime())[0];
+
+    expect(latestValue.marketPrice).toBe(200);
+    expect(activitiesService.getLatestActivity).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/app/portfolio/current-rate.service.ts
+++ b/apps/api/src/app/portfolio/current-rate.service.ts
@@ -126,7 +126,7 @@ export class CurrentRateService {
       for (const { dataSource, symbol } of quoteErrors) {
         try {
           // If missing quote, fallback to the latest available historical market price
-          let value: GetValueObject = response.values.find((currentValue) => {
+          const hasValueForToday = response.values.some((currentValue) => {
             return (
               currentValue.dataSource === dataSource &&
               currentValue.symbol === symbol &&
@@ -134,22 +134,8 @@ export class CurrentRateService {
             );
           });
 
-          if (!value) {
-            // Fallback to unit price of latest activity
-            const latestActivity =
-              await this.activitiesService.getLatestActivity({
-                dataSource,
-                symbol
-              });
-
-            value = {
-              dataSource,
-              symbol,
-              date: today,
-              marketPrice: latestActivity?.unitPrice ?? 0
-            };
-
-            response.values.push(value);
+          if (hasValueForToday) {
+            continue;
           }
 
           const [latestValue] = response.values
@@ -172,7 +158,21 @@ export class CurrentRateService {
               return 0;
             });
 
-          value.marketPrice = latestValue.marketPrice;
+          // Fallback to unit price of latest activity
+          const latestActivity = latestValue
+            ? undefined
+            : await this.activitiesService.getLatestActivity({
+                dataSource,
+                symbol
+              });
+
+          response.values.push({
+            dataSource,
+            symbol,
+            date: today,
+            marketPrice:
+              latestValue?.marketPrice ?? latestActivity?.unitPrice ?? 0
+          });
         } catch {}
       }
     }


### PR DESCRIPTION
## Summary

- prefer the latest historical market price when a live quote is unavailable
- query the latest activity only when no usable market price exists
- add regression coverage for the fallback order

Fixes #7775.

## Root cause

The quote-error fallback inserted a today-dated value from the latest activity before selecting the newest known value. That synthetic row then always won the date sort, so an older activity price could overwrite a more recent historical market close.

## Testing

- `nx test api --runInBand` — 45 suites passed, 177 tests passed, 1 suite/test skipped
- `nx test api --testFile=current-rate.service.spec.ts --runInBand` — 2 tests passed
- `nx lint api` — passed (repository warnings only)
- `nx build api --configuration=production` — passed
- `prettier --check` on both changed files — passed
- `git diff --check` — passed

## Risk and compatibility

The successful live-quote path is unchanged. The activity price remains the final fallback when no current or historical market value is available. An older open PR (#6703) changes currency conversion inside that final activity fallback; the behavior is complementary, though the two patches may need a small conflict resolution if both are merged.

## AI assistance

This change was implemented and tested with assistance from OpenAI Codex.
