### PR TITLE
Bugfix/include closed holdings in portfolio filters

### DIFF
--- a/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
+++ b/libs/ui/src/lib/assistant/assistant-list-item/assistant-list-item.component.ts
@@ -16,7 +16,7 @@ import {
 import { Params, RouterModule } from '@angular/router';
 
 import { SearchMode } from '../enums/search-mode';
-import {
+import type {
   AssetSearchResultItem,
   SearchResultItem
 } from '../interfaces/interfaces';

--- a/libs/ui/src/lib/assistant/assistant.component.spec.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.spec.ts
@@ -1,0 +1,201 @@
+import { Filter, PortfolioPosition } from '@ghostfolio/common/interfaces';
+import { DataService } from '@ghostfolio/ui/services';
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import '@angular/localize/init';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { provideRouter } from '@angular/router';
+import { AssetClass, AssetSubClass, DataSource } from '@prisma/client';
+import { of } from 'rxjs';
+
+import { GfAssistantComponent } from './assistant.component';
+
+jest.mock('@ionic/angular/standalone', () => {
+  const { Component } =
+    jest.requireActual<typeof import('@angular/core')>('@angular/core');
+
+  return {
+    IonIcon: Component({
+      selector: 'ion-icon',
+      template: '',
+      inputs: ['name']
+    })(class {})
+  };
+});
+
+describe('GfAssistantComponent holding filters', () => {
+  let fixture: ComponentFixture<GfAssistantComponent>;
+  let loader: HarnessLoader;
+  let holdings: PortfolioPosition[];
+  let filtersChanged: jest.Mock;
+
+  beforeEach(async () => {
+    holdings = [
+      {
+        name: 'Active holding',
+        quantity: 1,
+        assetSubClass: AssetSubClass.STOCK
+      },
+      {
+        name: 'Closed holding',
+        quantity: 0,
+        assetSubClass: AssetSubClass.STOCK
+      },
+      { name: 'Cash holding', quantity: 1, assetSubClass: AssetSubClass.CASH }
+    ].map(({ name, quantity, assetSubClass }) => {
+      return {
+        assetProfile: {
+          assetClass: AssetClass.EQUITY,
+          assetSubClass,
+          currency: 'USD',
+          dataSource: DataSource.MANUAL,
+          name,
+          symbol: name
+        },
+        quantity
+      } as PortfolioPosition;
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [GfAssistantComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: DataService,
+          useValue: {
+            fetchPortfolioHoldings: ({
+              filters = []
+            }: { filters?: Filter[] } = {}) => {
+              const activeOnly = filters.some(({ id, type }) => {
+                return type === 'HOLDING_TYPE' && id === 'ACTIVE';
+              });
+
+              return of({
+                holdings: holdings.filter(({ quantity }) => {
+                  return !activeOnly || quantity > 0;
+                })
+              });
+            }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GfAssistantComponent);
+    fixture.componentRef.setInput('hasPermissionToChangeFilters', true);
+    fixture.componentRef.setInput('user', {
+      accounts: [],
+      settings: {},
+      tags: []
+    });
+    filtersChanged = jest.fn();
+    fixture.componentRef.instance['filtersChanged'].subscribe(filtersChanged);
+    fixture.autoDetectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    await fixture.whenStable();
+  });
+
+  it('should offer active and closed holdings while excluding cash', async () => {
+    fixture.componentInstance.initialize();
+    const holdingSelect = await loader.getHarness(
+      MatSelectHarness.with({ selector: '[formControlName="holding"]' })
+    );
+    await holdingSelect.open();
+
+    expect(
+      await Promise.all(
+        (await holdingSelect.getOptions()).map((option) => option.getText())
+      )
+    ).toEqual([
+      '',
+      expect.stringMatching(/^Active holding/),
+      expect.stringMatching(/^Closed holding/)
+    ]);
+
+    await holdingSelect.clickOptions({ text: /Closed holding/ });
+    const applyButton = await loader.getHarness(
+      MatButtonHarness.with({ text: 'Apply Filters' })
+    );
+    await applyButton.click();
+
+    expect(filtersChanged).toHaveBeenCalledWith([
+      { id: '', type: 'ACCOUNT' },
+      { id: '', type: 'ASSET_CLASS' },
+      { id: DataSource.MANUAL, type: 'DATA_SOURCE' },
+      { id: 'Closed holding', type: 'SYMBOL' },
+      { id: '', type: 'TAG' }
+    ]);
+  });
+
+  it('should retain a selected holding after it closes and allow resetting its filters', async () => {
+    fixture.componentRef.setInput('user', {
+      accounts: [],
+      settings: {
+        'filters.dataSource': DataSource.MANUAL,
+        'filters.symbol': 'Active holding'
+      },
+      tags: []
+    });
+    await fixture.whenStable();
+    fixture.componentInstance.initialize();
+    const holdingSelect = await loader.getHarness(
+      MatSelectHarness.with({ selector: '[formControlName="holding"]' })
+    );
+    expect(await holdingSelect.getValueText()).toBe('Active holding');
+    fixture.componentInstance.onCloseAssistant();
+
+    holdings[0].quantity = 0;
+    fixture.componentInstance.initialize();
+
+    expect(await holdingSelect.getValueText()).toBe('Active holding');
+    const resetButton = await loader.getHarness(
+      MatButtonHarness.with({ text: 'Reset Filters' })
+    );
+    expect(await resetButton.isDisabled()).toBe(false);
+    await resetButton.click();
+
+    expect(filtersChanged).toHaveBeenCalledWith([
+      { type: 'ACCOUNT', id: '' },
+      { type: 'ASSET_CLASS', id: '' },
+      { type: 'DATA_SOURCE', id: '' },
+      { type: 'SYMBOL', id: '' },
+      { type: 'TAG', id: '' }
+    ]);
+    expect(fixture.componentInstance.isOpen).toBe(false);
+  });
+
+  it('should keep Reset Filters disabled when no filter is selected', async () => {
+    fixture.componentInstance.initialize();
+    const resetButton = await loader.getHarness(
+      MatButtonHarness.with({ text: 'Reset Filters' })
+    );
+
+    expect(await resetButton.isDisabled()).toBe(true);
+  });
+
+  it('should keep filters disabled without permission to change them', async () => {
+    fixture.componentRef.setInput('hasPermissionToChangeFilters', false);
+    fixture.componentRef.setInput('user', {
+      accounts: [],
+      settings: {
+        'filters.dataSource': DataSource.MANUAL,
+        'filters.symbol': 'Closed holding'
+      },
+      tags: []
+    });
+    await fixture.whenStable();
+    fixture.componentInstance.initialize();
+    const holdingSelect = await loader.getHarness(
+      MatSelectHarness.with({ selector: '[formControlName="holding"]' })
+    );
+    const resetButton = await loader.getHarness(
+      MatButtonHarness.with({ text: 'Reset Filters' })
+    );
+
+    expect(await holdingSelect.isDisabled()).toBe(true);
+    expect(await resetButton.isDisabled()).toBe(true);
+  });
+});

--- a/libs/ui/src/lib/assistant/assistant.component.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.ts
@@ -1,5 +1,9 @@
 import { SEARCH_QUERY_MAXIMUM_LENGTH } from '@ghostfolio/common/config';
-import { Filter, PortfolioPosition, User } from '@ghostfolio/common/interfaces';
+import type {
+  Filter,
+  PortfolioPosition,
+  User
+} from '@ghostfolio/common/interfaces';
 import { InternalRoute } from '@ghostfolio/common/routes/interfaces/internal-route.interface';
 import { internalRoutes } from '@ghostfolio/common/routes/routes';
 import { AccountWithPlatform, DateRange } from '@ghostfolio/common/types';
@@ -479,9 +483,7 @@ export class GfAssistantComponent implements OnChanges, OnDestroy, OnInit {
     this.setIsOpen(true);
 
     this.dataService
-      .fetchPortfolioHoldings({
-        filters: [{ id: 'ACTIVE', type: 'HOLDING_TYPE' }]
-      })
+      .fetchPortfolioHoldings()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ holdings }) => {
         this.holdings = getHoldingsForFilter(holdings);


### PR DESCRIPTION
The assistant's portfolio filter only requested active holdings. Closing the selected position removed it from the selector, losing the saved selection and leaving Reset Filters disabled when it was the only filter.

Use the holdings endpoint's existing default to include closed holdings. Component tests exercise selecting a closed holding, reopening the filter after a position closes, resetting the selection, and preserving disabled states. Type-only imports keep the newly tested components compatible with the test configuration's isolated-module compilation.

Closes #7852.

Validation on macOS (Node 24.19.0) and Linux (Node 24.20.0):

- New component regression: 2 failed / 2 passed before the fix; all 4 pass after it. The full UI suite passes all 10 tests.
- Existing `PortfolioService getHoldings` tests: 4 pass; 26 unrelated tests are excluded by the name filter.
- Production client build passes for all 14 locales.
- Changed-file ESLint and Prettier checks pass without warnings. UI lint passes with 176 project warnings on Linux.

The extra standalone spec typecheck still reports the same three diagnostics as the baseline in the common DTOs and historical-market-data editor. Full application/browser E2E, the entire backend suite, and Storybook were not run. Tests use synthetic holdings and mocked service responses; no investment accounts or live providers are involved.
