### PR TITLE
Task/update Turbobulls in personal finance tools

### DIFF
--- a/libs/common/src/lib/personal-finance-tools.ts
+++ b/libs/common/src/lib/personal-finance-tools.ts
@@ -2460,14 +2460,14 @@ export const personalFinanceTools: Product[] = [
   {
     categories: ['NET_WORTH_TRACKING', 'STOCK_TRACKING'],
     founded: 2025,
-    hasFreePlan: false,
+    hasFreePlan: true,
     hasSelfHostingAbility: false,
     key: 'turbobulls',
     name: 'Turbobulls',
     origin: 'RO',
     platforms: ['WEB'],
-    pricingPerYear: '€39.99',
-    slogan: 'Your complete financial dashboard. Actually private.',
+    pricingPerYear: '€35.90',
+    slogan: 'Your complete portfolio and expense tracker. Actually private.',
     url: 'https://www.turbobulls.com'
   },
   {


### PR DESCRIPTION
Thank you for maintaining this list. The Turbobulls entry has drifted since it was added, so this is a data refresh for the three fields that are now wrong. I work on Turbobulls, so please read this as a correction from the source rather than as independent research.

**`hasFreePlan: false` -> `true`**

Turbobulls has had a permanent free plan since August 2026. No card, no time limit, and nothing is deleted if a paid subscription lapses. Plans are listed at https://www.turbobulls.com/#pricing.

**`pricingPerYear: '€39.99'` -> `'€35.90'`**

There are several paid plans now rather than one. The comparison table renders this field as "Starting from ... / year", so I used the lowest paid annual plan, which was €35.90 on 8 September 2026. One caveat worth recording: prices are served from Stripe at request time, so they can change without a site deploy. The current list is always at https://www.turbobulls.com/pricing.md, which is generated from the same source the site renders.

**`slogan`**

The site headline is now "Your complete portfolio and expense tracker. Actually private." The previous value, "Your complete financial dashboard. Actually private.", is no longer used anywhere.

**Deliberately not changed**

- `founded: 2025` is correct as it stands. The product went live in 2025. The operating company is older than that, but that did not look like what the field means.
- `categories`, `platforms`, `origin` and `hasSelfHostingAbility` are all still accurate. I did not want to widen the entry's category coverage in a correction PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
