### PR TITLE
fix: allow updating cash balance for historical activities

### DIFF
--- a/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
+++ b/apps/client/src/app/pages/portfolio/activities/create-or-update-activity-dialog/create-or-update-activity-dialog.component.ts
@@ -560,12 +560,10 @@ export class GfCreateOrUpdateActivityDialogComponent {
     const accountBalanceControl = this.activityForm.get('updateAccountBalance');
     const accountId = this.activityForm.get('accountId')?.value;
     const dataSource = this.activityForm.get('dataSource')?.value;
-    const date = this.activityForm.get('date')?.value;
     const type = this.activityForm.get('type')?.value;
 
     const isEligible =
       !!accountId &&
-      isToday(date) &&
       !['LIABILITY', 'VALUABLE'].includes(type) &&
       !(dataSource === 'MANUAL' && type === 'BUY');
 


### PR DESCRIPTION
## Description

The “Update Cash Balance” option was disabled whenever an activity date was
older than today, even though the backend supports updating account balances
using historical dates.

This change allows the option for historical activities while preserving the
existing restrictions for liabilities, valuables, and manual buy activities.

## Testing

- `npx nx build client --configuration=development-en`

## Related issue

Closes #7834